### PR TITLE
Sort alerts in descending order of timestamp by default

### DIFF
--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -428,7 +428,7 @@ class Alerts extends Component<AlertsProps, AlertsState> {
     const sorting: any = {
       sort: {
         field: 'start_time',
-        direction: 'asc',
+        direction: 'dsc',
       },
     };
 


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Sort alerts in descending order of timestamp by default

### Issues Resolved
#119 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).