### PR TITLE
Feature/charts should show the entire time range selected in the filter #258

### DIFF
--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -257,7 +257,7 @@ class Alerts extends Component<AlertsProps, AlertsState> {
     } = this.props;
     const chartTimeUnits = getChartTimeUnit(dateTimeFilter.startTime, dateTimeFilter.endTime);
     return getAlertsVisualizationSpec(visData, this.state.groupBy, {
-      timeUnit: this.state.timeUnit,
+      timeUnit: chartTimeUnits.timeUnit,
       dateFormat: chartTimeUnits.dateFormat,
       domain: getDomainRange(
         [dateTimeFilter.startTime, dateTimeFilter.endTime],
@@ -352,10 +352,6 @@ class Alerts extends Component<AlertsProps, AlertsState> {
       ...timeUnits,
     });
 
-    console.log('Alert Time change: ', {
-      startTime: start,
-      endTime: endTime,
-    });
     this.props.setDateTimeFilter &&
       this.props.setDateTimeFilter({
         startTime: start,

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -25,7 +25,8 @@ import { ContentPanel } from '../../../../components/ContentPanel';
 import {
   getAlertsVisualizationSpec,
   getChartTimeUnit,
-  getDateFormatByTimeUnit,
+  getDomainRange,
+  TimeUnit,
 } from '../../../Overview/utils/helpers';
 import moment from 'moment';
 import {
@@ -77,7 +78,8 @@ export interface AlertsState {
   filteredAlerts: AlertItem[];
   detectors: { [key: string]: Detector };
   loading: boolean;
-  timeUnit: string;
+  timeUnit: TimeUnit;
+  dateFormat: string;
 }
 
 const groupByOptions = [
@@ -90,7 +92,10 @@ class Alerts extends Component<AlertsProps, AlertsState> {
 
   constructor(props: AlertsProps) {
     super(props);
+
+    const timeUnits = getChartTimeUnit(DEFAULT_DATE_RANGE.start, DEFAULT_DATE_RANGE.end);
     this.state = {
+      loading: false,
       groupBy: 'status',
       startTime: DEFAULT_DATE_RANGE.start,
       endTime: DEFAULT_DATE_RANGE.end,
@@ -100,8 +105,8 @@ class Alerts extends Component<AlertsProps, AlertsState> {
       alertsFiltered: false,
       filteredAlerts: [],
       detectors: {},
-      loading: false,
-      timeUnit: 'yearmonthdatehoursminutes',
+      timeUnit: timeUnits.timeUnit,
+      dateFormat: timeUnits.dateFormat,
     };
   }
 
@@ -227,9 +232,14 @@ class Alerts extends Component<AlertsProps, AlertsState> {
       };
     });
 
+    const chartTimeUnits = getChartTimeUnit(this.state.startTime, this.state.endTime);
     return getAlertsVisualizationSpec(visData, this.state.groupBy, {
       timeUnit: this.state.timeUnit,
-      dateFormat: getDateFormatByTimeUnit(this.state.startTime, this.state.endTime),
+      dateFormat: chartTimeUnits.dateFormat,
+      domain: getDomainRange(
+        [this.state.startTime, this.state.endTime],
+        chartTimeUnits.timeUnit.unit
+      ),
     });
   }
 
@@ -313,12 +323,12 @@ class Alerts extends Component<AlertsProps, AlertsState> {
       recentlyUsedRanges = recentlyUsedRanges.slice(0, MAX_RECENTLY_USED_TIME_RANGES);
     const endTime = start === end ? DEFAULT_DATE_RANGE.end : end;
 
-    const timeUnit = getChartTimeUnit(start, endTime);
+    const timeUnits = getChartTimeUnit(start, endTime);
     this.setState({
       startTime: start,
       endTime: endTime,
       recentlyUsedRanges: recentlyUsedRanges,
-      timeUnit,
+      ...timeUnits,
     });
   };
 

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -56,6 +56,7 @@ import {
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { match, withRouter } from 'react-router-dom';
 import { DateTimeFilter } from '../../../Overview/models/interfaces';
+import { ChartContainer } from '../../../../components/Charts/ChartContainer';
 
 export interface AlertsProps {
   alertService: AlertsService;
@@ -102,7 +103,7 @@ class Alerts extends Component<AlertsProps, AlertsState> {
     } = props;
     const timeUnits = getChartTimeUnit(dateTimeFilter.startTime, dateTimeFilter.endTime);
     this.state = {
-      loading: false,
+      loading: true,
       groupBy: 'status',
       recentlyUsedRanges: [DEFAULT_DATE_RANGE],
       selectedItems: [],
@@ -518,7 +519,7 @@ class Alerts extends Component<AlertsProps, AlertsState> {
                   {this.createGroupByControl()}
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <div id="alerts-view"></div>
+                  <ChartContainer chartViewId={'alerts-view'} loading={loading} />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPanel>
@@ -535,6 +536,7 @@ class Alerts extends Component<AlertsProps, AlertsState> {
                 search={search}
                 sorting={sorting}
                 selection={selection}
+                loading={loading}
               />
             </ContentPanel>
           </EuiFlexItem>

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -33,6 +33,7 @@ import {
 import {
   getChartTimeUnit,
   getDateFormatByTimeUnit,
+  getDomainRange,
   getFindingsVisualizationSpec,
 } from '../../../Overview/utils/helpers';
 import { CoreServicesContext } from '../../../../components/core_services';
@@ -51,7 +52,6 @@ import {
 } from '../../../../utils/helpers';
 import { DetectorHit, RuleSource } from '../../../../../server/models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { ruleSeverity } from '../../../Rules/utils/constants';
 
 interface FindingsProps extends RouteComponentProps {
   detectorService: DetectorsService;
@@ -111,7 +111,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
       groupBy: 'logType',
       filteredFindings: [],
       plugins: [],
-      timeUnit: 'yearmonthdatehoursminutes',
+      timeUnit: getChartTimeUnit(DEFAULT_DATE_RANGE.start, DEFAULT_DATE_RANGE.end),
     };
   }
 
@@ -273,6 +273,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
     return getFindingsVisualizationSpec(visData, this.state.groupBy, {
       timeUnit: this.state.timeUnit,
       dateFormat: getDateFormatByTimeUnit(this.state.startTime, this.state.endTime),
+      domain: getDomainRange([this.state.startTime, this.state.endTime]),
     });
   }
 

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -28,13 +28,12 @@ import {
   DEFAULT_DATE_RANGE,
   MAX_RECENTLY_USED_TIME_RANGES,
   OS_NOTIFICATION_PLUGIN,
-  ROUTES,
 } from '../../../../utils/constants';
 import {
   getChartTimeUnit,
-  getDateFormatByTimeUnit,
   getDomainRange,
   getFindingsVisualizationSpec,
+  TimeUnit,
 } from '../../../Overview/utils/helpers';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { Finding } from '../../models/interfaces';
@@ -75,7 +74,8 @@ interface FindingsState {
   groupBy: FindingsGroupByType;
   filteredFindings: FindingItemType[];
   plugins: string[];
-  timeUnit: string;
+  timeUnit: TimeUnit;
+  dateFormat: string;
 }
 
 interface FindingVisualizationData {
@@ -99,6 +99,8 @@ class Findings extends Component<FindingsProps, FindingsState> {
 
   constructor(props: FindingsProps) {
     super(props);
+
+    const timeUnits = getChartTimeUnit(DEFAULT_DATE_RANGE.start, DEFAULT_DATE_RANGE.end);
     this.state = {
       loading: false,
       detectors: [],
@@ -111,7 +113,8 @@ class Findings extends Component<FindingsProps, FindingsState> {
       groupBy: 'logType',
       filteredFindings: [],
       plugins: [],
-      timeUnit: getChartTimeUnit(DEFAULT_DATE_RANGE.start, DEFAULT_DATE_RANGE.end),
+      timeUnit: timeUnits.timeUnit,
+      dateFormat: timeUnits.dateFormat,
     };
   }
 
@@ -246,12 +249,12 @@ class Findings extends Component<FindingsProps, FindingsState> {
     if (recentlyUsedRanges.length > MAX_RECENTLY_USED_TIME_RANGES)
       recentlyUsedRanges = recentlyUsedRanges.slice(0, MAX_RECENTLY_USED_TIME_RANGES);
     const endTime = start === end ? DEFAULT_DATE_RANGE.end : end;
-    const timeUnit = getChartTimeUnit(start, endTime);
+    const timeUnits = getChartTimeUnit(start, endTime);
     this.setState({
       startTime: start,
       endTime: endTime,
       recentlyUsedRanges: recentlyUsedRanges,
-      timeUnit,
+      ...timeUnits,
     });
   };
 
@@ -270,10 +273,14 @@ class Findings extends Component<FindingsProps, FindingsState> {
       });
     });
 
+    const chartTimeUnits = getChartTimeUnit(this.state.startTime, this.state.endTime);
     return getFindingsVisualizationSpec(visData, this.state.groupBy, {
       timeUnit: this.state.timeUnit,
-      dateFormat: getDateFormatByTimeUnit(this.state.startTime, this.state.endTime),
-      domain: getDomainRange([this.state.startTime, this.state.endTime]),
+      dateFormat: chartTimeUnits.dateFormat,
+      domain: getDomainRange(
+        [this.state.startTime, this.state.endTime],
+        chartTimeUnits.timeUnit.unit
+      ),
     });
   }
 

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -52,6 +52,7 @@ import {
 import { DetectorHit, RuleSource } from '../../../../../server/models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { DateTimeFilter } from '../../../Overview/models/interfaces';
+import { ChartContainer } from '../../../../components/Charts/ChartContainer';
 
 interface FindingsProps extends RouteComponentProps {
   detectorService: DetectorsService;
@@ -109,7 +110,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
     } = props;
     const timeUnits = getChartTimeUnit(dateTimeFilter.startTime, dateTimeFilter.endTime);
     this.state = {
-      loading: false,
+      loading: true,
       detectors: [],
       findings: [],
       notificationChannels: [],
@@ -365,7 +366,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
                 {this.createGroupByControl()}
               </EuiFlexItem>
               <EuiFlexItem>
-                <div id="findings-view" style={{ width: '100%' }}></div>
+                <ChartContainer chartViewId={'findings-view'} loading={loading} />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -290,7 +290,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
     } = this.props;
     const chartTimeUnits = getChartTimeUnit(dateTimeFilter.startTime, dateTimeFilter.endTime);
     return getFindingsVisualizationSpec(visData, this.state.groupBy, {
-      timeUnit: this.state.timeUnit,
+      timeUnit: chartTimeUnits.timeUnit,
       dateFormat: chartTimeUnits.dateFormat,
       domain: getDomainRange(
         [dateTimeFilter.startTime, dateTimeFilter.endTime],

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -22,7 +22,7 @@ import {
 import { CoreStart } from 'opensearch-dashboards/public';
 import { ServicesConsumer } from '../../services';
 import { BrowserServices } from '../../models/interfaces';
-import { ROUTES } from '../../utils/constants';
+import { DEFAULT_DATE_RANGE, ROUTES } from '../../utils/constants';
 import { CoreServicesConsumer } from '../../components/core_services';
 import Findings from '../Findings';
 import Detectors from '../Detectors';
@@ -39,6 +39,7 @@ import { CreateRule } from '../Rules/containers/CreateRule/CreateRule';
 import { EditRule } from '../Rules/containers/EditRule/EditRule';
 import { ImportRule } from '../Rules/containers/ImportRule/ImportRule';
 import { DuplicateRule } from '../Rules/containers/DuplicateRule/DuplicateRule';
+import { DateTimeFilter } from '../Overview/models/interfaces';
 
 enum Navigation {
   SecurityAnalytics = 'Security Analytics',
@@ -67,6 +68,7 @@ interface MainProps extends RouteComponentProps {
 interface MainState {
   getStartedDismissedOnce: boolean;
   selectedNavItemIndex: number;
+  dateTimeFilter: DateTimeFilter;
 }
 
 const navItemIndexByRoute: { [route: string]: number } = {
@@ -83,6 +85,10 @@ export default class Main extends Component<MainProps, MainState> {
     this.state = {
       getStartedDismissedOnce: false,
       selectedNavItemIndex: 1,
+      dateTimeFilter: {
+        startTime: DEFAULT_DATE_RANGE.start,
+        endTime: DEFAULT_DATE_RANGE.end,
+      },
     };
   }
 
@@ -101,6 +107,12 @@ export default class Main extends Component<MainProps, MainState> {
 
     this.updateSelectedNavItem();
   }
+
+  setDateTimeFilter = (dateTimeFilter: DateTimeFilter) => {
+    this.setState({
+      dateTimeFilter: dateTimeFilter,
+    });
+  };
 
   /**
    * Returns current component route index
@@ -215,6 +227,7 @@ export default class Main extends Component<MainProps, MainState> {
         ],
       },
     ];
+
     return (
       <CoreServicesConsumer>
         {(core: CoreStart | null) =>
@@ -260,6 +273,8 @@ export default class Main extends Component<MainProps, MainState> {
                           render={(props: RouteComponentProps) => (
                             <Findings
                               {...props}
+                              setDateTimeFilter={this.setDateTimeFilter}
+                              dateTimeFilter={this.state.dateTimeFilter}
                               findingsService={services.findingsService}
                               opensearchService={services.opensearchService}
                               detectorService={services.detectorsService}
@@ -355,6 +370,8 @@ export default class Main extends Component<MainProps, MainState> {
                           render={(props: RouteComponentProps) => (
                             <Overview
                               {...props}
+                              setDateTimeFilter={this.setDateTimeFilter}
+                              dateTimeFilter={this.state.dateTimeFilter}
                               getStartedDismissedOnce={this.state.getStartedDismissedOnce}
                               onGetStartedDismissed={this.setGetStartedDismissedOnce}
                               notifications={core?.notifications}
@@ -366,6 +383,8 @@ export default class Main extends Component<MainProps, MainState> {
                           render={(props: RouteComponentProps) => (
                             <Alerts
                               {...props}
+                              setDateTimeFilter={this.setDateTimeFilter}
+                              dateTimeFilter={this.state.dateTimeFilter}
                               alertService={services.alertService}
                               detectorService={services.detectorsService}
                               findingService={services.findingsService}

--- a/public/pages/Overview/components/Widgets/Summary.tsx
+++ b/public/pages/Overview/components/Widgets/Summary.tsx
@@ -8,9 +8,11 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { WidgetContainer } from './WidgetContainer';
 import { summaryGroupByOptions } from '../../utils/constants';
 import {
-  getDateFormatByTimeUnit,
+  getChartTimeUnit,
+  getDomainRange,
   getOverviewVisualizationSpec,
   getTimeWithMinPrecision,
+  TimeUnit,
 } from '../../utils/helpers';
 import { AlertItem, FindingItem } from '../../models/interfaces';
 import { createSelectComponent, renderVisualization } from '../../../../utils/helpers';
@@ -21,6 +23,9 @@ export interface SummaryProps {
   findings: FindingItem[];
   alerts: AlertItem[];
   loading?: boolean;
+  startTime: string;
+  endTime: string;
+  timeUnit: TimeUnit;
 }
 
 export interface SummaryData {
@@ -62,9 +67,12 @@ export const Summary: React.FC<SummaryProps> = ({
   );
 
   const generateVisualizationSpec = useCallback((summaryData, groupBy) => {
+    const chartTimeUnits = getChartTimeUnit(startTime, endTime);
+
     return getOverviewVisualizationSpec(summaryData, groupBy, {
       timeUnit: timeUnit,
-      dateFormat: getDateFormatByTimeUnit(startTime, endTime),
+      dateFormat: chartTimeUnits.dateFormat,
+      domain: getDomainRange([startTime, endTime], chartTimeUnits.timeUnit.unit),
     });
   }, []);
 

--- a/public/pages/Overview/components/Widgets/Summary.tsx
+++ b/public/pages/Overview/components/Widgets/Summary.tsx
@@ -66,15 +66,18 @@ export const Summary: React.FC<SummaryProps> = ({
     [onGroupByChange]
   );
 
-  const generateVisualizationSpec = useCallback((summaryData, groupBy) => {
-    const chartTimeUnits = getChartTimeUnit(startTime, endTime);
+  const generateVisualizationSpec = useCallback(
+    (summaryData, groupBy) => {
+      const chartTimeUnits = getChartTimeUnit(startTime, endTime);
 
-    return getOverviewVisualizationSpec(summaryData, groupBy, {
-      timeUnit: timeUnit,
-      dateFormat: chartTimeUnits.dateFormat,
-      domain: getDomainRange([startTime, endTime], chartTimeUnits.timeUnit.unit),
-    });
-  }, []);
+      return getOverviewVisualizationSpec(summaryData, groupBy, {
+        timeUnit: timeUnit,
+        dateFormat: chartTimeUnits.dateFormat,
+        domain: getDomainRange([startTime, endTime], chartTimeUnits.timeUnit.unit),
+      });
+    },
+    [startTime, endTime]
+  );
 
   useEffect(() => {
     const summaryData: SummaryData[] = [];

--- a/public/pages/Overview/components/Widgets/Summary.tsx
+++ b/public/pages/Overview/components/Widgets/Summary.tsx
@@ -69,9 +69,8 @@ export const Summary: React.FC<SummaryProps> = ({
   const generateVisualizationSpec = useCallback(
     (summaryData, groupBy) => {
       const chartTimeUnits = getChartTimeUnit(startTime, endTime);
-
       return getOverviewVisualizationSpec(summaryData, groupBy, {
-        timeUnit: timeUnit,
+        timeUnit: chartTimeUnits.timeUnit,
         dateFormat: chartTimeUnits.dateFormat,
         domain: getDomainRange([startTime, endTime], chartTimeUnits.timeUnit.unit),
       });

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -31,6 +31,13 @@ import { GettingStartedPopup } from '../../components/GettingStarted/GettingStar
 import { getChartTimeUnit, TimeUnit } from '../../utils/helpers';
 
 export const Overview: React.FC<OverviewProps> = (props) => {
+  const {
+    dateTimeFilter = {
+      startTime: DEFAULT_DATE_RANGE.start,
+      endTime: DEFAULT_DATE_RANGE.end,
+    },
+  } = props;
+
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [initialLoadingFinished, setInitialLoadingFinished] = useState(false);
   const [state, setState] = useState<OverviewState>({
@@ -41,12 +48,11 @@ export const Overview: React.FC<OverviewProps> = (props) => {
       alerts: [],
     },
   });
-  const [startTime, setStartTime] = useState(DEFAULT_DATE_RANGE.start);
-  const [endTime, setEndTime] = useState(DEFAULT_DATE_RANGE.end);
+
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState([DEFAULT_DATE_RANGE]);
   const [loading, setLoading] = useState(true);
 
-  const timeUnits = getChartTimeUnit(DEFAULT_DATE_RANGE.start, DEFAULT_DATE_RANGE.end);
+  const timeUnits = getChartTimeUnit(dateTimeFilter.startTime, dateTimeFilter.endTime);
   const [timeUnit, setTimeUnit] = useState<TimeUnit>(timeUnits.timeUnit);
 
   const context = useContext(CoreServicesContext);
@@ -70,12 +76,12 @@ export const Overview: React.FC<OverviewProps> = (props) => {
     overviewViewModelActor.registerRefreshHandler(updateState);
 
     const updateModel = async () => {
-      await overviewViewModelActor.onRefresh(startTime, endTime);
+      await overviewViewModelActor.onRefresh(dateTimeFilter.startTime, dateTimeFilter.endTime);
       setInitialLoadingFinished(true);
     };
 
     updateModel();
-  }, []);
+  }, [dateTimeFilter.startTime, dateTimeFilter.endTime]);
 
   useEffect(() => {
     if (
@@ -97,19 +103,23 @@ export const Overview: React.FC<OverviewProps> = (props) => {
 
     const endTime = start === end ? DEFAULT_DATE_RANGE.end : end;
     const timeUnits = getChartTimeUnit(start, endTime);
-    setStartTime(start);
-    setEndTime(endTime);
+
+    props.setDateTimeFilter &&
+      props.setDateTimeFilter({
+        startTime: start,
+        endTime: endTime,
+      });
     setTimeUnit(timeUnits.timeUnit);
     setRecentlyUsedRanges(usedRanges);
   };
 
   useEffect(() => {
-    overviewViewModelActor.onRefresh(startTime, endTime);
-  }, [startTime, endTime]);
+    overviewViewModelActor.onRefresh(dateTimeFilter.startTime, dateTimeFilter.endTime);
+  }, [dateTimeFilter.startTime, dateTimeFilter.endTime]);
 
   const onRefresh = async () => {
     setLoading(true);
-    await overviewViewModelActor.onRefresh(startTime, endTime);
+    await overviewViewModelActor.onRefresh(dateTimeFilter.startTime, dateTimeFilter.endTime);
   };
 
   const onButtonClick = () => setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
@@ -146,8 +156,8 @@ export const Overview: React.FC<OverviewProps> = (props) => {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSuperDatePicker
-              start={startTime}
-              end={endTime}
+              start={dateTimeFilter.startTime}
+              end={dateTimeFilter.endTime}
               recentlyUsedRanges={recentlyUsedRanges}
               isLoading={loading}
               onTimeChange={onTimeChange}
@@ -161,8 +171,8 @@ export const Overview: React.FC<OverviewProps> = (props) => {
         <Summary
           alerts={state.overviewViewModel.alerts}
           findings={state.overviewViewModel.findings}
-          startTime={startTime}
-          endTime={endTime}
+          startTime={dateTimeFilter.startTime}
+          endTime={dateTimeFilter.endTime}
           timeUnit={timeUnit}
           loading={loading}
         />

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -28,7 +28,7 @@ import { ServicesContext } from '../../../../services';
 import { Summary } from '../../components/Widgets/Summary';
 import { TopRulesWidget } from '../../components/Widgets/TopRulesWidget';
 import { GettingStartedPopup } from '../../components/GettingStarted/GettingStartedPopup';
-import { getChartTimeUnit } from '../../utils/helpers';
+import { getChartTimeUnit, TimeUnit } from '../../utils/helpers';
 
 export const Overview: React.FC<OverviewProps> = (props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -45,7 +45,9 @@ export const Overview: React.FC<OverviewProps> = (props) => {
   const [endTime, setEndTime] = useState(DEFAULT_DATE_RANGE.end);
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState([DEFAULT_DATE_RANGE]);
   const [loading, setLoading] = useState(true);
-  const [timeUnit, setTimeUnit] = useState('yearmonthdatehoursminutes');
+
+  const timeUnits = getChartTimeUnit(DEFAULT_DATE_RANGE.start, DEFAULT_DATE_RANGE.end);
+  const [timeUnit, setTimeUnit] = useState<TimeUnit>(timeUnits.timeUnit);
 
   const context = useContext(CoreServicesContext);
   const services = useContext(ServicesContext);
@@ -94,10 +96,10 @@ export const Overview: React.FC<OverviewProps> = (props) => {
       usedRanges = usedRanges.slice(0, MAX_RECENTLY_USED_TIME_RANGES);
 
     const endTime = start === end ? DEFAULT_DATE_RANGE.end : end;
-    const timeUnit = getChartTimeUnit(start, endTime);
+    const timeUnits = getChartTimeUnit(start, endTime);
     setStartTime(start);
     setEndTime(endTime);
-    setTimeUnit(timeUnit);
+    setTimeUnit(timeUnits.timeUnit);
     setRecentlyUsedRanges(usedRanges);
   };
 

--- a/public/pages/Overview/models/OverviewViewModel.ts
+++ b/public/pages/Overview/models/OverviewViewModel.ts
@@ -7,7 +7,7 @@ import { BrowserServices } from '../../../models/interfaces';
 import { DetectorHit, RuleSource } from '../../../../server/models/interfaces';
 import { AlertItem, FindingItem } from './interfaces';
 import { RuleService } from '../../../services';
-import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { DEFAULT_DATE_RANGE, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast } from '../../../utils/helpers';
 import dateMath from '@elastic/datemath';
@@ -191,8 +191,8 @@ export class OverviewViewModelActor {
     this.refreshHandlers.push(handler);
   }
 
-  startTime = 'now-15m';
-  endTime = 'now';
+  startTime = DEFAULT_DATE_RANGE.start;
+  endTime = DEFAULT_DATE_RANGE.end;
 
   public async onRefresh(startTime: string, endTime: string) {
     this.startTime = startTime;

--- a/public/pages/Overview/models/interfaces.ts
+++ b/public/pages/Overview/models/interfaces.ts
@@ -7,10 +7,17 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { RouteComponentProps } from 'react-router-dom';
 import { OverviewViewModel } from './OverviewViewModel';
 
+export interface DateTimeFilter {
+  startTime: string;
+  endTime: string;
+}
+
 export interface OverviewProps extends RouteComponentProps {
   getStartedDismissedOnce: boolean;
   onGetStartedDismissed: () => void;
   notifications?: NotificationsStart;
+  setDateTimeFilter?: Function;
+  dateTimeFilter?: DateTimeFilter;
 }
 
 export interface OverviewState {

--- a/public/pages/Overview/utils/constants.ts
+++ b/public/pages/Overview/utils/constants.ts
@@ -9,18 +9,3 @@ export const summaryGroupByOptions = [
 ];
 
 export const moreLink = 'https://opensearch.org/docs/latest/security-analytics/';
-
-/**
- * Time axis' timeUnit map
- * for each time search unit there is a mapped chart timeUnit
- */
-export const TimeUnitsMap: {
-  [key: string]: string;
-} = {
-  minutes: 'yearmonthdatehoursminutes',
-  hours: 'yearmonthdatehoursminutes',
-  days: 'yearmonthdatehours',
-  weeks: 'yearmonthdatehours',
-  months: 'yearmonthdatehours',
-  years: 'yearmonthdate',
-};

--- a/public/pages/Overview/utils/helper.test.ts
+++ b/public/pages/Overview/utils/helper.test.ts
@@ -1,35 +1,7 @@
-import { getChartTimeUnit, getDateFormatByTimeUnit } from './helpers';
+import { getChartTimeUnit } from './helpers';
 import { TimeUnitsMap } from './constants';
-import moment from 'moment';
 
 describe('helper utilities spec', () => {
-  describe('tests getDateFormatByTimeUnit function', () => {
-    const yearFormat = '%Y-%m-%d';
-    const dayFormat = '%H:%M:%S';
-    const fullFormat = '%Y-%m-%d %H:%M';
-    const hoursAgo = moment().subtract(15, 'hours');
-
-    const timeFormats: {
-      [key: string]: string;
-    } = {
-      'now-15m': dayFormat,
-      'now-15h': hoursAgo.date() === moment().date() ? dayFormat : fullFormat,
-      'now-15d': fullFormat,
-      'now-2M': yearFormat,
-      'now-2y': fullFormat,
-    };
-
-    it(` - function should return default format ${fullFormat} if dates are not valid`, () => {
-      expect(getDateFormatByTimeUnit('', '')).toBe(fullFormat);
-    });
-
-    for (const [start, format] of Object.entries(timeFormats)) {
-      it(` - function should return ${format} if start date is ${start}`, () => {
-        expect(getDateFormatByTimeUnit(start, 'now')).toBe(format);
-      });
-    }
-  });
-
   describe('tests getChartTimeUnit function', () => {
     const defaultTimeUnit = 'yearmonthdatehoursminutes';
     it(' - function should return default timeUnit if fn params are invalid', () => {

--- a/public/pages/Overview/utils/helper.test.ts
+++ b/public/pages/Overview/utils/helper.test.ts
@@ -1,4 +1,4 @@
-import { getChartTimeUnit, TimeUnit, TimeUnits } from './helpers';
+import { getChartTimeUnit, TimeUnits } from './helpers';
 
 describe('helper utilities spec', () => {
   describe('tests getChartTimeUnit function', () => {

--- a/public/pages/Overview/utils/helper.test.ts
+++ b/public/pages/Overview/utils/helper.test.ts
@@ -1,17 +1,52 @@
-import { getChartTimeUnit } from './helpers';
-import { TimeUnitsMap } from './constants';
+import { getChartTimeUnit, TimeUnit, TimeUnits } from './helpers';
 
 describe('helper utilities spec', () => {
   describe('tests getChartTimeUnit function', () => {
-    const defaultTimeUnit = 'yearmonthdatehoursminutes';
+    const defaultTimeUnit = {
+      timeUnit: { unit: 'yearmonthdatehoursminutes', step: 1 },
+      dateFormat: '%Y-%m-%d %H:%M',
+    };
     it(' - function should return default timeUnit if fn params are invalid', () => {
-      expect(getChartTimeUnit('', '')).toBe(defaultTimeUnit);
+      const timeUnits = getChartTimeUnit('', '');
+      expect(timeUnits.dateFormat).toBe(defaultTimeUnit.dateFormat);
+      expect(timeUnits.timeUnit.unit).toBe(defaultTimeUnit.timeUnit.unit);
+      expect(timeUnits.timeUnit.step).toBe(defaultTimeUnit.timeUnit.step);
     });
 
     it(' - function should return default timeUnit if one is passed as param', () => {
-      const defaultFormat = 'yearmonthdate';
-      expect(getChartTimeUnit('', '', defaultFormat)).toBe(defaultFormat);
+      const defaultFormat = 'yearmonthdatehoursminutes';
+      const timeUnits = getChartTimeUnit('', '', defaultFormat);
+      expect(timeUnits.timeUnit.unit).toBe(defaultFormat);
     });
+
+    const timeUnitsExpected: {
+      [key: string]: TimeUnits;
+    } = {
+      minutes: {
+        dateFormat: '%Y-%m-%d %H:%M',
+        timeUnit: { step: 1, unit: 'yearmonthdatehoursminutes' },
+      },
+      hours: {
+        dateFormat: '%Y-%m-%d %H:%M',
+        timeUnit: { step: 1, unit: 'yearmonthdatehours' },
+      },
+      days: {
+        dateFormat: '%Y-%m-%d',
+        timeUnit: { step: 1, unit: 'yearmonthdate' },
+      },
+      weeks: {
+        dateFormat: '%Y-%m-%d',
+        timeUnit: { step: 1, unit: 'yearmonthdate' },
+      },
+      months: {
+        dateFormat: '%Y-%m-%d',
+        timeUnit: { step: 1, unit: 'yearmonthdate' },
+      },
+      years: {
+        dateFormat: '%Y',
+        timeUnit: { step: 1, unit: 'year' },
+      },
+    };
 
     const timeUnits: {
       [key: string]: string;
@@ -24,9 +59,16 @@ describe('helper utilities spec', () => {
       years: 'now-15y',
     };
 
+    const validateTimeUnit = (timeUnit: TimeUnits, expectedTimeUnit: TimeUnits) => {
+      expect(timeUnit.dateFormat).toBe(expectedTimeUnit.dateFormat);
+      expect(timeUnit.timeUnit.unit).toBe(expectedTimeUnit.timeUnit.unit);
+      expect(timeUnit.timeUnit.step).toBe(expectedTimeUnit.timeUnit.step);
+    };
+
     for (const [unit, start] of Object.entries(timeUnits)) {
-      it(` - function should return ${TimeUnitsMap[unit]} if unit is ${unit}`, () => {
-        expect(getChartTimeUnit(start, 'now')).toBe(TimeUnitsMap[unit]);
+      it(` - filter ${start} should return valid timeUnit object`, () => {
+        const timeUnitResult = getChartTimeUnit(start, 'now');
+        validateTimeUnit(timeUnitResult, timeUnitsExpected[unit]);
       });
     }
   });

--- a/public/pages/Overview/utils/helpers.ts
+++ b/public/pages/Overview/utils/helpers.ts
@@ -170,6 +170,7 @@ export function getOverviewVisualizationSpec(
       {
         mark: {
           type: 'line',
+          clip: true,
           interpolate: 'monotone',
           color: lineColor,
           point: {
@@ -257,7 +258,6 @@ export function getAlertsVisualizationSpec(
         y: getYAxis('alert', 'Count'),
         color: {
           field: groupBy,
-          type: 'nominal',
           title: groupBy === 'status' ? 'Alert status' : 'Alert severity',
           scale: {
             range: groupBy === 'status' ? euiPaletteForStatus(5) : euiPaletteColorBlind(),

--- a/public/pages/Overview/utils/helpers.ts
+++ b/public/pages/Overview/utils/helpers.ts
@@ -163,6 +163,7 @@ export function getOverviewVisualizationSpec(
               grid: false,
               format: dateOpts.dateFormat,
             },
+            band: 0.5,
             scale: {
               domain: dateOpts.domain,
             },

--- a/public/pages/Overview/utils/helpers.ts
+++ b/public/pages/Overview/utils/helpers.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import moment from 'moment';
 import { euiPaletteColorBlind, euiPaletteForStatus } from '@elastic/eui';
 import { TopLevelSpec } from 'vega-lite';
 import { SummaryData } from '../components/Widgets/Summary';
@@ -360,34 +359,24 @@ export function getChartTimeUnit(
     if (totalSeconds <= minute) {
       timeUnit = 'yearmonthdatehoursminutesseconds';
       dateFormat = '%Y-%m-%d %H:%M:%S';
+    } else if (totalSeconds <= hour) {
+      timeUnit = 'yearmonthdatehoursminutes';
+      dateFormat = '%Y-%m-%d %H:%M';
+    } else if (totalSeconds <= day) {
+      timeUnit = 'yearmonthdatehours';
+      dateFormat = '%Y-%m-%d %H:%M';
+    } else if (totalSeconds <= month * 6) {
+      timeUnit = 'yearmonthdate';
+      dateFormat = '%Y-%m-%d';
+    } else if (totalSeconds <= year * 2) {
+      timeUnit = 'yearmonth';
+      dateFormat = '%Y-%m';
+    } else if (totalSeconds <= year * 6) {
+      timeUnit = 'yearquarter';
+      dateFormat = '%Y';
     } else {
-      if (totalSeconds <= hour) {
-        timeUnit = 'yearmonthdatehoursminutes';
-        dateFormat = '%Y-%m-%d %H:%M';
-      } else {
-        if (totalSeconds <= day) {
-          timeUnit = 'yearmonthdatehours';
-          dateFormat = '%Y-%m-%d %H:%M';
-        } else {
-          if (totalSeconds <= month * 6) {
-            timeUnit = 'yearmonthdate';
-            dateFormat = '%Y-%m-%d';
-          } else {
-            if (totalSeconds <= year * 2) {
-              timeUnit = 'yearmonth';
-              dateFormat = '%Y-%m';
-            } else {
-              if (totalSeconds <= year * 6) {
-                timeUnit = 'yearquarter';
-                dateFormat = '%Y';
-              } else {
-                timeUnit = 'year';
-                dateFormat = '%Y';
-              }
-            }
-          }
-        }
-      }
+      timeUnit = 'year';
+      dateFormat = '%Y';
     }
   } catch (e) {
     console.error(`Time diff can't be calculated for dates: ${start} and ${end}`);

--- a/public/pages/Overview/utils/helpers.ts
+++ b/public/pages/Overview/utils/helpers.ts
@@ -348,78 +348,46 @@ export function getChartTimeUnit(
 
   try {
     const timeDiff = endMoment.diff(startMoment);
-    const momentTimeDiff = moment.duration(timeDiff);
+    const totalSeconds = Math.ceil(timeDiff / 1000);
 
-    const { years, months, days, hours, minutes, seconds } = _.get(momentTimeDiff, '_data');
-    if (!years) {
-      if (!months) {
-        if (!days) {
-          if (!hours) {
-            if (!minutes) {
-              if (seconds <= 60) {
-                timeUnit = 'yearmonthdatehoursminutesseconds';
-                dateFormat = '%Y-%m-%d %H:%M:%S';
-              } else {
-                timeUnit = 'yearmonthdatehoursminutes';
-                dateFormat = '%Y-%m-%d %H:%M';
-              }
-            } else {
-              if (minutes <= 60) {
-                timeUnit = 'yearmonthdatehoursminutes';
-                dateFormat = '%Y-%m-%d %H:%M';
+    const second = 1;
+    const minute = second * 60;
+    const hour = minute * 60;
+    const day = hour * 24;
+    const month = day * 30;
+    const year = month * 12;
 
-                if (minutes === 1) {
-                  timeUnit = 'yearmonthdatehoursminutesseconds';
-                  dateFormat = '%Y-%m-%d %H:%M%S';
-                }
-              } else {
-                timeUnit = 'yearmonthdatehours';
-                dateFormat = '%Y-%m-%d %H:%M';
-              }
-            }
-          } else {
-            if (hours <= 60) {
-              timeUnit = 'yearmonthdatehours';
-              dateFormat = '%Y-%m-%d %H:%M';
-
-              if (hours === 1) {
-                timeUnit = 'yearmonthdatehoursminutes';
-                dateFormat = '%Y-%m-%d %H:%M';
-              }
-            }
-          }
-        } else {
-          if (days === 1) {
-            timeUnit = 'yearmonthdatehours';
-            dateFormat = '%Y-%m-%d %H:%M';
-          } else if (days <= 14) {
-            timeUnit = 'yearmonthdate';
-            dateFormat = '%Y-%m-%d';
-          } else {
-            timeUnit = 'yearmonthdate';
-            dateFormat = '%Y-%m-%d';
-          }
-        }
-      } else {
-        if (months <= 6) {
-          timeUnit = 'yearmonthdate';
-          dateFormat = '%Y-%m-%d';
-        } else {
-          timeUnit = 'yearmonth';
-          dateFormat = '%Y-%m';
-        }
-      }
-    } else if (years <= 6) {
-      timeUnit = 'yearmonth';
-      dateFormat = '%Y-%m';
-
-      if (years >= 2) {
-        timeUnit = 'quarter';
-        dateFormat = '%Y';
-      }
+    if (totalSeconds <= minute) {
+      timeUnit = 'yearmonthdatehoursminutesseconds';
+      dateFormat = '%Y-%m-%d %H:%M:%S';
     } else {
-      timeUnit = 'year';
-      dateFormat = '%Y';
+      if (totalSeconds <= hour) {
+        timeUnit = 'yearmonthdatehoursminutes';
+        dateFormat = '%Y-%m-%d %H:%M';
+      } else {
+        if (totalSeconds <= day) {
+          timeUnit = 'yearmonthdatehours';
+          dateFormat = '%Y-%m-%d %H:%M';
+        } else {
+          if (totalSeconds <= month * 6) {
+            timeUnit = 'yearmonthdate';
+            dateFormat = '%Y-%m-%d';
+          } else {
+            if (totalSeconds <= year * 2) {
+              timeUnit = 'yearmonth';
+              dateFormat = '%Y-%m';
+            } else {
+              if (totalSeconds <= year * 6) {
+                timeUnit = 'yearquarter';
+                dateFormat = '%Y';
+              } else {
+                timeUnit = 'year';
+                dateFormat = '%Y';
+              }
+            }
+          }
+        }
+      }
     }
   } catch (e) {
     console.error(`Time diff can't be calculated for dates: ${start} and ${end}`);

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -9,7 +9,7 @@ import { DETECTOR_TYPES } from '../pages/Detectors/utils/constants';
 
 export const DATE_MATH_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 export const MAX_RECENTLY_USED_TIME_RANGES = 5;
-export const DEFAULT_DATE_RANGE = { start: 'now-15m', end: 'now' };
+export const DEFAULT_DATE_RANGE = { start: 'now-24h', end: 'now' };
 
 export const PLUGIN_NAME = 'opensearch_security_analytics_dashboards';
 export const OS_NOTIFICATION_PLUGIN = 'opensearch-notifications';


### PR DESCRIPTION
### Description
Sets default time filter to last 24h and applies the same to all pages.
Sets all data from the chart into chart tooltips.
Sets time range exactly as in time filter.

### Issues Resolved
Closes #263 
Closes #258 
Closes #253

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).