### PR TITLE
UI Bug fixes

### DIFF
--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+  DurationRange,
   EuiBasicTableColumn,
   EuiButton,
   EuiButtonEmpty,
@@ -26,8 +27,9 @@ import moment from 'moment';
 import {
   ALERT_STATE,
   BREADCRUMBS,
-  DATE_MATH_FORMAT,
+  DEFAULT_DATE_RANGE,
   DEFAULT_EMPTY_DATA,
+  MAX_RECENTLY_USED_TIME_RANGES,
 } from '../../../../utils/constants';
 import { CoreServicesContext } from '../../../../components/core_services';
 import AlertsService from '../../../../services/AlertsService';
@@ -59,6 +61,7 @@ export interface AlertsState {
   groupBy: string;
   startTime: string;
   endTime: string;
+  recentlyUsedRanges: DurationRange[];
   selectedItems: AlertItem[];
   alerts: AlertItem[];
   flyoutData?: { alertItem: AlertItem };
@@ -78,12 +81,11 @@ export default class Alerts extends Component<AlertsProps, AlertsState> {
 
   constructor(props: AlertsProps) {
     super(props);
-    const now = moment.now();
-    const startTime = moment(now).subtract(15, 'minutes').format(DATE_MATH_FORMAT);
     this.state = {
       groupBy: 'status',
-      startTime,
-      endTime: moment(now).format(DATE_MATH_FORMAT),
+      startTime: DEFAULT_DATE_RANGE.start,
+      endTime: DEFAULT_DATE_RANGE.end,
+      recentlyUsedRanges: [DEFAULT_DATE_RANGE],
       selectedItems: [],
       alerts: [],
       alertsFiltered: false,
@@ -281,7 +283,19 @@ export default class Alerts extends Component<AlertsProps, AlertsState> {
   }
 
   onTimeChange = ({ start, end }: { start: string; end: string }) => {
-    this.setState({ startTime: start, endTime: end });
+    let { recentlyUsedRanges } = this.state;
+    recentlyUsedRanges = recentlyUsedRanges.filter(
+      (range) => !(range.start === start && range.end === end)
+    );
+    recentlyUsedRanges.unshift({ start: start, end: end });
+    if (recentlyUsedRanges.length > MAX_RECENTLY_USED_TIME_RANGES)
+      recentlyUsedRanges = recentlyUsedRanges.slice(0, MAX_RECENTLY_USED_TIME_RANGES);
+    const endTime = start === end ? DEFAULT_DATE_RANGE.end : end;
+    this.setState({
+      startTime: start,
+      endTime: endTime,
+      recentlyUsedRanges: recentlyUsedRanges,
+    });
   };
 
   onRefresh = async () => {
@@ -330,7 +344,17 @@ export default class Alerts extends Component<AlertsProps, AlertsState> {
 
   render() {
     const { ruleService } = this.props;
-    const { alerts, alertsFiltered, detectors, filteredAlerts, flyoutData } = this.state;
+    const {
+      alerts,
+      alertsFiltered,
+      detectors,
+      filteredAlerts,
+      flyoutData,
+      loading,
+      startTime,
+      endTime,
+      recentlyUsedRanges,
+    } = this.state;
 
     const severities = new Set();
     const statuses = new Set();
@@ -407,6 +431,10 @@ export default class Alerts extends Component<AlertsProps, AlertsState> {
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiSuperDatePicker
+                  start={startTime}
+                  end={endTime}
+                  recentlyUsedRanges={recentlyUsedRanges}
+                  isLoading={loading}
                   onTimeChange={this.onTimeChange}
                   onRefresh={this.onRefresh}
                   updateButtonProps={{ fill: false }}

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -241,7 +241,7 @@ export default class Alerts extends Component<AlertsProps, AlertsState> {
       const detectorsRes = await detectorService.getDetectors();
       if (detectorsRes.ok) {
         const detectorIds = detectorsRes.response.hits.hits.map((hit) => {
-          detectors[hit._id] = hit._source;
+          detectors[hit._id] = { ...hit._source, id: hit._id };
           return hit._id;
         });
 

--- a/public/pages/CreateDetector/components/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/containers/DefineDetector.tsx
@@ -54,7 +54,7 @@ export default class DefineDetector extends Component<DefineDetectorProps, Defin
     this.updateDetectorCreationState(newDetector);
   };
 
-  onDetectorInputDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>, index = 0) => {
+  onDetectorInputDescriptionChange = (description: string) => {
     const { inputs } = this.props.detector;
     const newDetector: Detector = {
       ...this.props.detector,
@@ -62,13 +62,12 @@ export default class DefineDetector extends Component<DefineDetectorProps, Defin
         {
           detector_input: {
             ...inputs[0].detector_input,
-            description: event.target.value,
+            description: description,
           },
         },
         ...inputs.slice(1),
       ],
     };
-
     this.updateDetectorCreationState(newDetector);
   };
 

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
@@ -12,10 +12,9 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { Detector, PeriodSchedule } from '../../../../../models/interfaces';
-import React, { ChangeEvent, useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import DetectorBasicDetailsForm from '../../../CreateDetector/components/DefineDetector/components/DetectorDetails';
-import { MIN_NUM_DATA_SOURCES } from '../../utils/constants';
 import DetectorDataSource from '../../../CreateDetector/components/DefineDetector/components/DetectorDataSource';
 import { IndexService, ServicesContext } from '../../../../services';
 import { DetectorSchedule } from '../../../CreateDetector/components/DefineDetector/components/DetectorSchedule/DetectorSchedule';
@@ -78,14 +77,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
 
   const updateDetectorState = useCallback(
     (detector: Detector) => {
-      const isDataValid =
-        !!detector.name &&
-        !!detector.detector_type &&
-        detector.inputs[0].detector_input.indices.length >= MIN_NUM_DATA_SOURCES;
-
-      if (isDataValid) {
-        setDetector(detector);
-      }
+      setDetector(detector);
     },
     [setDetector]
   );

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
@@ -37,6 +37,8 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
     props.location.state?.detectorHit?._source || EMPTY_DEFAULT_DETECTOR
   );
   const { name, inputs } = detector;
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const description = inputs[0].detector_input.description;
   const detectorId = props.location.pathname.replace(`${ROUTES.EDIT_DETECTOR_DETAILS}/`, '');
 
@@ -62,7 +64,9 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
     };
 
     const execute = async () => {
+      setLoading(true);
       await getDetector();
+      setLoading(false);
     };
 
     if (!detector.id?.length) {
@@ -99,7 +103,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
   );
 
   const onDetectorInputDescriptionChange = useCallback(
-    (event: ChangeEvent<HTMLTextAreaElement>, index = 0) => {
+    (description: string) => {
       const { inputs } = detector;
       const newDetector: Detector = {
         ...detector,
@@ -107,7 +111,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
           {
             detector_input: {
               ...inputs[0].detector_input,
-              description: event.target.value,
+              description: description,
             },
           },
           ...inputs.slice(1),
@@ -165,6 +169,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
     const detectorHit = props.location.state.detectorHit;
 
     const updateDetector = async () => {
+      setSubmitting(true);
       const updateDetectorRes = await services?.detectorsService?.updateDetector(
         detectorHit._id,
         detector
@@ -187,6 +192,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
           detectorHit: { ...detectorHit, _source: { ...detectorHit._source, ...detector } },
         },
       });
+      setSubmitting(false);
     };
 
     updateDetector().catch((e) => {
@@ -224,10 +230,14 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
 
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={onCancel}>Cancel</EuiButton>
+          <EuiButton onClick={onCancel} disabled={loading}>
+            Cancel
+          </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={onSave}>Save changes</EuiButton>
+          <EuiButton onClick={onSave} disabled={loading || submitting} isLoading={submitting}>
+            Save changes
+          </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </div>

--- a/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
+++ b/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
@@ -225,7 +225,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton disabled={loading} isLoading={submitting} onClick={onSave}>
+          <EuiButton disabled={loading} fill={true} isLoading={submitting} onClick={onSave}>
             Save changes
           </EuiButton>
         </EuiFlexItem>

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -8,6 +8,8 @@ import { DetectorHit } from '../../server/models/interfaces';
 import { DETECTOR_TYPES } from '../pages/Detectors/utils/constants';
 
 export const DATE_MATH_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
+export const MAX_RECENTLY_USED_TIME_RANGES = 5;
+export const DEFAULT_DATE_RANGE = { start: 'now-15m', end: 'now' };
 
 export const PLUGIN_NAME = 'opensearch_security_analytics_dashboards';
 

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -195,14 +195,15 @@ export const errorNotificationToast = (
   notifications: NotificationsStart | null,
   actionName: string,
   objectName: string,
-  errorMessage: string = ''
+  errorMessage: string = '',
+  displayTime: number = 5000 // 5 seconds; default is 10 seconds
 ) => {
   const message = `Failed to ${actionName} ${objectName}:`;
   console.error(message, errorMessage);
   notifications?.toasts.addDanger({
     title: message,
     text: errorMessage,
-    toastLifeTimeMs: 20000, // the default lifetime for toasts is 10 sec
+    toastLifeTimeMs: displayTime,
   });
 };
 
@@ -211,11 +212,12 @@ export const successNotificationToast = (
   notifications: NotificationsStart | null,
   actionName: string,
   objectName: string,
-  successMessage: string = ''
+  successMessage: string = '',
+  displayTime: number = 5000 // 5 seconds; default is 10 seconds
 ) => {
   notifications?.toasts.addSuccess({
     title: `Successfully ${actionName} ${objectName}`,
     text: successMessage,
-    toastLifeTimeMs: 20000, // the default lifetime for toasts is 10 sec
+    toastLifeTimeMs: displayTime,
   });
 };

--- a/server/models/interfaces/Detectors.ts
+++ b/server/models/interfaces/Detectors.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Query } from '@elastic/eui';
 import { Detector } from '../../../models/interfaces';
 
 export interface CreateDetectorParams {
@@ -23,7 +22,10 @@ export interface GetDetectorParams {
 export interface GetDetectorResponse {}
 
 export interface SearchDetectorsParams {
-  body: { query: Query };
+  body: {
+    size: number;
+    query: object;
+  };
 }
 
 export interface SearchDetectorsResponse {

--- a/server/services/DetectorService.ts
+++ b/server/services/DetectorService.ts
@@ -26,7 +26,6 @@ import {
 import { CLIENT_DETECTOR_METHODS } from '../utils/constants';
 import { Detector } from '../../models/interfaces';
 import { ServerResponse } from '../models/types';
-import { Query } from '@elastic/eui';
 
 export default class DetectorService {
   osDriver: ILegacyCustomClusterClient;
@@ -122,8 +121,8 @@ export default class DetectorService {
     IOpenSearchDashboardsResponse<ServerResponse<SearchDetectorsResponse> | ResponseError>
   > => {
     try {
-      const { query } = request.body as { query: Query };
-      const params: SearchDetectorsParams = { body: { query } };
+      const { query } = request.body as { query: object };
+      const params: SearchDetectorsParams = { body: { size: 10000, query } };
       const { callAsCurrentUser: callWithRequest } = this.osDriver.asScoped(request);
       const searchDetectorResponse: SearchDetectorsResponse = await callWithRequest(
         CLIENT_DETECTOR_METHODS.SEARCH_DETECTORS,


### PR DESCRIPTION
### Description
1. Adjusted the display time for toasts.
2. Fixed an issue that was preventing the recent time selections from rendering in the SuperTimePicker. This also fixed the issue that was causing the "update" text on the refresh button from changing back to "refresh" after loading.
3. Fixed the link to the detector details page on the FindingDetailsFlyout when opening the flyout from the AlertFlyout.
4. Made save button on rules edit page filled.
5. Fixed an issue that was preventing the data source combo box from being cleared when editing a detector. Removed unused imports.
6. Fixed an issue that was limiting the number of detectors returned when calling the SearchDetector backend API.
7. Fixed bug that prevented setting a detector description.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).