### PR TITLE
[Overview page] Fixed recent alerts & finding order; count for pie chart

### DIFF
--- a/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
@@ -53,7 +53,7 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
     items.sort((a, b) => {
       const timeA = new Date(a.time).getTime();
       const timeB = new Date(b.time).getTime();
-      return timeA - timeB;
+      return timeB - timeA;
     });
     setAlertItems(items.slice(0, 20));
     setwidgetEmptyMessage(

--- a/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
@@ -58,7 +58,7 @@ export const RecentFindingsWidget: React.FC<RecentFindingsWidgetProps> = ({
 
   useEffect(() => {
     items.sort((a, b) => {
-      return a.time - b.time;
+      return b.time - a.time;
     });
     setFindingItems(items.slice(0, 20));
     setWidgetEmptyMessage(

--- a/public/pages/Overview/components/Widgets/TopRulesWidget.tsx
+++ b/public/pages/Overview/components/Widgets/TopRulesWidget.tsx
@@ -28,7 +28,7 @@ export const TopRulesWidget: React.FC<TopRulesWidgetProps> = ({ findings, loadin
     if (Object.keys(rulesCount).length > 0) {
       const visualizationData = Object.keys(rulesCount).map((ruleName) => ({
         ruleName,
-        count: 1,
+        count: rulesCount[ruleName],
       }));
       renderVisualization(getTopRulesVisualizationSpec(visualizationData), 'top-rules-view');
     }


### PR DESCRIPTION
### Description
[Overview page] Fixed recent alerts & finding order; count for pie chart

- Pie chart shows counts correctly:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/114732919/236392315-81c5d39b-d068-4f52-8e3a-93b96371cc9e.png">

- Recent alerts/findings show the latest entries:
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/114732919/236392453-2fe6fb95-9ab0-4760-b389-415cd33582a9.png">



### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).