### PR TITLE
Updated breadcrums for Rules pages

### DIFF
--- a/public/pages/Rules/containers/CreateRule/CreateRule.tsx
+++ b/public/pages/Rules/containers/CreateRule/CreateRule.tsx
@@ -13,7 +13,7 @@ import { Rule } from '../../../../../models/interfaces';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast } from '../../../../utils/helpers';
-import { validateRule } from '../../utils/helpers';
+import { setBreadCrumb, validateRule } from '../../utils/helpers';
 
 export interface CreateRuleProps {
   services: BrowserServices;
@@ -23,7 +23,7 @@ export interface CreateRuleProps {
 
 export const CreateRule: React.FC<CreateRuleProps> = ({ history, services, notifications }) => {
   const context = useContext(CoreServicesContext);
-  context?.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES_CREATE]);
+  setBreadCrumb(BREADCRUMBS.RULES_CREATE, context?.chrome.setBreadcrumbs);
   const footerActions: React.FC<{ rule: Rule }> = ({ rule }) => {
     const onCreate = async () => {
       if (!validateRule(rule, notifications!, 'create')) {

--- a/public/pages/Rules/containers/DuplicateRule/DuplicateRule.tsx
+++ b/public/pages/Rules/containers/DuplicateRule/DuplicateRule.tsx
@@ -12,7 +12,7 @@ import { BREADCRUMBS, ROUTES } from '../../../../utils/constants';
 import { Rule } from '../../../../../models/interfaces';
 import { RuleItemInfoBase } from '../../models/types';
 import { CoreServicesContext } from '../../../../components/core_services';
-import { validateRule } from '../../utils/helpers';
+import { setBreadCrumb, validateRule } from '../../utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast } from '../../../../utils/helpers';
 
@@ -29,7 +29,7 @@ export const DuplicateRule: React.FC<DuplicateRuleProps> = ({
   notifications,
 }) => {
   const context = useContext(CoreServicesContext);
-  context?.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES_DUPLICATE]);
+  setBreadCrumb(BREADCRUMBS.RULES_DUPLICATE, context?.chrome.setBreadcrumbs);
   const footerActions: React.FC<{ rule: Rule }> = ({ rule }) => {
     const onCreate = async () => {
       if (!validateRule(rule, notifications!, 'create')) {

--- a/public/pages/Rules/containers/EditRule/EditRule.tsx
+++ b/public/pages/Rules/containers/EditRule/EditRule.tsx
@@ -14,7 +14,7 @@ import { RuleItemInfoBase } from '../../models/types';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast } from '../../../../utils/helpers';
-import { validateRule } from '../../utils/helpers';
+import { setBreadCrumb, validateRule } from '../../utils/helpers';
 
 export interface EditRuleProps
   extends RouteComponentProps<any, any, { ruleItem: RuleItemInfoBase }> {
@@ -29,7 +29,7 @@ export const EditRule: React.FC<EditRuleProps> = ({
   notifications,
 }) => {
   const context = useContext(CoreServicesContext);
-  context?.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES_EDIT]);
+  setBreadCrumb(BREADCRUMBS.RULES_EDIT, context?.chrome.setBreadcrumbs);
   const footerActions: React.FC<{ rule: Rule }> = ({ rule }) => {
     const onSave = async () => {
       if (!validateRule(rule, notifications!, 'save')) {

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -15,7 +15,7 @@ import { ContentPanel } from '../../../../components/ContentPanel';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast } from '../../../../utils/helpers';
 import { CoreServicesContext } from '../../../../components/core_services';
-import { validateRule } from '../../utils/helpers';
+import { setBreadCrumb, validateRule } from '../../utils/helpers';
 
 export interface ImportRuleProps {
   services: BrowserServices;
@@ -114,7 +114,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
         </EuiFlexGroup>
       </>
     );
-    context?.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES_IMPORT]);
+    setBreadCrumb(BREADCRUMBS.RULES_IMPORT, context?.chrome.setBreadcrumbs);
   }, [fileError, onChange]);
 
   const footerActions: React.FC<{ rule: Rule }> = ({ rule }) => {

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiLink } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiBreadcrumb, EuiLink } from '@elastic/eui';
 import React from 'react';
 import { capitalizeFirstLetter, errorNotificationToast } from '../../../utils/helpers';
 import { ruleSeverity, ruleSource, ruleTypes } from './constants';
@@ -13,6 +13,7 @@ import { Rule } from '../../../../models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { AUTHOR_REGEX, validateDescription, validateName } from '../../../utils/validation';
 import { dump, load } from 'js-yaml';
+import { BREADCRUMBS } from '../../../utils/constants';
 
 export interface RuleTableItem {
   title: string;
@@ -145,4 +146,11 @@ export function validateRule(
   }
 
   return true;
+}
+
+export function setBreadCrumb(
+  breadCrumb: EuiBreadcrumb,
+  breadCrumbSetter?: (breadCrumbs: EuiBreadcrumb[]) => void
+) {
+  breadCrumbSetter?.([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES, breadCrumb]);
 }


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Added "Rules" step as part of the breadcrumbs shown on Create, Edit, Duplicate and Import rule pages. This will make it easier for user to navigate back to the rules page.

<img width="442" alt="image" src="https://user-images.githubusercontent.com/114732919/202822900-695e03f3-5a7b-43ad-ae00-d365eab731c7.png">

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/139

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).