### PR TITLE
[FEATURE] Set header size to medium

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -38,7 +38,7 @@ const renderSubTitleText = (subTitleText: string | JSX.Element): JSX.Element | n
 
 const ContentPanel: React.SFC<ContentPanelProps> = ({
   title = '',
-  titleSize = 'l',
+  titleSize = 'm',
   subTitleText = '',
   bodyStyles = {},
   panelStyles = {},

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
       class="euiFlexItem"
     >
       <h3
-        class="euiTitle euiTitle--large"
+        class="euiTitle euiTitle--medium"
       >
         Testing
       </h3>

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -425,7 +425,7 @@ export default class Alerts extends Component<AlertsProps, AlertsState> {
           <EuiFlexItem>
             <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
               <EuiFlexItem>
-                <EuiTitle size="l">
+                <EuiTitle size="m">
                   <h1>Security alerts</h1>
                 </EuiTitle>
               </EuiFlexItem>

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -97,7 +97,7 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
     const { loading, notificationChannels } = this.state;
     return (
       <div>
-        <EuiTitle size={'l'}>
+        <EuiTitle size={'m'}>
           <h3>
             {createDetectorSteps[DetectorCreationStep.CONFIGURE_ALERTS].title +
               ` (${triggers.length})`}

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -144,7 +144,7 @@ export default class ConfigureFieldMapping extends Component<
       <div>
         {!isEdit && (
           <div>
-            <EuiTitle size={'l'}>
+            <EuiTitle size={'m'}>
               <h3>{createDetectorSteps[DetectorCreationStep.CONFIGURE_FIELD_MAPPING].title}</h3>
             </EuiTitle>
             <EuiSpacer size={'m'} />

--- a/public/pages/CreateDetector/components/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/containers/DefineDetector.tsx
@@ -165,7 +165,7 @@ export default class DefineDetector extends Component<DefineDetectorProps, Defin
 
     return (
       <div>
-        <EuiTitle size={'l'}>
+        <EuiTitle size={'m'}>
           <h3>{`${isEdit ? 'Edit' : 'Define'} detector`}</h3>
         </EuiTitle>
 

--- a/public/pages/CreateDetector/components/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/CreateDetector/components/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -38,7 +38,7 @@ export class ReviewAndCreate extends React.Component<ReviewAndCreateProps, Revie
   render() {
     return (
       <div>
-        <EuiTitle size={'l'}>
+        <EuiTitle size={'m'}>
           <h3>Review and create</h3>
         </EuiTitle>
         <DetectorDetailsView

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
@@ -194,7 +194,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
 
   return (
     <div>
-      <EuiTitle size={'l'}>
+      <EuiTitle size={'m'}>
         <h3>Edit detector details</h3>
       </EuiTitle>
       <EuiSpacer size="xxl" />

--- a/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
+++ b/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
@@ -151,7 +151,7 @@ export default class UpdateFieldMappings extends Component<
     const { submitting, detector, fieldMappings, loading } = this.state;
     return (
       <div>
-        <EuiTitle size={'l'}>
+        <EuiTitle size={'m'}>
           <h3>Edit detector details</h3>
         </EuiTitle>
         <EuiSpacer size={'xxl'} />

--- a/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
+++ b/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
@@ -205,7 +205,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
   const ruleItems = prePackagedRuleItems.concat(customRuleItems);
   return (
     <div>
-      <EuiTitle size={'l'}>
+      <EuiTitle size={'m'}>
         <h3>Edit detector rules</h3>
       </EuiTitle>
       <EuiSpacer size="xl" />

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -338,7 +338,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
         <EuiFlexItem>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiTitle size="l">
+              <EuiTitle size="m">
                 <h1>Threat detectors</h1>
               </EuiTitle>
             </EuiFlexItem>

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -290,7 +290,7 @@ export default class Findings extends Component<FindingsProps, FindingsState> {
         <EuiFlexItem>
           <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
             <EuiFlexItem>
-              <EuiTitle size="l">
+              <EuiTitle size="m">
                 <h1>Findings</h1>
               </EuiTitle>
             </EuiFlexItem>

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -108,7 +108,7 @@ export const Overview: React.FC<OverviewProps> = (props) => {
       <EuiFlexItem>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem>
-            <EuiTitle size="l">
+            <EuiTitle size="m">
               <h1>Overview</h1>
             </EuiTitle>
           </EuiFlexItem>

--- a/public/pages/Rules/containers/Rules/Rules.tsx
+++ b/public/pages/Rules/containers/Rules/Rules.tsx
@@ -99,7 +99,7 @@ export const Rules: React.FC<RulesProps> = (props) => {
         <EuiFlexItem>
           <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
             <EuiFlexItem>
-              <EuiTitle size="l">
+              <EuiTitle size="m">
                 <h1>Rules</h1>
               </EuiTitle>
             </EuiFlexItem>


### PR DESCRIPTION
Signed-off-by: Sinisa Andric <johnsie@gmail.com>

### Description
Sets header size to medium on all instances in plugin.

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/171

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).