### PR TITLE
Fix detector link in Overview to display Detector details

### DIFF
--- a/public/pages/Overview/components/Widgets/DetectorsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/DetectorsWidget.tsx
@@ -61,7 +61,7 @@ export const DetectorsWidget: React.FC<DetectorsWidgetProps> = ({ detectorHits, 
 
   const showDetectorDetails = useCallback((detectorHit: DetectorHit) => {
     history.push({
-      pathname: ROUTES.DETECTOR_DETAILS,
+      pathname: `${ROUTES.DETECTOR_DETAILS}/${detectorHit._id}`,
       state: { detectorHit },
     });
   }, []);


### PR DESCRIPTION
Signed-off-by: Chris Hesterman <phestech@amazon.com>

### Description
This change correctly presents the clicked on detector's Detector details page

### Issues Resolved
#123

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).