### PR TITLE
Updated field mapping UX; disabled windows run for cypress

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -17,8 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         include:
-          - os: windows-latest
-            cypress_cache_folder: ~/AppData/Local/Cypress/Cache
           - os: ubuntu-latest
             cypress_cache_folder: ~/.cache/Cypress
     runs-on: ${{ matrix.os }}
@@ -33,10 +31,6 @@ jobs:
         with:
           # TODO: Parse this from security analytics plugin (https://github.com/opensearch-project/security-analytics/issues/170)
           java-version: 11
-
-      - name: Enable longer filenames
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: git config --system core.longpaths true
 
       - name: Checkout security analytics
         uses: actions/checkout@v2
@@ -93,14 +87,7 @@ jobs:
           yarn start --no-base-path --no-watch &
         shell: bash
 
-      # Window is slow so wait longer
-      - name: Sleep until OSD server starts - windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: Start-Sleep -s 400
-        shell: powershell
-
-      - name: Sleep until OSD server starts - non-windows
-        if: ${{ matrix.os != 'windows-latest' }}
+      - name: Sleep until OSD server starts
         run: sleep 300
         shell: bash
       

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run Cypress E2E tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         include:
           - os: windows-latest
             cypress_cache_folder: ~/AppData/Local/Cypress/Cache

--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -69,7 +69,7 @@ describe('Detectors', () => {
     cy.get('button').contains('Next').click({ force: true });
 
     // Check that correct page now showing
-    cy.contains('Required field mappings');
+    cy.contains('Configure field mapping');
 
     // Select appropriate names to map fields to
     for (let field_name in sample_field_mappings.properties) {

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -5,12 +5,20 @@
 
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { EuiSpacer, EuiTitle, EuiText } from '@elastic/eui';
+import {
+  EuiSpacer,
+  EuiTitle,
+  EuiText,
+  EuiCallOut,
+  EuiAccordion,
+  EuiHorizontalRule,
+  EuiPanel,
+} from '@elastic/eui';
 import FieldMappingsTable from '../components/RequiredFieldMapping';
 import { createDetectorSteps } from '../../../utils/constants';
 import { ContentPanel } from '../../../../../components/ContentPanel';
 import { Detector, FieldMapping } from '../../../../../../models/interfaces';
-import { EMPTY_FIELD_MAPPINGS } from '../utils/constants';
+import { EMPTY_FIELD_MAPPINGS_VIEW } from '../utils/constants';
 import { DetectorCreationStep } from '../../../models/types';
 import { GetFieldMappingViewResponse } from '../../../../../../server/models/interfaces';
 import FieldMappingService from '../../../../../services/FieldMappingService';
@@ -49,7 +57,7 @@ export default class ConfigureFieldMapping extends Component<
     });
     this.state = {
       loading: props.loading || false,
-      mappingsData: EMPTY_FIELD_MAPPINGS,
+      mappingsData: EMPTY_FIELD_MAPPINGS_VIEW,
       createdMappings,
       invalidMappingFieldNames: [],
     };
@@ -75,11 +83,6 @@ export default class ConfigureFieldMapping extends Component<
     }
     this.setState({ loading: false });
   };
-
-  validateMappings(mappings: ruleFieldToIndexFieldMap): boolean {
-    // TODO: Implement validation
-    return true; //allFieldsMapped; // && allAliasesUnique;
-  }
 
   /**
    * Returns the fieldName(s) that have duplicate alias assigned to them
@@ -110,8 +113,7 @@ export default class ConfigureFieldMapping extends Component<
       invalidMappingFieldNames: invalidMappingFieldNames,
     });
     this.updateMappingSharedState(newMappings);
-    const mappingsValid = this.validateMappings(newMappings);
-    this.props.updateDataValidState(DetectorCreationStep.CONFIGURE_FIELD_MAPPING, mappingsValid);
+    this.props.updateDataValidState(DetectorCreationStep.CONFIGURE_FIELD_MAPPING, true);
   };
 
   updateMappingSharedState = (createdMappings: ruleFieldToIndexFieldMap) => {
@@ -126,42 +128,52 @@ export default class ConfigureFieldMapping extends Component<
   };
 
   render() {
-    const { isEdit } = this.props;
     const { loading, mappingsData, createdMappings, invalidMappingFieldNames } = this.state;
     const existingMappings: ruleFieldToIndexFieldMap = {
       ...createdMappings,
     };
+
+    // read only data
+    const mappedRuleFields: string[] = [];
+    const mappedLogFields: string[] = [];
+    Object.keys(mappingsData.properties).forEach((ruleFieldName) => {
+      mappedRuleFields.unshift(ruleFieldName);
+      mappedLogFields.unshift(mappingsData.properties[ruleFieldName].path);
+    });
+
+    // edit data
     const ruleFields = [...(mappingsData.unmapped_field_aliases || [])];
     const indexFields = [...(mappingsData.unmapped_index_fields || [])];
 
-    Object.keys(mappingsData.properties).forEach((ruleFieldName) => {
-      existingMappings[ruleFieldName] = mappingsData.properties[ruleFieldName].path;
-      ruleFields.unshift(ruleFieldName);
-      indexFields.unshift(mappingsData.properties[ruleFieldName].path);
-    });
-
     return (
       <div>
-        {!isEdit && (
+        <EuiTitle size={'m'}>
+          <h3>{createDetectorSteps[DetectorCreationStep.CONFIGURE_FIELD_MAPPING].title}</h3>
+        </EuiTitle>
+
+        <EuiText size="s" color="subdued">
+          To perform threat detection, known field names from your log data source are automatically
+          mapped to rule field names. Additional fields that may require manual mapping will be
+          shown below.
+        </EuiText>
+
+        <EuiSpacer size={'m'} />
+
+        {ruleFields.length > 0 ? (
           <>
-            <EuiTitle size={'m'}>
-              <h3>{createDetectorSteps[DetectorCreationStep.CONFIGURE_FIELD_MAPPING].title}</h3>
-            </EuiTitle>
-
-            <EuiText size="s" color="subdued">
-              To perform threat detection, known field names from your log data source are
-              automatically mapped to rule field names. Additional fields that may require manual
-              mapping will be shown below.
-            </EuiText>
-
+            <EuiCallOut
+              title={`${ruleFields.length} rule fields may need manual mapping`}
+              color={'warning'}
+            >
+              <p>
+                To generate accurate findings, we recommend mapping the following security rules
+                fields with the log field from your data source.
+              </p>
+            </EuiCallOut>
             <EuiSpacer size={'m'} />
-          </>
-        )}
-
-        {ruleFields.length > 0 && (
-          <>
-            <ContentPanel title={`Required field mappings (${ruleFields.length})`} titleSize={'m'}>
+            <ContentPanel title={`Manual field mappings (${ruleFields.length})`} titleSize={'m'}>
               <FieldMappingsTable<MappingViewType.Edit>
+                {...this.props}
                 loading={loading}
                 ruleFields={ruleFields}
                 indexFields={indexFields}
@@ -171,12 +183,48 @@ export default class ConfigureFieldMapping extends Component<
                   invalidMappingFieldNames,
                   onMappingCreation: this.onMappingCreation,
                 }}
-                {...this.props}
               />
             </ContentPanel>
             <EuiSpacer size={'m'} />
           </>
+        ) : (
+          <>
+            <EuiCallOut title={'We have automatically mapped all fields'} color={'success'}>
+              <p>
+                Your data source(s) have been mapped with all security rule fields. No action is
+                needed.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer size={'m'} />
+          </>
         )}
+
+        <EuiPanel>
+          <EuiAccordion
+            buttonContent={
+              <div data-test-subj="mapped-fields-btn">
+                <EuiTitle>
+                  <h4>{`View mapped fields (${mappedRuleFields.length})`}</h4>
+                </EuiTitle>
+              </div>
+            }
+            buttonProps={{ style: { paddingLeft: '10px', paddingRight: '10px' } }}
+            id={'mappedFieldsAccordion'}
+            initialIsOpen={false}
+          >
+            <EuiHorizontalRule margin={'xs'} />
+            <FieldMappingsTable<MappingViewType.Readonly>
+              {...this.props}
+              loading={loading}
+              ruleFields={mappedRuleFields}
+              indexFields={mappedLogFields}
+              mappingProps={{
+                type: MappingViewType.Readonly,
+              }}
+            />
+          </EuiAccordion>
+        </EuiPanel>
+        <EuiSpacer size={'m'} />
       </div>
     );
   }

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -78,7 +78,16 @@ export default class ConfigureFieldMapping extends Component<
       Object.keys(mappingsView.response.properties).forEach((ruleFieldName) => {
         existingMappings[ruleFieldName] = mappingsView.response.properties[ruleFieldName].path;
       });
-      this.setState({ createdMappings: existingMappings, mappingsData: mappingsView.response });
+      this.setState({
+        createdMappings: existingMappings,
+        mappingsData: {
+          ...mappingsView.response,
+          unmapped_field_aliases: [
+            'timestamp',
+            ...(mappingsView.response.unmapped_field_aliases || []),
+          ],
+        },
+      });
       this.updateMappingSharedState(existingMappings);
     }
     this.setState({ loading: false });

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/utils/constants.ts
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/utils/constants.ts
@@ -3,15 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GetFieldMappingViewResponse } from '../../../../../../server/models/interfaces';
+import {
+  FieldMappingPropertyMap,
+  GetFieldMappingViewResponse,
+} from '../../../../../../server/models/interfaces';
 
 export const STATUS_ICON_PROPS = {
   unmapped: { type: 'alert', color: 'danger' },
   mapped: { type: 'checkInCircleFilled', color: 'success' },
 };
 
-export const EMPTY_FIELD_MAPPINGS: GetFieldMappingViewResponse = {
+export const EMPTY_FIELD_MAPPINGS_VIEW: GetFieldMappingViewResponse = {
   properties: {},
   unmapped_field_aliases: [],
   unmapped_index_fields: [],
+};
+
+export const EMPTY_FIELD_MAPPINGS: FieldMappingPropertyMap = {
+  properties: {},
 };

--- a/public/pages/Detectors/components/FieldMappingsView/FieldMappingsView.tsx
+++ b/public/pages/Detectors/components/FieldMappingsView/FieldMappingsView.tsx
@@ -52,10 +52,10 @@ export const FieldMappingsView: React.FC<FieldMappingsViewProps> = ({
     async (indexName: string) => {
       const getMappingRes = await services?.fieldMappingService.getMappings(indexName);
       if (getMappingRes?.ok) {
-        const mappings = getMappingRes.response[detector.detector_type.toLowerCase()];
-        if (mappings) {
+        const mappingsData = getMappingRes.response[indexName];
+        if (mappingsData) {
           let items: FieldMappingsTableItem[] = [];
-          Object.entries(mappings.mappings.properties).forEach((entry) => {
+          Object.entries(mappingsData.mappings.properties).forEach((entry) => {
             items.push({
               ruleFieldName: entry[0],
               logFieldName: entry[1].path,

--- a/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
+++ b/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
@@ -6,7 +6,6 @@
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
-import ConfigureFieldMapping from '../../../CreateDetector/components/ConfigureFieldMapping';
 import { Detector, FieldMapping } from '../../../../../models/interfaces';
 import FieldMappingService from '../../../../services/FieldMappingService';
 import { DetectorHit, SearchDetectorsResponse } from '../../../../../server/models/interfaces';
@@ -15,6 +14,7 @@ import { DetectorsService } from '../../../../services';
 import { ServerResponse } from '../../../../../server/models/types';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast, successNotificationToast } from '../../../../utils/helpers';
+import EditFieldMappings from '../../containers/FieldMappings/EditFieldMapping';
 
 export interface UpdateFieldMappingsProps
   extends RouteComponentProps<any, any, { detectorHit: DetectorHit }> {
@@ -159,14 +159,12 @@ export default class UpdateFieldMappings extends Component<
         <EuiSpacer size={'xxl'} />
 
         {!loading && (
-          <ConfigureFieldMapping
+          <EditFieldMappings
             {...this.props}
-            isEdit={true}
             detector={detector}
             fieldMappings={fieldMappings}
             filedMappingService={filedMappingService}
             replaceFieldMappings={this.replaceFieldMappings}
-            updateDataValidState={() => {}}
             loading={loading}
           />
         )}

--- a/public/pages/Detectors/containers/FieldMappings/EditFieldMapping.tsx
+++ b/public/pages/Detectors/containers/FieldMappings/EditFieldMapping.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { Component } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { EuiSpacer } from '@elastic/eui';
+import FieldMappingsTable from '../../../CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping';
+import { ContentPanel } from '../../../../components/ContentPanel';
+import { Detector, FieldMapping } from '../../../../../models/interfaces';
+import { EMPTY_FIELD_MAPPINGS } from '../../../CreateDetector/components/ConfigureFieldMapping/utils/constants';
+import { FieldMappingPropertyMap } from '../../../../../server/models/interfaces';
+import FieldMappingService from '../../../../services/FieldMappingService';
+import { MappingViewType } from '../../../CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldMappingsTable';
+
+export interface ruleFieldToIndexFieldMap {
+  [fieldName: string]: string;
+}
+
+interface EditFieldMappingsProps extends RouteComponentProps {
+  detector: Detector;
+  filedMappingService: FieldMappingService;
+  fieldMappings: FieldMapping[];
+  loading: boolean;
+  replaceFieldMappings: (mappings: FieldMapping[]) => void;
+}
+
+interface EditFieldMappingsState {
+  loading: boolean;
+  mappingsData: FieldMappingPropertyMap;
+  createdMappings: ruleFieldToIndexFieldMap;
+  invalidMappingFieldNames: string[];
+}
+
+export default class EditFieldMappings extends Component<
+  EditFieldMappingsProps,
+  EditFieldMappingsState
+> {
+  constructor(props: EditFieldMappingsProps) {
+    super(props);
+    const createdMappings: ruleFieldToIndexFieldMap = {};
+    props.fieldMappings.forEach((mapping) => {
+      createdMappings[mapping.ruleFieldName] = mapping.indexFieldName;
+    });
+    this.state = {
+      loading: props.loading || false,
+      mappingsData: EMPTY_FIELD_MAPPINGS,
+      createdMappings,
+      invalidMappingFieldNames: [],
+    };
+  }
+
+  componentDidMount = async () => {
+    this.getAllMappings();
+  };
+
+  getAllMappings = async () => {
+    this.setState({ loading: true });
+    const indexName = this.props.detector.inputs[0].detector_input.indices[0];
+    const mappingsView = await this.props.filedMappingService.getMappings(indexName);
+    if (mappingsView.ok) {
+      const existingMappings = { ...this.state.createdMappings };
+      const properties = mappingsView.response[indexName]?.mappings.properties;
+
+      if (properties) {
+        Object.keys(properties).forEach((ruleFieldName) => {
+          existingMappings[ruleFieldName] = properties[ruleFieldName].path;
+        });
+        this.setState({ createdMappings: existingMappings, mappingsData: { properties } });
+        this.updateMappingSharedState(existingMappings);
+      }
+    }
+    this.setState({ loading: false });
+  };
+
+  /**
+   * Returns the fieldName(s) that have duplicate alias assigned to them
+   */
+  getInvalidMappingFieldNames(mappings: ruleFieldToIndexFieldMap): string[] {
+    const seenAliases = new Set();
+    const invalidFields: string[] = [];
+
+    Object.entries(mappings).forEach((entry) => {
+      if (seenAliases.has(entry[1])) {
+        invalidFields.push(entry[0]);
+      }
+
+      seenAliases.add(entry[1]);
+    });
+
+    return invalidFields;
+  }
+
+  onMappingCreation = (ruleFieldName: string, indxFieldName: string): void => {
+    const newMappings: ruleFieldToIndexFieldMap = {
+      ...this.state.createdMappings,
+      [ruleFieldName]: indxFieldName,
+    };
+    const invalidMappingFieldNames = this.getInvalidMappingFieldNames(newMappings);
+    this.setState({
+      createdMappings: newMappings,
+      invalidMappingFieldNames: invalidMappingFieldNames,
+    });
+    this.updateMappingSharedState(newMappings);
+  };
+
+  updateMappingSharedState = (createdMappings: ruleFieldToIndexFieldMap) => {
+    this.props.replaceFieldMappings(
+      Object.entries(createdMappings).map((entry) => {
+        return {
+          ruleFieldName: entry[0],
+          indexFieldName: entry[1],
+        };
+      })
+    );
+  };
+
+  render() {
+    const { loading, mappingsData, createdMappings, invalidMappingFieldNames } = this.state;
+    const existingMappings: ruleFieldToIndexFieldMap = {
+      ...createdMappings,
+    };
+    const ruleFields: string[] = [];
+    const indexFields: string[] = [];
+
+    Object.keys(mappingsData.properties).forEach((ruleFieldName) => {
+      existingMappings[ruleFieldName] = mappingsData.properties[ruleFieldName].path;
+      ruleFields.unshift(ruleFieldName);
+      indexFields.unshift(mappingsData.properties[ruleFieldName].path);
+    });
+
+    return (
+      <div>
+        {ruleFields.length > 0 && (
+          <>
+            <ContentPanel title={`Required field mappings (${ruleFields.length})`} titleSize={'m'}>
+              <FieldMappingsTable<MappingViewType.Edit>
+                {...this.props}
+                loading={loading}
+                ruleFields={ruleFields}
+                indexFields={indexFields}
+                mappingProps={{
+                  type: MappingViewType.Edit,
+                  existingMappings,
+                  invalidMappingFieldNames,
+                  onMappingCreation: this.onMappingCreation,
+                }}
+              />
+            </ContentPanel>
+            <EuiSpacer size={'m'} />
+          </>
+        )}
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Splits field mapping table into Edit and Read-only fields tables when configuring field mappings during detector creation.
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/114732919/211585618-921a96ce-7f6b-431a-8f95-6d413d611d68.png">

This PR is also disabling windows test run for cypress tests as it is very flaky. Will investigate this in a follow up PR

### Issues Resolved
#144 
#293

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).