### PR TITLE
[BUG] Alerts and Findings overview table should have even height #250

### DIFF
--- a/public/app.scss
+++ b/public/app.scss
@@ -46,3 +46,4 @@ $euiTextColor: $euiColorDarkestShade !default;
 }
 
 @import "./components/Charts/ChartContainer.scss";
+@import "./pages/Overview/components/Widgets/WidgetContainer.scss";

--- a/public/pages/Overview/components/Widgets/WidgetContainer.scss
+++ b/public/pages/Overview/components/Widgets/WidgetContainer.scss
@@ -1,0 +1,25 @@
+.grid-item {
+  > div {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    > :nth-child(1) {
+      flex: 0;
+    }
+
+    > :nth-child(3) {
+      flex: 1;
+
+      > div {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+
+        > :first-child {
+          flex: 1;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Sets widget tables to fit the widget and to be the same height across the widgets in the same layout row.

### Issues Resolved
Closes #250

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).