### PR TITLE
Filtered findings shown in alert details

### DIFF
--- a/cypress/integration/3_alerts.spec.js
+++ b/cypress/integration/3_alerts.spec.js
@@ -159,12 +159,12 @@ describe('Alerts', () => {
       cy.get('[data-test-subj="text-details-group-content-detector"]').contains(testDetector.name);
 
       // Wait for the findings table to finish loading
-      cy.contains('Findings (4)', TWENTY_SECONDS_TIMEOUT);
+      cy.contains('Findings (1)', TWENTY_SECONDS_TIMEOUT);
       cy.contains('USB Device Plugged', TWENTY_SECONDS_TIMEOUT);
 
       // Confirm alert findings contain expected values
       cy.get('tbody > tr', TWENTY_SECONDS_TIMEOUT)
-        .should(($tr) => expect($tr, '4 rows').to.have.length(4))
+        .should(($tr) => expect($tr, '1 row').to.have.length(1))
         .each(($el, $index) => {
           expect($el, `row number ${$index} timestamp`).to.contain(date);
           expect($el, `row number ${$index} rule name`).to.contain('USB Device Plugged');
@@ -355,7 +355,7 @@ describe('Alerts', () => {
       });
 
     // Filter the table to show only "Active" alerts
-    cy.get('[data-text="Status"]');
+    cy.get('[data-text="Status"]').click({ force: true });
     cy.get('[class="euiFilterSelect__items"]').within(() => {
       cy.contains('Acknowledged').click({ force: true });
       cy.contains('Active').click({ force: true });
@@ -391,7 +391,7 @@ describe('Alerts', () => {
     );
 
     // Filter the table to show only "Acknowledged" alerts
-    cy.get('[data-text="Status"]');
+    cy.get('[data-text="Status"]').click({ force: true });
     cy.get('[class="euiFilterSelect__items"]').within(() => {
       cy.contains('Active').click({ force: true });
       cy.contains('Acknowledged').click({ force: true });

--- a/cypress/integration/3_alerts.spec.js
+++ b/cypress/integration/3_alerts.spec.js
@@ -355,7 +355,7 @@ describe('Alerts', () => {
       });
 
     // Filter the table to show only "Active" alerts
-    cy.get('[data-text="Status"]').click({ force: true });
+    cy.get('[data-text="Status"]');
     cy.get('[class="euiFilterSelect__items"]').within(() => {
       cy.contains('Acknowledged').click({ force: true });
       cy.contains('Active').click({ force: true });
@@ -391,7 +391,7 @@ describe('Alerts', () => {
     );
 
     // Filter the table to show only "Acknowledged" alerts
-    cy.get('[data-text="Status"]').click({ force: true });
+    cy.get('[data-text="Status"]');
     cy.get('[class="euiFilterSelect__items"]').within(() => {
       cy.contains('Active').click({ force: true });
       cy.contains('Acknowledged').click({ force: true });

--- a/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
+++ b/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
@@ -82,7 +82,10 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
     try {
       const findingRes = await findingsService.getFindings({ detectorId: detector_id });
       if (findingRes.ok) {
-        this.setState({ findingItems: findingRes.response.findings });
+        const relatedFindings = findingRes.response.findings.filter((finding) =>
+          this.props.alertItem.finding_ids.includes(finding.id)
+        );
+        this.setState({ findingItems: relatedFindings });
       } else {
         errorNotificationToast(notifications, 'retrieve', 'findings', findingRes.error);
       }


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Currently all the findings for a detector of an alert are shown in the alerts details which is not correct. This PR filters the findings to only show the finding which resulted in the alert.

### Issues Resolved
#228

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).