### PR TITLE
Suppressed unnecessary error toast for custom rules

### DIFF
--- a/public/pages/Overview/models/OverviewViewModel.ts
+++ b/public/pages/Overview/models/OverviewViewModel.ts
@@ -78,7 +78,7 @@ export class OverviewViewModelActor {
       }
       if (customResponse.ok) {
         customResponse.response.hits.hits.forEach((hit) => (ruleById[hit._id] = hit._source));
-      } else {
+      } else if (!customResponse.error?.includes('index doesnt exist')) {
         errorNotificationToast(
           this.notifications,
           'retrieve',


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
When the plugin is freshly installed there are no custom rules and we get an index not found error when trying to fetch custom rules. This error is not of any use to the user and should not be shown in the toast notification. Added a check for this specific error.

### Issues Resolved
NA

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).