### PR TITLE
Provide empty states for Findings and Alerts page

### DIFF
--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -707,10 +707,10 @@ exports[`<Alerts /> spec renders the component 1`] = `
               </div>
             </EuiFlexGroup>
             <EuiSpacer
-              size="xxl"
+              size="m"
             >
               <div
-                className="euiSpacer euiSpacer--xxl"
+                className="euiSpacer euiSpacer--m"
               />
             </EuiSpacer>
           </div>
@@ -873,42 +873,76 @@ exports[`<Alerts /> spec renders the component 1`] = `
                       <div
                         className="euiFlexItem"
                       >
-                        <ChartContainer
-                          chartViewId="alerts-view"
-                          loading={true}
+                        <EuiEmptyPrompt
+                          body={
+                            <p>
+                              Adjust the time range to see more results or create alert triggers in your
+                               
+                              <EuiLink
+                                href="/#/detectors"
+                              >
+                                detectors
+                              </EuiLink>
+                               to generate alerts.
+                            </p>
+                          }
+                          title={
+                            <h2>
+                              No alerts
+                            </h2>
+                          }
                         >
                           <div
-                            className="chart-view-container"
+                            className="euiEmptyPrompt"
                           >
-                            <EuiLoadingChart
-                              className="chart-view-container-loading"
-                              size="xl"
+                            <EuiTitle
+                              size="m"
+                            >
+                              <h2
+                                className="euiTitle euiTitle--medium"
+                              >
+                                No alerts
+                              </h2>
+                            </EuiTitle>
+                            <EuiTextColor
+                              color="subdued"
                             >
                               <span
-                                className="euiLoadingChart chart-view-container-loading euiLoadingChart--xLarge"
+                                className="euiTextColor euiTextColor--subdued"
                               >
-                                <span
-                                  className="euiLoadingChart__bar"
-                                />
-                                <span
-                                  className="euiLoadingChart__bar"
-                                />
-                                <span
-                                  className="euiLoadingChart__bar"
-                                />
-                                <span
-                                  className="euiLoadingChart__bar"
-                                />
+                                <EuiSpacer
+                                  size="m"
+                                >
+                                  <div
+                                    className="euiSpacer euiSpacer--m"
+                                  />
+                                </EuiSpacer>
+                                <EuiText>
+                                  <div
+                                    className="euiText euiText--medium"
+                                  >
+                                    <p>
+                                      Adjust the time range to see more results or create alert triggers in your
+                                       
+                                      <EuiLink
+                                        href="/#/detectors"
+                                      >
+                                        <a
+                                          className="euiLink euiLink--primary"
+                                          href="/#/detectors"
+                                          rel="noreferrer"
+                                        >
+                                          detectors
+                                        </a>
+                                      </EuiLink>
+                                       to generate alerts.
+                                    </p>
+                                  </div>
+                                </EuiText>
                               </span>
-                            </EuiLoadingChart>
-                            <div
-                              className="chart-view-container-mask"
-                            />
-                            <div
-                              id="alerts-view"
-                            />
+                            </EuiTextColor>
                           </div>
-                        </ChartContainer>
+                        </EuiEmptyPrompt>
                       </div>
                     </EuiFlexItem>
                   </div>

--- a/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
@@ -12,6 +12,7 @@ import {
   EuiInMemoryTable,
   EuiLink,
   EuiToolTip,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import { FieldValueSelectionFilterConfigType } from '@elastic/eui/src/components/search_bar/filters/field_value_selection_filter';
 import dateMath from '@elastic/datemath';
@@ -48,6 +49,7 @@ interface FindingsTableState {
   flyout: object | undefined;
   flyoutOpen: boolean;
   selectedFinding?: Finding;
+  widgetEmptyMessage: React.ReactNode | undefined;
 }
 
 export default class FindingsTable extends Component<FindingsTableProps, FindingsTableState> {
@@ -59,6 +61,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
       flyout: undefined,
       flyoutOpen: false,
       selectedFinding: undefined,
+      widgetEmptyMessage: undefined,
     };
   }
 
@@ -82,7 +85,21 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
     const filteredFindings = findings.filter((finding) =>
       moment(finding.timestamp).isBetween(moment(startMoment), moment(endMoment))
     );
-    this.setState({ findingsFiltered: true, filteredFindings: filteredFindings });
+    this.setState({
+      findingsFiltered: true,
+      filteredFindings: filteredFindings,
+      widgetEmptyMessage:
+        filteredFindings.length || findings.length ? undefined : (
+          <EuiEmptyPrompt
+            body={
+              <p>
+                <span style={{ display: 'block' }}>No findings.</span>Adjust the time range to see
+                more results.
+              </p>
+            }
+          />
+        ),
+    });
     this.props.onFindingsFiltered(filteredFindings);
   };
 
@@ -142,7 +159,13 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
 
   render() {
     const { findings, loading, rules } = this.props;
-    const { findingsFiltered, filteredFindings, flyout, flyoutOpen } = this.state;
+    const {
+      findingsFiltered,
+      filteredFindings,
+      flyout,
+      flyoutOpen,
+      widgetEmptyMessage,
+    } = this.state;
 
     const columns: EuiBasicTableColumn<Finding>[] = [
       {
@@ -285,6 +308,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
           sorting={sorting}
           isSelectable={false}
           loading={loading}
+          message={widgetEmptyMessage}
         />
         {flyoutOpen && flyout}
       </div>

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -14,6 +14,8 @@ import {
   EuiSpacer,
   EuiSuperDatePicker,
   EuiTitle,
+  EuiEmptyPrompt,
+  EuiLink,
 } from '@elastic/eui';
 import FindingsTable from '../../components/FindingsTable';
 import FindingsService from '../../../../services/FindingsService';
@@ -37,7 +39,6 @@ import {
 } from '../../../Overview/utils/helpers';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { Finding } from '../../models/interfaces';
-import { Detector } from '../../../../../models/interfaces';
 import { FeatureChannelList } from '../../../../../server/models/interfaces';
 import {
   getNotificationChannels,
@@ -54,6 +55,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { DateTimeFilter } from '../../../Overview/models/interfaces';
 import { ChartContainer } from '../../../../components/Charts/ChartContainer';
 import { DataStore } from '../../../../store/DataStore';
+import { Detector } from '../../../../../types';
 
 interface FindingsProps extends RouteComponentProps {
   detectorService: DetectorsService;
@@ -340,7 +342,22 @@ class Findings extends Component<FindingsProps, FindingsState> {
                 {this.createGroupByControl()}
               </EuiFlexItem>
               <EuiFlexItem>
-                <ChartContainer chartViewId={'findings-view'} loading={loading} />
+                {!findings || findings.length === 0 ? (
+                  <EuiEmptyPrompt
+                    title={<h2>No findings</h2>}
+                    body={
+                      <p>
+                        Adjust the time range to see more results or{' '}
+                        <EuiLink href={`${location.pathname}#/create-detector`}>
+                          create a detector
+                        </EuiLink>{' '}
+                        to generate findings.
+                      </p>
+                    }
+                  />
+                ) : (
+                  <ChartContainer chartViewId={'findings-view'} loading={loading} />
+                )}
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -11,6 +11,7 @@ import {
   EuiPopover,
   EuiSuperDatePicker,
   EuiTitle,
+  EuiSpacer,
 } from '@elastic/eui';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import {
@@ -166,6 +167,7 @@ export const Overview: React.FC<OverviewProps> = (props) => {
             />
           </EuiFlexItem>
         </EuiFlexGroup>
+        <EuiSpacer size={'m'} />
       </EuiFlexItem>
       <EuiFlexItem>
         <Summary


### PR DESCRIPTION
### Description
Adds empty state messages for the Findings and Alerts page. 
Find all the mocks attached on issue #471 

### Issues Resolved
Resolves #471 

### Screenshots
![screencapture-localhost-5601-app-opensearch-security-analytics-dashboards-2023-04-06-15_18_56](https://user-images.githubusercontent.com/28289071/230390706-0732e589-e556-44aa-843c-aefd4c4c8af0.png)
![screencapture-localhost-5601-app-opensearch-security-analytics-dashboards-2023-04-06-15_19_19](https://user-images.githubusercontent.com/28289071/230390710-996c2bbb-36bf-4d64-9daa-f12d8682cc6b.png)


### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).