### PR TITLE
Remove mac os from unit test platforms

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        os: [ubuntu-latest, mac-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       # Enable longer filenames for windows

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "*.{ts,tsx,js,jsx,json,css,md}": ["prettier --write", "git add"]
+  "*.{ts,tsx,js,jsx,json,css,md}": ["prettier --write"]
 }


### PR DESCRIPTION
### Description
Currently there is no infra setup to be able to successfully run unit tests on mac-os, so it is redundant to even try.
This PR also fixes the below warning shown on commit
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/114732919/207124953-29b48c42-e4d0-48c2-820b-54ceff559da2.png">


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).