### PR TITLE
[BUG] Finding's fly-out has no correlations if open from alerts

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Sleep until OSD server starts - non-windows
         if: ${{ matrix.os != 'windows-latest' }}
-        run: sleep 300
+        run: sleep 400
         shell: bash
 
       - name: Install Cypress

--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -113,7 +113,7 @@ const createDetector = (detectorName, dataSource, expectFailure) => {
     }
   }
 
-  // Confirm entries user has made
+  // Confirm entries user made
   cy.contains('Detector details');
   cy.contains(detectorName);
   cy.contains('dns');

--- a/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
+++ b/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
@@ -180,6 +180,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
     return !!this.state.findingFlyoutData ? (
       <FindingDetailsFlyout
         {...this.props}
+        shouldLoadAllFindings={true}
         finding={{
           ...(findingFlyoutData as Finding),
           detector: { _id: detector.id as string, _index: '', _source: detector },

--- a/public/pages/Correlations/containers/CorrelationRules.tsx
+++ b/public/pages/Correlations/containers/CorrelationRules.tsx
@@ -40,7 +40,7 @@ export const CorrelationRules: React.FC<RouteComponentProps> = (props: RouteComp
 
   const getCorrelationRules = useCallback(
     async (ruleItem?) => {
-      const allCorrelationRules: CorrelationRuleHit[] = await DataStore.correlationsStore.getCorrelationRules();
+      const allCorrelationRules: CorrelationRuleHit[] = await DataStore.correlations.getCorrelationRules();
       const allRuleItems: CorrelationRuleTableItem[] = allCorrelationRules.map(
         (rule: CorrelationRuleHit) => ({
           ...rule,
@@ -58,7 +58,7 @@ export const CorrelationRules: React.FC<RouteComponentProps> = (props: RouteComp
       setAllRules(allRuleItems);
       setFilteredRules(allRuleItems);
     },
-    [DataStore.correlationsStore.getCorrelationRules]
+    [DataStore.correlations.getCorrelationRules]
   );
 
   useEffect(() => {
@@ -113,7 +113,7 @@ export const CorrelationRules: React.FC<RouteComponentProps> = (props: RouteComp
 
   const onDeleteRuleConfirmed = async (rule: any) => {
     if (selectedRule) {
-      const response = await DataStore.correlationsStore.deleteCorrelationRule(selectedRule.id);
+      const response = await DataStore.correlations.deleteCorrelationRule(selectedRule.id);
 
       if (response) {
         closeDeleteModal();

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -150,7 +150,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
       const end = datemath.parse(this.dateTimeFilter.endTime);
       const startTime = start?.valueOf() || Date.now();
       const endTime = end?.valueOf() || Date.now();
-      let allCorrelations = await DataStore.correlationsStore.getAllCorrelationsInWindow(
+      let allCorrelations = await DataStore.correlations.getAllCorrelationsInWindow(
         startTime.toString(),
         endTime.toString()
       );
@@ -197,9 +197,9 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
       return;
     }
 
-    const allFindings = await DataStore.correlationsStore.fetchAllFindings();
+    const allFindings = await DataStore.correlations.fetchAllFindings();
     const detectorType = allFindings[findingId].logType;
-    const correlations = await DataStore.correlationsStore.getCorrelatedFindings(
+    const correlations = await DataStore.correlations.getCorrelatedFindings(
       findingId,
       detectorType
     );
@@ -311,10 +311,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
 
   onFindingInspect = async (id: string, logType: string) => {
     // get finding data and set the specificFindingInfo
-    const specificFindingInfo = await DataStore.correlationsStore.getCorrelatedFindings(
-      id,
-      logType
-    );
+    const specificFindingInfo = await DataStore.correlations.getCorrelatedFindings(id, logType);
     this.setState({ specificFindingInfo });
     this.updateGraphDataState(specificFindingInfo);
   };

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -52,7 +52,7 @@ export interface CorrelationOptions {
 export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
   props: CreateCorrelationRuleProps
 ) => {
-  const correlationStore = DataStore.correlationsStore;
+  const correlationStore = DataStore.correlations;
   const validateCorrelationRule = useCallback((rule: CorrelationRuleModel) => {
     if (!rule.name) {
       return 'Invalid rule name';

--- a/public/pages/Detectors/components/DetectorBasicDetailsView/DetectorBasicDetailsView.tsx
+++ b/public/pages/Detectors/components/DetectorBasicDetailsView/DetectorBasicDetailsView.tsx
@@ -72,7 +72,7 @@ export const DetectorBasicDetailsView: React.FC<DetectorBasicDetailsViewProps> =
           content: (
             <>
               {inputs[0].detector_input.indices.map((ind: string) => (
-                <EuiText>{ind}</EuiText>
+                <EuiText key={ind}>{ind}</EuiText>
               ))}
             </>
           ),

--- a/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
@@ -1854,7 +1854,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                               >
-                                <EuiText>
+                                <EuiText
+                                  key=".windows"
+                                >
                                   <div
                                     className="euiText euiText--medium"
                                   >

--- a/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
@@ -897,7 +897,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                               onBlur={[Function]}
                               onFocus={[Function]}
                             >
-                              <EuiText>
+                              <EuiText
+                                key=".windows"
+                              >
                                 <div
                                   className="euiText euiText--medium"
                                 >

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -83,16 +83,16 @@ export default class FindingDetailsFlyout extends Component<
     };
   }
 
-  componentDidMount(): void {
-    this.getIndexPatternId().then((patternId) => {
-      if (patternId) {
-        this.setState({ indexPatternId: patternId });
-      }
-    });
-
+  getCorrelations = async () => {
     const { id, detector } = this.props.finding;
-    const allFindings = this.props.findings;
-    DataStore.correlationsStore
+    let allFindings = this.props.findings;
+    if (allFindings.length === 1 && allFindings[0].id === id) {
+      // if findings come from the alerts fly-out, then there is only one finding
+      // so, we need to get all the findings to match those with the correlations
+      allFindings = await DataStore.findings.getAllFindings();
+    }
+
+    DataStore.correlations
       .getCorrelatedFindings(id, detector._source?.detector_type)
       .then((findings) => {
         if (findings?.correlatedFindings.length) {
@@ -107,6 +107,16 @@ export default class FindingDetailsFlyout extends Component<
           this.setState({ correlatedFindings });
         }
       });
+  };
+
+  componentDidMount(): void {
+    this.getIndexPatternId().then((patternId) => {
+      if (patternId) {
+        this.setState({ indexPatternId: patternId });
+      }
+    });
+
+    this.getCorrelations();
 
     this.setState({
       selectedTab: {

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -57,6 +57,7 @@ interface FindingDetailsFlyoutProps extends RouteComponentProps {
   indexPatternsService: IndexPatternsService;
   correlationService: CorrelationService;
   closeFlyout: () => void;
+  shouldLoadAllFindings: boolean;
 }
 
 interface FindingDetailsFlyoutState {
@@ -86,9 +87,8 @@ export default class FindingDetailsFlyout extends Component<
   getCorrelations = async () => {
     const { id, detector } = this.props.finding;
     let allFindings = this.props.findings;
-    if (allFindings.length === 1 && allFindings[0].id === id) {
-      // if findings come from the alerts fly-out, then there is only one finding
-      // so, we need to get all the findings to match those with the correlations
+    if (this.props.shouldLoadAllFindings) {
+      // if findings come from the alerts fly-out, we need to get all the findings to match those with the correlations
       allFindings = await DataStore.findings.getAllFindings();
     }
 

--- a/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
@@ -134,6 +134,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
         flyout: (
           <FindingDetailsFlyout
             {...this.props}
+            shouldLoadAllFindings={false}
             finding={finding}
             findings={findingsFiltered ? filteredFindings : findings}
             closeFlyout={this.closeFlyout}

--- a/public/store/DataStore.ts
+++ b/public/store/DataStore.ts
@@ -9,11 +9,13 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { DetectorsStore } from './DetectorsStore';
 import { ICorrelationsStore } from '../../types';
 import { CorrelationsStore } from './CorrelationsStore';
+import { FindingsStore, IFindingsStore } from './FindingsStore';
 
 export class DataStore {
   public static rules: RulesStore;
   public static detectors: DetectorsStore;
-  public static correlationsStore: ICorrelationsStore;
+  public static correlations: ICorrelationsStore;
+  public static findings: IFindingsStore;
 
   public static init = (services: BrowserServices, notifications: NotificationsStart) => {
     const rulesStore = new RulesStore(services.ruleService, notifications);
@@ -25,7 +27,13 @@ export class DataStore {
       services.savedObjectsService
     );
 
-    DataStore.correlationsStore = new CorrelationsStore(
+    DataStore.findings = new FindingsStore(
+      services.findingsService,
+      services.detectorsService,
+      notifications
+    );
+
+    DataStore.correlations = new CorrelationsStore(
       services.correlationsService,
       services.detectorsService,
       services.findingsService,

--- a/public/store/FindingsStore.ts
+++ b/public/store/FindingsStore.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DetectorsService, FindingsService } from '../services';
+import { NotificationsStart } from 'opensearch-dashboards/public';
+import { RouteComponentProps } from 'react-router-dom';
+import { errorNotificationToast } from '../utils/helpers';
+import { FindingItemType } from '../pages/Findings/containers/Findings/Findings';
+
+export interface IFindingsStore {
+  readonly service: FindingsService;
+
+  readonly detectorsService: DetectorsService;
+
+  readonly notifications: NotificationsStart;
+
+  getFindingsPerDetector: (detectorId: string) => Promise<FindingItemType[]>;
+
+  getAllFindings: () => Promise<FindingItemType[]>;
+}
+
+export interface IFindingsCache {}
+
+/**
+ * Findings store
+ *
+ * @class FindingsStore
+ * @implements IDetectorsStore
+ * @param {BrowserServices} services Uses services to make API requests
+ */
+export class FindingsStore implements IFindingsStore {
+  /**
+   * Findings service instance
+   *
+   * @property {FindingsService} service
+   * @readonly
+   */
+  readonly service: FindingsService;
+
+  /**
+   * Detectors service instance
+   *
+   * @property {DetectorsService} detectorsService
+   * @readonly
+   */
+  readonly detectorsService: DetectorsService;
+
+  /**
+   * Notifications
+   * @property {NotificationsStart}
+   * @readonly
+   */
+  readonly notifications: NotificationsStart;
+
+  /**
+   * Router history
+   * @property {RouteComponentProps['history']}
+   * @readonly
+   */
+  history: RouteComponentProps['history'] | undefined = undefined;
+
+  constructor(
+    service: FindingsService,
+    detectorsService: DetectorsService,
+    notifications: NotificationsStart
+  ) {
+    this.service = service;
+    this.detectorsService = detectorsService;
+    this.notifications = notifications;
+  }
+
+  public getFindingsPerDetector = async (detectorId: string): Promise<FindingItemType[]> => {
+    let allFindings: FindingItemType[] = [];
+    const findingRes = await this.service.getFindings({ detectorId });
+    if (findingRes.ok) {
+      allFindings = findingRes.response.findings as FindingItemType[];
+    } else {
+      errorNotificationToast(this.notifications, 'retrieve', 'findings', findingRes.error);
+    }
+
+    return allFindings;
+  };
+
+  public getAllFindings = async (): Promise<FindingItemType[]> => {
+    let allFindings: FindingItemType[] = [];
+    const detectorsRes = await this.detectorsService.getDetectors();
+    if (detectorsRes.ok) {
+      const detectors = detectorsRes.response.hits.hits;
+
+      for (let detector of detectors) {
+        const findings = await this.getFindingsPerDetector(detector._id);
+        const findingsPerDetector: FindingItemType[] = findings.map((finding) => {
+          return {
+            ...finding,
+            detectorName: detector._source.name,
+            logType: detector._source.detector_type,
+            detector: detector,
+          };
+        });
+        allFindings = allFindings.concat(findingsPerDetector);
+      }
+    }
+
+    return allFindings;
+  };
+}

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -37,6 +37,12 @@ module.exports = {
   ],
   clearMocks: true,
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+  transformIgnorePatterns: [
+    // ignore all node_modules except those which require babel transforms to
+    // handle newer syntax like `??=` which is not already transformed by the
+    // package and not yet supported in the node version we use.
+    '[/\\\\]node_modules(?![\\/\\\\](vega-lite))[/\\\\].+\\.js$',
+  ],
   modulePathIgnorePatterns: ['securityAnalyticsDashboards'],
   testEnvironment: 'jsdom',
   snapshotSerializers: ['enzyme-to-json/serializer'],


### PR DESCRIPTION
### Description
Fixing finding's fly-out has no correlations if open from the alerts page.

### Issues Resolved
Resolves #557 

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).