### PR TITLE
[BUG] Edit detector rules table paging goes to page the first page if…

### DIFF
--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRulesTable.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRulesTable.tsx
@@ -70,7 +70,7 @@ export const DetectionRulesTable: React.FC<DetectionRulesTableProps> = ({
       },
     ],
   };
-  const [pagination, setPagination] = useState({ pageIndex: 0 });
+  const [pagination, setPagination] = useState({ pageIndex: pageIndex || 0 });
   const allRulesEnabled = ruleItems.every((item) => item.active);
   ruleItems.sort((a, b) => {
     return (rulePriorityBySeverity[a.severity] || 6) - (rulePriorityBySeverity[b.severity] || 6);

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRulesTable.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRulesTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import { CriteriaWithPagination, EuiInMemoryTable } from '@elastic/eui';
-import React from 'react';
+import React, { useState } from 'react';
 import { RuleItem } from './types/interfaces';
 import { getRulesColumns } from './utils/constants';
 import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
@@ -70,11 +70,16 @@ export const DetectionRulesTable: React.FC<DetectionRulesTableProps> = ({
       },
     ],
   };
-
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const allRulesEnabled = ruleItems.every((item) => item.active);
   ruleItems.sort((a, b) => {
     return (rulePriorityBySeverity[a.severity] || 6) - (rulePriorityBySeverity[b.severity] || 6);
   });
+
+  const onTableChangeHandler = (pagination: CriteriaWithPagination<T>) => {
+    setPagination({ pageIndex: pagination.page.index });
+    onTableChange && onTableChange(pagination);
+  };
 
   return (
     <div style={{ padding: 10 }}>
@@ -88,14 +93,8 @@ export const DetectionRulesTable: React.FC<DetectionRulesTableProps> = ({
         items={ruleItems}
         itemId={(item: RuleItem) => `${item.name}`}
         search={search}
-        pagination={
-          pageIndex !== undefined
-            ? {
-                pageIndex,
-              }
-            : true
-        }
-        onTableChange={onTableChange}
+        pagination={pagination}
+        onTableChange={onTableChangeHandler}
         loading={loading}
         data-test-subj={'edit-detector-rules-table'}
       />


### PR DESCRIPTION
### Description
Fixes bad pagination on detectors edit rules page after toggling rules. Currently, if the user toggles rules on any page rather than the first, the pagination is reset to the first page.

### Issues Resolved
Closes #269

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).