### PR TITLE
Redirect to rules page when payload empty for edit or duplicate pages; Improved import page

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -170,15 +170,25 @@ export default class Main extends Component<MainProps, MainState> {
                         />
                         <Route
                           path={ROUTES.RULES_EDIT}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <EditRule services={services} {...props} />
-                          )}
+                          render={(props: RouteComponentProps<any, any, any>) => {
+                            if (!props.location.state?.ruleItem) {
+                              props.history.replace(ROUTES.RULES);
+                              return <Rules {...props} notifications={core?.notifications} />;
+                            }
+
+                            return <EditRule services={services} {...props} />;
+                          }}
                         />
                         <Route
                           path={ROUTES.RULES_DUPLICATE}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <DuplicateRule services={services} {...props} />
-                          )}
+                          render={(props: RouteComponentProps<any, any, any>) => {
+                            if (!props.location.state?.ruleItem) {
+                              props.history.replace(ROUTES.RULES);
+                              return <Rules {...props} notifications={core?.notifications} />;
+                            }
+
+                            return <DuplicateRule services={services} {...props} />;
+                          }}
                         />
                         <Route
                           path={ROUTES.RULES_IMPORT}

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -193,7 +193,11 @@ export default class Main extends Component<MainProps, MainState> {
                         <Route
                           path={ROUTES.RULES_IMPORT}
                           render={(props: RouteComponentProps) => (
-                            <ImportRule services={services} history={props.history} />
+                            <ImportRule
+                              services={services}
+                              history={props.history}
+                              notifications={core?.notifications}
+                            />
                           )}
                         />
                         <Route

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -4,12 +4,12 @@
  */
 
 import {
+  EuiButton,
   EuiButtonEmpty,
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
-  EuiSuperDatePicker,
   EuiTitle,
 } from '@elastic/eui';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
@@ -112,12 +112,8 @@ export const Overview: React.FC<OverviewProps> = (props) => {
               <h1>Overview</h1>
             </EuiTitle>
           </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiSuperDatePicker
-              onTimeChange={onTimeChange}
-              onRefresh={onRefresh}
-              updateButtonProps={{ fill: false }}
-            />
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={onRefresh}>Refresh</EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -12,13 +12,16 @@ import { Rule } from '../../../../../models/interfaces';
 import { RouteComponentProps } from 'react-router-dom';
 import { load, safeDump } from 'js-yaml';
 import { ContentPanel } from '../../../../components/ContentPanel';
+import { NotificationsStart } from 'opensearch-dashboards/public';
+import { errorNotificationToast } from '../../../../utils/helpers';
 
 export interface ImportRuleProps {
   services: BrowserServices;
   history: RouteComponentProps['history'];
+  notifications?: NotificationsStart;
 }
 
-export const ImportRule: React.FC<ImportRuleProps> = ({ history, services }) => {
+export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notifications }) => {
   const [fileError, setFileError] = useState('');
   const onChange = useCallback((files: any) => {
     setFileError('');
@@ -101,11 +104,10 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services }) => 
       const updateRuleRes = await services.ruleService.createRule(rule);
 
       if (!updateRuleRes.ok) {
-        // TODO: show toast notification
-        alert('Failed rule creation');
+        errorNotificationToast(notifications!, 'create', 'rule', updateRuleRes.error);
+      } else {
+        history.replace(ROUTES.RULES);
       }
-
-      history.replace(ROUTES.RULES);
     };
 
     return (

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -5,7 +5,7 @@
 
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditor } from '../../components/RuleEditor/RuleEditor';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { EuiButton, EuiFilePicker, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { ROUTES } from '../../../../utils/constants';
 import { Rule } from '../../../../../models/interfaces';
@@ -20,9 +20,10 @@ export interface ImportRuleProps {
 
 export const ImportRule: React.FC<ImportRuleProps> = ({ history, services }) => {
   const [fileError, setFileError] = useState('');
-  const onChange = (files: any) => {
+  const onChange = useCallback((files: any) => {
     setFileError('');
-    if (files[0].type === 'application/x-yaml') {
+
+    if (files[0]?.type === 'application/x-yaml') {
       let reader = new FileReader();
       reader.readAsText(files[0]);
       reader.onload = function () {
@@ -63,32 +64,37 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services }) => 
         );
       };
     } else {
-      setFileError('Only yaml files are accepted');
+      setFileError(files.length > 0 ? 'Only yaml files are accepted' : '');
     }
-  };
+  }, []);
 
-  const [content, setContent] = useState(
-    <>
-      <ContentPanel title="Import rule">
-        <EuiFilePicker
-          id={'filePickerId'}
-          fullWidth
-          initialPromptText="Select or drag yml file containing Sigma rules"
-          onChange={onChange}
-          display={'large'}
-          multiple={false}
-          aria-label="file picker"
-        />
-        {fileError && <div>Error: {fileError}</div>}
-      </ContentPanel>
-      <EuiSpacer size="xl" />
-      <EuiFlexGroup justifyContent="flexEnd">
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => history.replace(ROUTES.RULES)}>Cancel</EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
-  );
+  const [content, setContent] = useState<React.ReactElement | null>(null);
+
+  useEffect(() => {
+    setContent(
+      <>
+        <ContentPanel title="Import rule">
+          <EuiFilePicker
+            id={'filePickerId'}
+            fullWidth
+            initialPromptText="Select or drag yml file containing Sigma rules"
+            onChange={onChange}
+            display={'large'}
+            multiple={false}
+            aria-label="file picker"
+            isInvalid={!!fileError}
+          />
+          {fileError && <div style={{ color: 'red', margin: '0 auto' }}>Error: {fileError}</div>}
+        </ContentPanel>
+        <EuiSpacer size="xl" />
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={() => history.replace(ROUTES.RULES)}>Cancel</EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    );
+  }, [fileError, onChange]);
 
   const footerActions: React.FC<{ rule: Rule }> = ({ rule }) => {
     const onCreate = async () => {

--- a/public/pages/Rules/containers/Rules/Rules.tsx
+++ b/public/pages/Rules/containers/Rules/Rules.tsx
@@ -14,8 +14,11 @@ import { RuleTableItem } from '../../utils/helpers';
 import { RuleItemInfoBase } from '../../models/types';
 import { RuleViewerFlyout } from '../../components/RuleViewerFlyout/RuleViewerFlyout';
 import { ROUTES } from '../../../../utils/constants';
+import { NotificationsStart } from 'opensearch-dashboards/public';
 
-export interface RulesProps extends RouteComponentProps {}
+export interface RulesProps extends RouteComponentProps {
+  notifications?: NotificationsStart;
+}
 
 export const Rules: React.FC<RulesProps> = (props) => {
   const services = useContext(ServicesContext) as BrowserServices;


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Redirect to rules page when payload empty for edit or duplicate pages; Improved import page

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).