### PR TITLE
[Backport 2.x] Cypress windows tests fix (#296)

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -95,7 +95,7 @@ Cypress.Commands.add('getTableFirstRow', (selector) => {
 });
 
 Cypress.Commands.add('triggerSearchField', (placeholder, text) => {
-  cy.get(`[placeholder="${placeholder}"]`).type(`{selectall}${text}`).trigger('search');
+  cy.get(`[placeholder="${placeholder}"]`).type(`{selectall}${text}`).realPress('Enter');
 });
 
 Cypress.Commands.add('waitForPageLoad', (url, { timeout = 10000, contains = null }) => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,6 +13,8 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+import 'cypress-real-events';
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "jest-cli": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1",
     "lint-staged": "^9.2.0",
-    "ts-loader": "^6.2.1"
+    "ts-loader": "^6.2.1",
+    "cypress-real-events": "1.7.6"
   },
   "engines": {
     "yarn": "^1.21.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
   "compilerOptions": {
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "outDir": "./target"
+    "outDir": "./target",
+    "types": ["cypress", "node", "cypress-real-events"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
+cypress-real-events@1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.6.tgz#6f17e0b2ceea1d6dc60f6737d8f84cc517bbbb4c"
+  integrity sha512-yP6GnRrbm6HK5q4DH6Nnupz37nOfZu/xn1xFYqsE2o4G73giPWQOdu6375QYpwfU1cvHNCgyD2bQ2hPH9D7NMw==
+
 cypress@^6.0.0:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.9.1.tgz#ce1106bfdc47f8d76381dba63f943447883f864c"


### PR DESCRIPTION
* [FEATURE] Detector must have at least one alert set #288

Signed-off-by: Jovan Cvetkovic <jovanca.cvetkovic@gmail.com>

* [TASK] Investigate and fix cypress windows tests #295

Signed-off-by: Jovan Cvetkovic <jovanca.cvetkovic@gmail.com>

* [TASK] Investigate and fix cypress windows tests #295

Signed-off-by: Jovan Cvetkovic <jovanca.cvetkovic@gmail.com>

Signed-off-by: Jovan Cvetkovic <jovanca.cvetkovic@gmail.com>

### Description
Backporting #296 to 2.x

### Issues Resolved
NA

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).