### PR TITLE
Fix reduced margin in Get started popup

### DIFF
--- a/public/pages/Overview/components/GettingStarted/GetStartedStep.tsx
+++ b/public/pages/Overview/components/GettingStarted/GetStartedStep.tsx
@@ -20,7 +20,7 @@ interface GetStartedStepProps {
 
 export const GetStartedStep: React.FC<GetStartedStepProps> = ({ buttons, title }) => {
   return (
-    <div style={{ marginTop: '-20px' }}>
+    <div>
       <EuiText>
         <p>{title}</p>
       </EuiText>


### PR DESCRIPTION
### Description
Currently there is a negative margin applied to the step content in the Get Started popup. That is not required since there is a global style applied to the step title that offsets the extra space added after the title. Removed the inline style to fix the padding.

### Issues Resolved
#463

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).