### PR TITLE
[Backport 2.x] Add EuiHealth component to Detector Details

### DIFF
--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -386,7 +386,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
   createStepsMetadata(currentStep: number): EuiContainedStepProps[] {
     return Object.values(createDetectorSteps).map((stepData) => ({
       title: stepData.title,
-      status: currentStep < stepData.step + 1 ? 'disabled' : 'complete',
+      status: currentStep < stepData.step ? 'disabled' : undefined,
       children: <></>,
     }));
   }

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -16,6 +16,7 @@ import {
   EuiTabs,
   EuiText,
   EuiTitle,
+  EuiHealth,
 } from '@elastic/eui';
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -338,11 +339,9 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiText>
-                  <span style={{ color: `${detector.enabled ? 'green' : 'red'}` }}>
-                    {detector.enabled ? 'Active' : 'Inactive'}
-                  </span>
-                </EuiText>
+                <EuiHealth color={detector.enabled ? 'success' : 'subdued'}>
+                  {detector.enabled ? 'Active' : 'Inactive'}
+                </EuiHealth>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>


### PR DESCRIPTION
### Description
Add EuiHealth instead of colored label for Detector status. EuiHealth is a consistent means of reflecting the entity state. It should replace custom colored label.

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/143

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).