### PR TITLE
Use lower case for detector type when editing detector

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -131,7 +131,7 @@ export default class AlertConditionPanel extends Component<
       detector: { triggers },
       indexNum,
     } = this.props;
-    trigger.types = [detector.detector_type];
+    trigger.types = [detector.detector_type.toLowerCase()];
     const newTriggers = [...triggers];
     newTriggers.splice(indexNum, 1, { ...alertCondition, ...trigger });
     onAlertTriggerChanged({ ...detector, triggers: newTriggers });

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -63,7 +63,7 @@ export default class ConfigureFieldMapping extends Component<
     this.setState({ loading: true });
     const mappingsView = await this.props.filedMappingService.getMappingsView(
       this.props.detector.inputs[0].detector_input.indices[0],
-      this.props.detector.detector_type
+      this.props.detector.detector_type.toLowerCase()
     );
     if (mappingsView.ok) {
       const existingMappings = { ...this.state.createdMappings };


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Use lower case for detector type when editing detector. This ensures the alerts get generated correctly when matching detector type.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).