### PR TITLE
Use user provided end date for calculating the end time of the x-axis time range

### DIFF
--- a/public/pages/Overview/utils/helpers.ts
+++ b/public/pages/Overview/utils/helpers.ts
@@ -464,7 +464,9 @@ export const getDomainRange = (
   if (timeUnit) {
     const timeUnitSize = timeUnit.match(/.*(seconds|minutes|hours|date|month|year)$/);
     if (timeUnitSize && timeUnitSize[1]) {
-      rangeEnd = `now+1${timeUnitSize[1][0]}`;
+      // `||` is the separator which the datemath's parse method will use to split the dates for
+      // the addition.
+      rangeEnd = `${range[1]}||+1${timeUnitSize[1][0]}`;
     }
   }
   const end: number = parseDateString(rangeEnd);


### PR DESCRIPTION
### Description
Currently, the x-axis time range for the charts always ends at one unit greater than `now`. This does not respect user provided end time in the date picker.
This PR changes that logic to use the end time provided by the user.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).