### PR TITLE
[BUG] Fetch only Rules matching Rule Types

### DIFF
--- a/public/pages/Rules/models/RulesViewModelActor.ts
+++ b/public/pages/Rules/models/RulesViewModelActor.ts
@@ -7,6 +7,7 @@ import { load, safeDump } from 'js-yaml';
 import { RuleInfo } from '../../../../server/models/interfaces';
 import { BrowserServices } from '../../../models/interfaces';
 import { RuleItemInfoBase } from './types';
+import { ruleTypes } from "../utils/constants";
 
 export interface RulesViewModel {
   allRules: RuleItemInfoBase[];
@@ -45,7 +46,9 @@ export class RulesViewModelActor {
         nested: {
           path: 'rule',
           query: {
-            match_all: {},
+            terms: {
+              "rule.category": ruleTypes,
+            }
           },
         },
       },


### PR DESCRIPTION
Signed-off-by: Sinisa Andric <johnsie@gmail.com>

### Description
Rules table contains rules of type not supported. Only fetch Rules that are matching types.

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/256

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).