### PR TITLE
Toggle all rules button on detector edit page

### DIFF
--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -222,7 +222,7 @@ describe('Detectors', () => {
     cy.contains('tr', 'USB Device Plugged').within(() => {
       // Of note, timeout can sometimes work instead of wait here, but is very unreliable from case to case.
       cy.wait(1000);
-      cy.get('button').eq(0).click();
+      cy.get('button').eq(1).click();
     });
 
     // Save changes
@@ -246,7 +246,7 @@ describe('Detectors', () => {
     // Toggle single search result to checked
     cy.contains('tr', 'USB Device Plugged').within(() => {
       cy.wait(2000);
-      cy.get('button').eq(0).click({ force: true });
+      cy.get('button').eq(1).click({ force: true });
     });
 
     // Save changes

--- a/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
+++ b/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
@@ -166,6 +166,11 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
     }
   };
 
+  const onAllRulesToggle = (isActive: boolean) => {
+    setCustomRuleItems(customRuleItems.map((rule) => ({ ...rule, active: isActive })));
+    setPrePackagedRuleItems(prePackagedRuleItems.map((rule) => ({ ...rule, active: isActive })));
+  };
+
   const onCancel = useCallback(() => {
     props.history.replace({
       pathname: `${ROUTES.DETECTOR_DETAILS}/${detectorId}`,
@@ -214,6 +219,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
         loading={loading}
         ruleItems={ruleItems}
         onRuleActivationToggle={onToggle}
+        onAllRulesToggled={onAllRulesToggle}
       />
 
       <EuiSpacer size="xl" />


### PR DESCRIPTION
### Description
Same toggling rules button as present on detector create flow

### Issues Resolved
Closed #122 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).