### PR TITLE
Creating new object for alert condition initialization

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -20,8 +20,12 @@ import {
 } from '@elastic/eui';
 import { Detector } from '../../../../../../../models/interfaces';
 import { AlertCondition } from '../../../../../../../models/interfaces';
-import { createSelectedOptions, parseAlertSeverityToOption } from '../../utils/helpers';
-import { ALERT_SEVERITY_OPTIONS, EMPTY_DEFAULT_ALERT_CONDITION } from '../../utils/constants';
+import {
+  createSelectedOptions,
+  getEmptyAlertCondition,
+  parseAlertSeverityToOption,
+} from '../../utils/helpers';
+import { ALERT_SEVERITY_OPTIONS } from '../../utils/constants';
 import { CreateDetectorRulesOptions } from '../../../../../../models/types';
 import { NotificationChannelOption, NotificationChannelTypeOptions } from '../../models/interfaces';
 import { NOTIFICATIONS_HREF } from '../../../../../../utils/constants';
@@ -247,7 +251,7 @@ export default class AlertConditionPanel extends Component<
 
   render() {
     const {
-      alertCondition = EMPTY_DEFAULT_ALERT_CONDITION,
+      alertCondition = getEmptyAlertCondition(),
       allNotificationChannels,
       indexNum,
       loadingNotifications,

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -15,13 +15,17 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { createDetectorSteps } from '../../../utils/constants';
-import { EMPTY_DEFAULT_ALERT_CONDITION, MAX_ALERT_CONDITIONS } from '../utils/constants';
+import { MAX_ALERT_CONDITIONS } from '../utils/constants';
 import AlertConditionPanel from '../components/AlertCondition';
 import { Detector } from '../../../../../../models/interfaces';
 import { DetectorCreationStep } from '../../../models/types';
 import { CreateDetectorRulesOptions } from '../../../../../models/types';
 import { NotificationChannelTypeOptions } from '../models/interfaces';
-import { getNotificationChannels, parseNotificationChannelsToOptions } from '../utils/helpers';
+import {
+  getEmptyAlertCondition,
+  getNotificationChannels,
+  parseNotificationChannelsToOptions,
+} from '../utils/helpers';
 import { NotificationsService } from '../../../../../services';
 
 interface ConfigureAlertsProps extends RouteComponentProps {
@@ -71,7 +75,7 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
       detector,
       detector: { triggers },
     } = this.props;
-    triggers.push(EMPTY_DEFAULT_ALERT_CONDITION);
+    triggers.push(getEmptyAlertCondition());
     changeDetector({ ...detector, triggers });
   };
 

--- a/public/pages/CreateDetector/components/ConfigureAlerts/utils/constants.ts
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/utils/constants.ts
@@ -2,9 +2,6 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { AlertCondition, TriggerAction } from '../../../../../../models/interfaces';
-
 export const MAX_ALERT_CONDITIONS = 10;
 export const MIN_ALERT_CONDITIONS = 0;
 
@@ -25,35 +22,6 @@ export const RULE_SEVERITY_OPTIONS = {
   MEDIUM: { id: '3', value: 'medium', label: 'Medium', text: 'Medium' },
   LOW: { id: '4', value: 'low', label: 'Low', text: 'Low' },
   INFORMATIONAL: { id: '5', value: 'informational', label: 'Info', text: 'Info' },
-};
-
-export const EMPTY_DEFAULT_TRIGGER_ACTION: TriggerAction = {
-  id: '',
-  name: '',
-  destination_id: '',
-  subject_template: {
-    source: '',
-    lang: 'mustache',
-  },
-  message_template: {
-    source: '',
-    lang: 'mustache',
-  },
-  throttle_enabled: false,
-  throttle: {
-    value: 10,
-    unit: 'MINUTES',
-  },
-};
-
-export const EMPTY_DEFAULT_ALERT_CONDITION: AlertCondition = {
-  name: '',
-  sev_levels: [],
-  tags: [],
-  actions: [EMPTY_DEFAULT_TRIGGER_ACTION],
-  types: [],
-  severity: '1',
-  ids: [],
 };
 
 export const MIN_NUM_NOTIFICATION_CHANNELS = 1;

--- a/public/pages/CreateDetector/components/ConfigureAlerts/utils/helpers.ts
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/utils/helpers.ts
@@ -8,6 +8,7 @@ import { ALERT_SEVERITY_OPTIONS, CHANNEL_TYPES } from './constants';
 import { FeatureChannelList } from '../../../../../../server/models/interfaces/Notifications';
 import { NotificationChannelTypeOptions } from '../models/interfaces';
 import { NotificationsService } from '../../../../../services';
+import { AlertCondition, TriggerAction } from '../../../../../../models/interfaces';
 
 export const parseAlertSeverityToOption = (severity: string): EuiComboBoxOptionOption<string> => {
   return Object.values(ALERT_SEVERITY_OPTIONS).find(
@@ -47,4 +48,35 @@ export function parseNotificationChannelsToOptions(
     label: type,
     options: allOptions.filter((channel) => channel.type === type),
   }));
+}
+
+export function getEmptyAlertCondition(): AlertCondition {
+  const emptyTriggerAction: TriggerAction = {
+    id: '',
+    name: '',
+    destination_id: '',
+    subject_template: {
+      source: '',
+      lang: 'mustache',
+    },
+    message_template: {
+      source: '',
+      lang: 'mustache',
+    },
+    throttle_enabled: false,
+    throttle: {
+      value: 10,
+      unit: 'MINUTES',
+    },
+  };
+
+  return {
+    name: '',
+    sev_levels: [],
+    tags: [],
+    actions: [emptyTriggerAction],
+    types: [],
+    severity: '1',
+    ids: [],
+  };
 }

--- a/public/pages/Findings/components/CreateAlertFlyout.tsx
+++ b/public/pages/Findings/components/CreateAlertFlyout.tsx
@@ -13,19 +13,18 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiFormRow,
-  EuiLink,
   EuiSpacer,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import AlertConditionPanel from '../../CreateDetector/components/ConfigureAlerts/components/AlertCondition';
 import { AlertCondition, Detector } from '../../../../models/interfaces';
-import { EMPTY_DEFAULT_ALERT_CONDITION } from '../../CreateDetector/components/ConfigureAlerts/utils/constants';
 import { DetectorsService } from '../../../services';
 import { RulesSharedState } from '../../../models/interfaces';
 import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { NotificationChannelTypeOptions } from '../../CreateDetector/components/ConfigureAlerts/models/interfaces';
 import { Finding } from '../models/interfaces';
+import { getEmptyAlertCondition } from '../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 
 interface CreateAlertFlyoutProps extends RouteComponentProps {
   closeFlyout: (refreshPage?: boolean) => void;
@@ -52,7 +51,7 @@ export default class CreateAlertFlyout extends Component<
   constructor(props: CreateAlertFlyoutProps) {
     super(props);
     this.state = {
-      alertCondition: EMPTY_DEFAULT_ALERT_CONDITION,
+      alertCondition: getEmptyAlertCondition(),
       loading: false,
       detector: this.props.finding.detector._source,
       submitting: false,


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Currently same object is being used for storing actions related to multiple alert conditions which results in notification channel getting modified for each alert condition. This PR ensures new objects is created from the template when initializing an alert condition.

### Issues Resolved
#213 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).