### PR TITLE
Loading spinner added to Rules in Define detector step

### DIFF
--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
@@ -28,6 +28,7 @@ export interface CreateDetectorRulesState {
 
 export interface DetectionRulesProps {
   rulesState: CreateDetectorRulesState;
+  loading?: boolean;
   onRuleToggle: (changedItem: RuleItem, isActive: boolean) => void;
   onAllRulesToggle: (enabled: boolean) => void;
   onPageChange: (page: { index: number; size: number }) => void;
@@ -35,6 +36,7 @@ export interface DetectionRulesProps {
 
 export const DetectionRules: React.FC<DetectionRulesProps> = ({
   rulesState,
+  loading,
   onPageChange,
   onRuleToggle,
   onAllRulesToggle,
@@ -103,6 +105,7 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
         buttonProps={{ style: { paddingLeft: '10px', paddingRight: '10px' } }}
         id={'detectorRulesAccordion'}
         initialIsOpen={false}
+        isLoading={loading}
       >
         <EuiHorizontalRule margin={'xs'} />
         <DetectionRulesTable

--- a/public/pages/CreateDetector/components/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/containers/DefineDetector.tsx
@@ -28,6 +28,7 @@ interface DefineDetectorProps extends RouteComponentProps {
   indexService: IndexService;
   rulesState: CreateDetectorRulesState;
   notifications: NotificationsStart;
+  loadingRules?: boolean;
   changeDetector: (detector: Detector) => void;
   updateDataValidState: (step: DetectorCreationStep, isValid: boolean) => void;
   onPageChange: (page: { index: number; size: number }) => void;
@@ -203,6 +204,7 @@ export default class DefineDetector extends Component<DefineDetectorProps, Defin
 
         <DetectionRules
           rulesState={rulesState}
+          loading={this.props.loadingRules}
           onPageChange={onPageChange}
           onRuleToggle={onRuleToggle}
           onAllRulesToggle={onAllRulesToggle}

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -51,6 +51,7 @@ interface CreateDetectorState {
   creatingDetector: boolean;
   rulesState: CreateDetectorRulesState;
   plugins: string[];
+  loadingRules: boolean;
 }
 
 export default class CreateDetector extends Component<CreateDetectorProps, CreateDetectorState> {
@@ -73,6 +74,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
       creatingDetector: false,
       rulesState: { page: { index: 0 }, allRules: [] },
       plugins: [],
+      loadingRules: false,
     };
   }
 
@@ -182,7 +184,9 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
 
   async setupRulesState() {
     const { detector_type } = this.state.detector;
-
+    this.setState({
+      loadingRules: true,
+    });
     const allRules = await this.rulesViewModelActor.fetchRules(undefined, {
       bool: {
         must: [{ match: { 'rule.category': `${detector_type}` } }],
@@ -212,6 +216,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
           },
         ],
       },
+      loadingRules: false,
     });
   }
 
@@ -299,6 +304,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
             detector={this.state.detector}
             indexService={services.indexService}
             rulesState={this.state.rulesState}
+            loadingRules={this.state.loadingRules}
             onRuleToggle={this.onRuleToggle}
             onAllRulesToggle={this.onAllRulesToggle}
             onPageChange={this.onPageChange}


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
Loading spinner added to Rules in Define detector step. This helps indicate to the user that rules are being loaded.

### Issues Resolved
NA

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).