### PR TITLE
Update selection panel component for the "Create detection rule"

### DIFF
--- a/cypress/integration/2_rules.spec.js
+++ b/cypress/integration/2_rules.spec.js
@@ -10,11 +10,9 @@ const SAMPLE_RULE = {
   name: `Cypress test rule ${uniqueId}`,
   logType: 'windows',
   description: 'This is a rule used to test the rule creation workflow.',
-  detection:
-    "condition: selection\nselection:\nProvider_Name|contains:\n- Service Control Manager\nEventID|contains:\n- '7045'\nServiceName|contains:\n- ZzNetSvc",
   detectionLine: [
-    'condition: selection',
-    'selection:',
+    'condition: Selection_1',
+    'Selection_1:',
     'Provider_Name|contains:',
     '- Service Control Manager',
     'EventID|contains:',
@@ -48,7 +46,7 @@ const YAML_RULE_LINES = [
   `- '${SAMPLE_RULE.references}'`,
   `author: ${SAMPLE_RULE.author}`,
   `detection:`,
-  ...SAMPLE_RULE.detection.replaceAll('  ', '').replaceAll('{backspace}', '').split('\n'),
+  ...SAMPLE_RULE.detectionLine,
 ];
 
 const checkRulesFlyout = () => {
@@ -184,7 +182,6 @@ describe('Rules', () => {
     cy.get('[data-test-subj="rule_author_field"]').type(`${SAMPLE_RULE.author}{enter}`);
 
     cy.get('[data-test-subj="detection-visual-editor-0"]').within(() => {
-      cy.getFieldByLabel('Name').type('selection');
       cy.getFieldByLabel('Key').type('Provider_Name');
       cy.getInputByPlaceholder('Value').type('Service Control Manager');
 
@@ -200,7 +197,7 @@ describe('Rules', () => {
         cy.getInputByPlaceholder('Value').type('ZzNetSvc');
       });
     });
-    cy.get('[data-test-subj="rule_detection_field"] textarea').type('selection', {
+    cy.get('[data-test-subj="rule_detection_field"] textarea').type('Selection_1', {
       force: true,
     });
 

--- a/public/app.scss
+++ b/public/app.scss
@@ -18,6 +18,7 @@ $euiTextColor: $euiColorDarkestShade !default;
 @import "./pages/Correlations/Correlations.scss";
 @import "./pages/Correlations/components/FindingCard.scss";
 @import "./pages/Findings/components/CorrelationsTable/CorrelationsTable.scss";
+@import "./pages/Rules/components/RuleEditor/DetectionVisualEditor.scss";
 
 .selected-radio-panel {
   background-color: tintOrShade($euiColorPrimary, 90%, 70%);

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
@@ -22,6 +22,12 @@
     .detection-visual-editor-textarea-clear-btn {
       align-items: flex-end;
     }
+
+    .detection-visual-editor-accordion {
+      .euiAccordion__childWrapper {
+        height: auto !important;
+      }
+    }
   }
 
   .detection-visual-editor-name {

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
@@ -1,0 +1,45 @@
+
+.detection-visual-editor {
+  .euiAccordionForm:nth-of-type(1) {
+    border-top: 1px solid #D3DAE6;
+  }
+
+  .euiAccordionForm {
+    border-top: 0 !important;
+  }
+
+  .detection-visual-editor-accordion-wrapper {
+    width: 100%;
+    .detection-visual-editor-form-row {
+      max-width: 100%;
+      .detection-visual-editor-textarea {
+        max-width: 100%;
+        padding: 0;
+        min-height: 100px;
+      }
+    }
+
+    .detection-visual-editor-textarea-clear-btn {
+      align-items: flex-end;
+    }
+  }
+
+  .detection-visual-editor-name {
+    box-shadow: none;
+    background-color: transparent;
+    padding: 0;
+  }
+
+  .detection-visual-editor-delete-selection {
+    margin-top: 0 !important;
+  }
+
+  .euiButtonIcon--danger {
+    color: $ouiTextSubduedColor !important;
+
+    &:hover {
+      color: $ouiColorDanger !important;
+      background-color: transparent !important;
+    }
+  }
+}

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -493,7 +493,7 @@ export class DetectionVisualEditor extends React.Component<
                 return (
                   <div key={`Map-${idx}`} className={'detection-visual-editor-accordion-wrapper'}>
                     <EuiAccordion
-                      className="euiAccordionForm"
+                      className="euiAccordionForm detection-visual-editor-accordion"
                       buttonClassName="euiAccordionForm__button"
                       id={`Map-${idx}`}
                       data-test-subj={`Map-${idx}`}
@@ -563,6 +563,7 @@ export class DetectionVisualEditor extends React.Component<
                           </EuiFormRow>
                         </EuiFlexItem>
                       </EuiFlexGroup>
+
                       <EuiSpacer size="s" />
 
                       <EuiRadioGroup
@@ -663,6 +664,8 @@ export class DetectionVisualEditor extends React.Component<
                           />
                         </EuiFormRow>
                       )}
+
+                      <EuiSpacer size={'m'} />
                     </EuiAccordion>
                   </div>
                 );
@@ -671,6 +674,7 @@ export class DetectionVisualEditor extends React.Component<
               <EuiSpacer size={'m'} />
 
               <EuiButton
+                style={{ width: '70%' }}
                 iconType="plusInCircle"
                 onClick={() => {
                   const newData = [

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -29,6 +29,7 @@ import {
   EuiModalFooter,
   EuiFilePicker,
   EuiCodeEditor,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import _ from 'lodash';
 import { validateCondition, validateDetectionFieldName } from '../../../../utils/validation';
@@ -275,6 +276,10 @@ export class DetectionVisualEditor extends React.Component<
     const { errors } = this.state;
     const selection = selections[selectionIdx];
 
+    if (!selection.name) {
+      selection.name = `Selection_${selectionIdx + 1}`;
+    }
+
     delete errors.fields['name'];
     if (!selection.name) {
       errors.fields['name'] = 'Selection name is required';
@@ -426,23 +431,38 @@ export class DetectionVisualEditor extends React.Component<
     } = this.state;
 
     return (
-      <EuiPanel style={{ maxWidth: 1000 }}>
+      <EuiPanel style={{ maxWidth: 1000 }} className={'detection-visual-editor'}>
         {selections.map((selection, selectionIdx) => {
           return (
-            <div data-test-subj={`detection-visual-editor-${selectionIdx}`}>
+            <div
+              data-test-subj={`detection-visual-editor-${selectionIdx}`}
+              key={`detection-visual-editor-${selectionIdx}`}
+            >
               <EuiFlexGroup alignItems="center">
                 <EuiFlexItem grow={true}>
-                  <EuiTitle size="s">
-                    <p>{selection.name || `Selection_${selectionIdx + 1}`}</p>
-                  </EuiTitle>
+                  <EuiFormRow
+                    isInvalid={errors.touched.name && !!errors.fields.name}
+                    error={errors.fields.name}
+                  >
+                    <EuiFieldText
+                      className={'detection-visual-editor-name euiTitle--small'}
+                      isInvalid={errors.touched.name && !!errors.fields.name}
+                      placeholder="Enter selection name"
+                      data-test-subj={'selection_name'}
+                      onChange={(e) => this.updateSelection(selectionIdx, { name: e.target.value })}
+                      onBlur={(e) => this.updateSelection(selectionIdx, { name: e.target.value })}
+                      value={selection.name || `Selection_${selectionIdx + 1}`}
+                    />
+                  </EuiFormRow>
                   <EuiText size="s">
                     <p>Define the search identifier in your data the rule will be applied to.</p>
                   </EuiText>
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
+                <EuiFlexItem grow={false} className={'detection-visual-editor-delete-selection'}>
                   {selections.length > 1 && (
                     <EuiToolTip title={'Delete selection'}>
                       <EuiButtonIcon
+                        aria-label={'Delete selection'}
                         iconType={'trash'}
                         color="danger"
                         onClick={() => {
@@ -466,182 +486,189 @@ export class DetectionVisualEditor extends React.Component<
 
               <EuiSpacer />
 
-              <EuiFormRow
-                isInvalid={errors.touched.name && !!errors.fields.name}
-                error={errors.fields.name}
-                label={<EuiText size={'s'}>Name</EuiText>}
-              >
-                <EuiFieldText
-                  isInvalid={errors.touched.name && !!errors.fields.name}
-                  placeholder="Enter selection name"
-                  data-test-subj={'selection_name'}
-                  onChange={(e) => this.updateSelection(selectionIdx, { name: e.target.value })}
-                  onBlur={(e) => this.updateSelection(selectionIdx, { name: e.target.value })}
-                  value={selection.name}
-                />
-              </EuiFormRow>
-
-              <EuiSpacer />
-
               {selection.data.map((datum, idx) => {
                 const radioGroupOptions = this.createRadioGroupOptions(selectionIdx, idx);
                 const fieldName = `field_${selectionIdx}_${idx}`;
                 const valueId = `value_${selectionIdx}_${idx}`;
                 return (
-                  <EuiAccordion
-                    id={`Map-${idx}`}
-                    data-test-subj={`Map-${idx}`}
-                    initialIsOpen={true}
-                    buttonContent={`Map ${idx + 1}`}
-                    extraAction={
-                      selection.data.length > 1 ? (
-                        <EuiToolTip title={'Delete map'}>
-                          <EuiButtonIcon
-                            iconType={'trash'}
-                            color="danger"
-                            onClick={() => {
-                              const newData = [...selection.data];
-                              newData.splice(idx, 1);
-                              this.updateSelection(selectionIdx, { data: newData });
-                            }}
-                          />
-                        </EuiToolTip>
-                      ) : null
-                    }
-                    style={{ maxWidth: '500px' }}
-                  >
-                    <EuiSpacer size="m" />
-
-                    <EuiFlexGroup>
-                      <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
-                        <EuiFormRow
-                          isInvalid={errors.touched[fieldName] && !!errors.fields[fieldName]}
-                          error={errors.fields[fieldName]}
-                          label={<EuiText size={'s'}>Key</EuiText>}
-                        >
-                          <EuiFieldText
+                  <div key={`Map-${idx}`} className={'detection-visual-editor-accordion-wrapper'}>
+                    <EuiAccordion
+                      className="euiAccordionForm"
+                      buttonClassName="euiAccordionForm__button"
+                      id={`Map-${idx}`}
+                      data-test-subj={`Map-${idx}`}
+                      initialIsOpen={true}
+                      buttonContent={<EuiText size="m">Map {idx + 1}</EuiText>}
+                      extraAction={
+                        selection.data.length > 1 ? (
+                          <EuiToolTip title={'Delete map'}>
+                            <EuiButtonIcon
+                              aria-label={'Delete map'}
+                              iconType={'trash'}
+                              color="danger"
+                              onClick={() => {
+                                const newData = [...selection.data];
+                                newData.splice(idx, 1);
+                                this.updateSelection(selectionIdx, { data: newData });
+                              }}
+                            />
+                          </EuiToolTip>
+                        ) : null
+                      }
+                      style={{ maxWidth: '70%' }}
+                    >
+                      <EuiFlexGroup>
+                        <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
+                          <EuiFormRow
                             isInvalid={errors.touched[fieldName] && !!errors.fields[fieldName]}
-                            placeholder="Enter key name"
-                            data-test-subj={'selection_field_key_name'}
-                            onChange={(e) =>
-                              this.updateDatumInState(selectionIdx, idx, {
-                                field: e.target.value,
-                              })
-                            }
-                            onBlur={(e) =>
-                              this.updateDatumInState(selectionIdx, idx, {
-                                field: e.target.value,
-                              })
-                            }
-                            value={datum.field}
-                          />
-                        </EuiFormRow>
-                      </EuiFlexItem>
-                      <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
-                        <EuiFormRow label={<EuiText size={'s'}>Modifier</EuiText>}>
-                          <EuiComboBox
-                            data-test-subj={'modifier_dropdown'}
-                            options={detectionModifierOptions}
-                            singleSelection={{ asPlainText: true }}
-                            onChange={(e) => {
-                              this.updateDatumInState(selectionIdx, idx, {
-                                modifier: e[0].value,
-                              });
-                            }}
-                            onBlur={(e) => {}}
-                            selectedOptions={
-                              datum.modifier
-                                ? [{ value: datum.modifier, label: datum.modifier }]
-                                : [detectionModifierOptions[0]]
-                            }
-                          />
-                        </EuiFormRow>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                    <EuiSpacer size="m" />
+                            error={errors.fields[fieldName]}
+                            label={<EuiText size={'s'}>Key</EuiText>}
+                          >
+                            <EuiFieldText
+                              isInvalid={errors.touched[fieldName] && !!errors.fields[fieldName]}
+                              placeholder="Enter key name"
+                              data-test-subj={'selection_field_key_name'}
+                              onChange={(e) =>
+                                this.updateDatumInState(selectionIdx, idx, {
+                                  field: e.target.value,
+                                })
+                              }
+                              onBlur={(e) =>
+                                this.updateDatumInState(selectionIdx, idx, {
+                                  field: e.target.value,
+                                })
+                              }
+                              value={datum.field}
+                            />
+                          </EuiFormRow>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
+                          <EuiFormRow label={<EuiText size={'s'}>Modifier</EuiText>}>
+                            <EuiComboBox
+                              data-test-subj={'modifier_dropdown'}
+                              options={detectionModifierOptions}
+                              singleSelection={{ asPlainText: true }}
+                              onChange={(e) => {
+                                this.updateDatumInState(selectionIdx, idx, {
+                                  modifier: e[0].value,
+                                });
+                              }}
+                              onBlur={(e) => {}}
+                              selectedOptions={
+                                datum.modifier
+                                  ? [{ value: datum.modifier, label: datum.modifier }]
+                                  : [detectionModifierOptions[0]]
+                              }
+                            />
+                          </EuiFormRow>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                      <EuiSpacer size="s" />
 
-                    <EuiRadioGroup
-                      options={radioGroupOptions}
-                      idSelected={datum.selectedRadioId || radioGroupOptions[0].id}
-                      onChange={(id) => {
-                        this.updateDatumInState(selectionIdx, idx, {
-                          selectedRadioId: id as SelectionMapValueRadioId,
-                        });
-                      }}
-                    />
-                    <EuiSpacer size="m" />
+                      <EuiRadioGroup
+                        options={radioGroupOptions}
+                        idSelected={datum.selectedRadioId || radioGroupOptions[0].id}
+                        onChange={(id) => {
+                          this.updateDatumInState(selectionIdx, idx, {
+                            selectedRadioId: id as SelectionMapValueRadioId,
+                          });
+                        }}
+                      />
 
-                    {datum.selectedRadioId?.includes('list') ? (
-                      <>
-                        <EuiButton
-                          iconType="download"
-                          onClick={() => {
-                            this.setState({
-                              fileUploadModalState: {
-                                selectionIdx,
-                                dataIdx: idx,
-                              },
-                            });
-                          }}
-                        >
-                          Upload file
-                        </EuiButton>
-                        <EuiSpacer />
+                      <EuiSpacer size="m" />
+
+                      {datum.selectedRadioId?.includes('list') ? (
+                        <>
+                          <EuiFlexGroup>
+                            <EuiFlexItem grow={false}>
+                              <EuiButton
+                                iconType="download"
+                                onClick={() => {
+                                  this.setState({
+                                    fileUploadModalState: {
+                                      selectionIdx,
+                                      dataIdx: idx,
+                                    },
+                                  });
+                                }}
+                              >
+                                Upload file
+                              </EuiButton>
+                            </EuiFlexItem>
+
+                            <EuiFlexItem
+                              grow={true}
+                              className={'detection-visual-editor-textarea-clear-btn'}
+                            >
+                              <EuiButtonEmpty
+                                isDisabled={!datum.values[0]}
+                                color={datum.values[0] ? 'primary' : 'ghost'}
+                                iconType={'cross'}
+                                onClick={() => {
+                                  this.updateDatumInState(selectionIdx, idx, {
+                                    values: [],
+                                  });
+                                }}
+                              >
+                                Clear list
+                              </EuiButtonEmpty>
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                          <EuiSpacer />
+                          <EuiFormRow
+                            isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
+                            error={errors.fields[valueId]}
+                            className={'detection-visual-editor-form-row'}
+                          >
+                            <EuiTextArea
+                              className={'detection-visual-editor-textarea'}
+                              onChange={(e) => {
+                                const values = e.target.value.split('\n');
+                                this.updateDatumInState(selectionIdx, idx, {
+                                  values,
+                                });
+                              }}
+                              onBlur={(e) => {
+                                const values = e.target.value.split('\n');
+                                this.updateDatumInState(selectionIdx, idx, {
+                                  values,
+                                });
+                              }}
+                              value={datum.values.join('\n')}
+                              compressed={true}
+                              isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
+                            />
+                          </EuiFormRow>
+                        </>
+                      ) : (
                         <EuiFormRow
                           isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
                           error={errors.fields[valueId]}
                         >
-                          <EuiTextArea
-                            style={{ maxWidth: '100%' }}
+                          <EuiFieldText
+                            isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
+                            placeholder="Value"
+                            data-test-subj={'selection_field_value'}
                             onChange={(e) => {
-                              const values = e.target.value.split('\n');
-                              console.log(values);
                               this.updateDatumInState(selectionIdx, idx, {
-                                values,
+                                values: [e.target.value, ...datum.values.slice(1)],
                               });
                             }}
                             onBlur={(e) => {
-                              const values = e.target.value.split('\n');
-                              console.log(values);
                               this.updateDatumInState(selectionIdx, idx, {
-                                values,
+                                values: [e.target.value, ...datum.values.slice(1)],
                               });
                             }}
-                            value={datum.values.join('\n')}
-                            compressed={true}
-                            isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
+                            value={datum.values[0]}
                           />
                         </EuiFormRow>
-                      </>
-                    ) : (
-                      <EuiFormRow
-                        isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
-                        error={errors.fields[valueId]}
-                      >
-                        <EuiFieldText
-                          isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
-                          placeholder="Value"
-                          data-test-subj={'selection_field_value'}
-                          onChange={(e) => {
-                            this.updateDatumInState(selectionIdx, idx, {
-                              values: [e.target.value, ...datum.values.slice(1)],
-                            });
-                          }}
-                          onBlur={(e) => {
-                            this.updateDatumInState(selectionIdx, idx, {
-                              values: [e.target.value, ...datum.values.slice(1)],
-                            });
-                          }}
-                          value={datum.values[0]}
-                        />
-                      </EuiFormRow>
-                    )}
-
-                    <EuiHorizontalRule margin="s" />
-                    <EuiSpacer size="m" />
-                  </EuiAccordion>
+                      )}
+                    </EuiAccordion>
+                  </div>
                 );
               })}
+
+              <EuiSpacer size={'m'} />
 
               <EuiButton
                 iconType="plusInCircle"
@@ -674,6 +701,7 @@ export class DetectionVisualEditor extends React.Component<
                   ...selections,
                   {
                     ...defaultDetectionObj.selections[0],
+                    name: `Selection_${selections.length + 1}`,
                   },
                 ],
               },

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -400,7 +400,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     selectedOptions={
                       props.values.status
                         ? [{ value: props.values.status, label: props.values.status }]
-                        : []
+                        : [{ value: ruleStatus[0], label: ruleStatus[0] }]
                     }
                   />
                 </EuiFormRow>

--- a/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/RuleTagsComboBox.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/RuleTagsComboBox.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { EuiFormRow, EuiText, EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
 export interface RuleTagsComboBoxProps {
@@ -16,25 +16,12 @@ export interface RuleTagsComboBoxProps {
   selectedOptions: EuiComboBoxOptionOption<string>[];
 }
 
-const STARTS_WITH = 'attack.';
-
-const isValid = (value: string) => {
-  if (value === '') return true;
-  return value.startsWith(STARTS_WITH) && value.length > STARTS_WITH.length;
-};
-
 export const RuleTagsComboBox: React.FC<RuleTagsComboBoxProps> = ({
   onCreateOption,
   onBlur,
   onChange,
   selectedOptions,
 }) => {
-  const [isCurrentlyTypingValueInvalid, setIsCurrentlyTypingValueInvalid] = useState(false);
-
-  const onSearchChange = (searchValue: string) => {
-    setIsCurrentlyTypingValueInvalid(!isValid(searchValue));
-  };
-
   return (
     <>
       <EuiFormRow
@@ -44,22 +31,15 @@ export const RuleTagsComboBox: React.FC<RuleTagsComboBoxProps> = ({
             <i>- optional</i>
           </EuiText>
         }
-        isInvalid={isCurrentlyTypingValueInvalid}
-        error={isCurrentlyTypingValueInvalid ? 'Invalid tag' : ''}
-        helpText={`Tags must start with '${STARTS_WITH}'`}
       >
         <EuiComboBox
           noSuggestions
-          onSearchChange={onSearchChange}
           placeholder="Create tags"
           onChange={onChange}
-          onCreateOption={(searchValue, options) =>
-            isValid(searchValue) && onCreateOption(searchValue, options)
-          }
+          onCreateOption={(searchValue, options) => onCreateOption(searchValue, options)}
           onBlur={onBlur}
           data-test-subj={'rule_tags_dropdown'}
           selectedOptions={selectedOptions}
-          isInvalid={isCurrentlyTypingValueInvalid}
         />
       </EuiFormRow>
     </>

--- a/public/pages/Rules/containers/CreateRule/CreateRule.tsx
+++ b/public/pages/Rules/containers/CreateRule/CreateRule.tsx
@@ -5,7 +5,7 @@
 
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS } from '../../../../utils/constants';
 import { CoreServicesContext } from '../../../../components/core_services';
@@ -20,7 +20,10 @@ export interface CreateRuleProps {
 
 export const CreateRule: React.FC<CreateRuleProps> = ({ history, services, notifications }) => {
   const context = useContext(CoreServicesContext);
-  setBreadCrumb(BREADCRUMBS.RULES_CREATE, context?.chrome.setBreadcrumbs);
+
+  useEffect(() => {
+    setBreadCrumb(BREADCRUMBS.RULES_CREATE, context?.chrome.setBreadcrumbs);
+  });
 
   return (
     <RuleEditorContainer


### PR DESCRIPTION
### Description
Update the selection panel component for each selection in the "Create detection rule" page:

Set "selection_1", "selection_2", etc. as editable default for selection names
Fix spacing and horizontal rule under collapsed maps accordions
Remove restrictions from the tag names
Set rule status to "experimental" as a default
The default color for the "trash can" button icon is OUItextsubdued, it changes to OUItextdanger on mouse over (no change in background color)

### Screenshots
![238993977-2c2df4ac-46ff-46e2-ab2a-fb64a83e0dec](https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/28289071/daf933c1-e706-4a96-92b9-d15f90be0f25)


### Issues Resolved
Resolves #587 

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).