### PR TITLE
Fixed cypress and unit test workflows after bumping main to 3.0.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -46,10 +46,12 @@ jobs:
           repository: opensearch-project/security-analytics
           ref: ${{ env.SECURITY_ANALYTICS_BRANCH }}
 
-      - name: Run opensearch with plugin
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
+
+      - name: Run opensearch with plugin
         run: |
           cd security-analytics
           ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -10,6 +10,7 @@ env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
   OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
   SECURITY_ANALYTICS_BRANCH: 'main'
+  GRADLE_VERSION: '7.6.1'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -46,6 +47,9 @@ jobs:
           ref: ${{ env.SECURITY_ANALYTICS_BRANCH }}
 
       - name: Run opensearch with plugin
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: ${{ env.GRADLE_VERSION }}
         run: |
           cd security-analytics
           ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -37,6 +37,12 @@ module.exports = {
   ],
   clearMocks: true,
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+  transformIgnorePatterns: [
+    // ignore all node_modules except those which require babel transforms to
+    // handle newer syntax like `??=` which is not already transformed by the
+    // package and not yet supported in the node version we use.
+    '[/\\\\]node_modules(?![\\/\\\\](vega-lite))[/\\\\].+\\.js$',
+  ],
   modulePathIgnorePatterns: ['securityAnalyticsDashboards'],
   testEnvironment: 'jsdom',
   snapshotSerializers: ['enzyme-to-json/serializer'],


### PR DESCRIPTION
### Description
Fixed cypress and unit test workflows after bumping main to 3.0.

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/560

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).