### PR TITLE
Check for existing node ids when creating correlations graph data

### DIFF
--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -158,6 +158,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
         return this.shouldShowFinding(corr.finding1) && this.shouldShowFinding(corr.finding2);
       });
       const createdEdges = new Set<string>();
+      const createdNodes = new Set<string>();
       const graphData: CorrelationGraphData = {
         graph: {
           nodes: [],
@@ -175,8 +176,14 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
           return;
         }
 
-        this.addNode(graphData.graph.nodes, correlation.finding1);
-        this.addNode(graphData.graph.nodes, correlation.finding2);
+        if (!createdNodes.has(correlation.finding1.id)) {
+          this.addNode(graphData.graph.nodes, correlation.finding1);
+          createdNodes.add(correlation.finding1.id);
+        }
+        if (!createdNodes.has(correlation.finding2.id)) {
+          this.addNode(graphData.graph.nodes, correlation.finding2);
+          createdNodes.add(correlation.finding2.id);
+        }
         this.addEdge(graphData.graph.edges, correlation.finding1, correlation.finding2);
 
         createdEdges.add(`${correlation.finding1.id}:${correlation.finding2.id}`);


### PR DESCRIPTION
### Description
When there are more than one correlations for a finding, we are adding same node id twice in graph data which crashes the graph. This PR checks for existing node ids before adding same one again.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).