### PR TITLE
Updated the cypress workflow to support overriding the dependency versions.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -77,6 +77,19 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
 
+      # This job adjusts the 'version' and 'opensearchDashboardsVersion' attributes in the package.json and
+      # opensearch_dashboards.json file to the provided versions (e.g., "2.8.0.0", and "2.8.0" respectively)
+      # if those env variables are not empty.
+      # This is most useful on the 'main' branch as it will enable us to specify which version to use for the build when
+      # one of this package's dependencies is not building reliably without having to adjust the actual version of this package.
+      - name: Override Package Versions
+        if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
+        run: |
+          cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
+          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' opensearch_dashboards.json
+          sed -i 's/"opensearchDashboardsVersion": "[^"]*"/"opensearchDashboardsVersion": "${{ env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION }}"/' opensearch_dashboards.json
+          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' package.json
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -92,19 +105,6 @@ jobs:
           npm i -g yarn@$YARN_VERSION
       - run: node -v
       - run: yarn -v
-
-      # This job adjusts the 'version' and 'opensearchDashboardsVersion' attributes in the package.json and
-      # opensearch_dashboards.json file to the provided versions (e.g., "2.8.0.0", and "2.8.0" respectively)
-      # if those env variables are not empty.
-      # This is most useful on the 'main' branch as it will enable us to specify which version to use for the build when
-      # one of this package's dependencies is not building reliably without having to adjust the actual version of this package.
-      - name: Override Package Versions
-        if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
-        run: |
-          cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' opensearch_dashboards.json
-          sed -i 's/"opensearchDashboardsVersion": "[^"]*"/"opensearchDashboardsVersion": "${{ env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION }}"/' opensearch_dashboards.json
-          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' package.json
 
       - name: Bootstrap plugin/OpenSearch-Dashboards
         run: |

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -54,6 +54,8 @@ jobs:
           ref: ${{ env.SECURITY_ANALYTICS_BRANCH }}
 
       - name: Set up Gradle
+        # Currently, we only want to set up gradle when executing the tests on v3.0.
+        if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -82,9 +82,9 @@ jobs:
         if: ${{ env.OVERRIDE_REFERENCE != '' }}
         run: |
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          git checkout ${{ env.OVERRIDE_REFERENCE != '' }} opensearch_dashboards.json
-          git checkout ${{ env.OVERRIDE_REFERENCE != '' }} package.json
-          git checkout ${{ env.OVERRIDE_REFERENCE != '' }} yarn.lock
+          git checkout ${{ env.OVERRIDE_REFERENCE }} opensearch_dashboards.json
+          git checkout ${{ env.OVERRIDE_REFERENCE }} package.json
+          git checkout ${{ env.OVERRIDE_REFERENCE }} yarn.lock
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -12,12 +12,9 @@ env:
   SECURITY_ANALYTICS_BRANCH: '2.x'
   GRADLE_VERSION: '7.6.1'
 
-  # The 'Override Package Versions' job adjusts the 'version' attribute in the package.json and
-  # opensearch_dashboards.json files to the provided version (e.g., "2.8.0.0") if this variable is not empty.
-  OVERRIDE_PACKAGE_VERSION: '2.8.0.0'
-  # The 'Override Package Versions' job adjusts the 'opensearchDashboardsVersion' attribute in the
-  # opensearch_dashboards.json file to the provided version (e.g., "2.8.0") if this variable is not empty.
-  OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION: '2.8.0'
+  # If this variable is not empty, the package.json, opensearch_dashboards.json, and yarn.lock files will be replaced
+  # with those files from the 'opensearch-project/security-analytics-dashboards-plugin' branch or commit specified.
+  OVERRIDE_BRANCH: ''
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -54,8 +51,6 @@ jobs:
           ref: ${{ env.SECURITY_ANALYTICS_BRANCH }}
 
       - name: Set up Gradle
-        # Currently, we only want to set up gradle when executing the tests on v3.0.
-        if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
@@ -79,18 +74,17 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
 
-      # This job adjusts the 'version' and 'opensearchDashboardsVersion' attributes in the package.json and
-      # opensearch_dashboards.json file to the provided versions (e.g., "2.8.0.0", and "2.8.0" respectively)
-      # if those env variables are not empty.
+      # This job replaces the package.json, opensearch_dashboards.json, and yarn.lock files from the
+      # 'opensearch-project/security-analytics-dashboards-plugin' branch or commit specified in env variable.
       # This is most useful on the 'main' branch as it will enable us to specify which version to use for the build when
       # one of this package's dependencies is not building reliably without having to adjust the actual version of this package.
-      - name: Override Package Versions
-        if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
+      - name: Override Package Version
+        if: ${{ env.OVERRIDE_BRANCH != '' }}
         run: |
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' opensearch_dashboards.json
-          sed -i 's/"opensearchDashboardsVersion": "[^"]*"/"opensearchDashboardsVersion": "${{ env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION }}"/' opensearch_dashboards.json
-          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' package.json
+          git checkout ${{ env.OVERRIDE_BRANCH != '' }} opensearch_dashboards.json
+          git checkout ${{ env.OVERRIDE_BRANCH != '' }} package.json
+          git checkout ${{ env.OVERRIDE_BRANCH != '' }} yarn.lock
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -83,9 +83,9 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
           git fetch --all
-          git checkout ${{ env.OVERRIDE_REFERENCE }} opensearch_dashboards.json
-          git checkout ${{ env.OVERRIDE_REFERENCE }} package.json
-          git checkout ${{ env.OVERRIDE_REFERENCE }} yarn.lock
+          git checkout origin/${{ env.OVERRIDE_REFERENCE }} opensearch_dashboards.json
+          git checkout origin/${{ env.OVERRIDE_REFERENCE }} package.json
+          git checkout origin/${{ env.OVERRIDE_REFERENCE }} yarn.lock
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Override Package Versions
         if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
         run: |
+          cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
           sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' opensearch_dashboards.json
           sed -i 's/"opensearchDashboardsVersion": "[^"]*"/"opensearchDashboardsVersion": "${{ env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION }}"/' opensearch_dashboards.json
           sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' package.json

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,17 +7,17 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
-  SECURITY_ANALYTICS_BRANCH: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.8.0'
+  OPENSEARCH_VERSION: '2.8.0-SNAPSHOT'
+  SECURITY_ANALYTICS_BRANCH: '2.x'
   GRADLE_VERSION: '7.6.1'
 
   # The 'Override Package Versions' job adjusts the 'version' attribute in the package.json and
   # opensearch_dashboards.json files to the provided version (e.g., "2.8.0.0") if this variable is not empty.
-  OVERRIDE_PACKAGE_VERSION: ''
+  OVERRIDE_PACKAGE_VERSION: '2.8.0.0'
   # The 'Override Package Versions' job adjusts the 'opensearchDashboardsVersion' attribute in the
   # opensearch_dashboards.json file to the provided version (e.g., "2.8.0") if this variable is not empty.
-  OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION: ''
+  OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION: '2.8.0'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -97,7 +97,7 @@ jobs:
       # opensearch_dashboards.json file to the provided versions (e.g., "2.8.0.0", and "2.8.0" respectively)
       # if those env variables are not empty.
       # This is most useful on the 'main' branch as it will enable us to specify which version to use for the build when
-      # one of this package's dependencies is not building reliably.
+      # one of this package's dependencies is not building reliably without having to adjust the actual version of this package.
       - name: Override Package Versions
         if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
         run: |

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -14,7 +14,7 @@ env:
 
   # If this variable is not empty, the package.json, opensearch_dashboards.json, and yarn.lock files will be replaced
   # with those files from the 'opensearch-project/security-analytics-dashboards-plugin' branch or commit specified.
-  OVERRIDE_BRANCH: ''
+  OVERRIDE_REFERENCE: '2.8'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -79,12 +79,12 @@ jobs:
       # This is most useful on the 'main' branch as it will enable us to specify which version to use for the build when
       # one of this package's dependencies is not building reliably without having to adjust the actual version of this package.
       - name: Override Package Version
-        if: ${{ env.OVERRIDE_BRANCH != '' }}
+        if: ${{ env.OVERRIDE_REFERENCE != '' }}
         run: |
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          git checkout ${{ env.OVERRIDE_BRANCH != '' }} opensearch_dashboards.json
-          git checkout ${{ env.OVERRIDE_BRANCH != '' }} package.json
-          git checkout ${{ env.OVERRIDE_BRANCH != '' }} yarn.lock
+          git checkout ${{ env.OVERRIDE_REFERENCE != '' }} opensearch_dashboards.json
+          git checkout ${{ env.OVERRIDE_REFERENCE != '' }} package.json
+          git checkout ${{ env.OVERRIDE_REFERENCE != '' }} yarn.lock
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -11,6 +11,13 @@ env:
   OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
   SECURITY_ANALYTICS_BRANCH: 'main'
   GRADLE_VERSION: '7.6.1'
+
+  # The 'Override Package Versions' job adjusts the 'version' attribute in the package.json and
+  # opensearch_dashboards.json files to the provided version (e.g., "2.8.0.0") if this variable is not empty.
+  OVERRIDE_PACKAGE_VERSION: ''
+  # The 'Override Package Versions' job adjusts the 'opensearchDashboardsVersion' attribute in the
+  # opensearch_dashboards.json file to the provided version (e.g., "2.8.0") if this variable is not empty.
+  OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION: ''
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -85,6 +92,18 @@ jobs:
           npm i -g yarn@$YARN_VERSION
       - run: node -v
       - run: yarn -v
+
+      # This job adjusts the 'version' and 'opensearchDashboardsVersion' attributes in the package.json and
+      # opensearch_dashboards.json file to the provided versions (e.g., "2.8.0.0", and "2.8.0" respectively)
+      # if those env variables are not empty.
+      # This is most useful on the 'main' branch as it will enable us to specify which version to use for the build when
+      # one of this package's dependencies is not building reliably.
+      - name: Override Package Versions
+        if: ${{ env.OVERRIDE_PACKAGE_VERSION != '' && env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION != '' }}
+        run: |
+          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' opensearch_dashboards.json
+          sed -i 's/"opensearchDashboardsVersion": "[^"]*"/"opensearchDashboardsVersion": "${{ env.OVERRIDE_OPENSEARCH_DASHBOARDS_VERSION }}"/' opensearch_dashboards.json
+          sed -i 's/"version": "[^"]*"/"version": "${{ env.OVERRIDE_PACKAGE_VERSION }}"/' package.json
 
       - name: Bootstrap plugin/OpenSearch-Dashboards
         run: |

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -82,6 +82,7 @@ jobs:
         if: ${{ env.OVERRIDE_REFERENCE != '' }}
         run: |
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
+          git fetch --all
           git checkout ${{ env.OVERRIDE_REFERENCE }} opensearch_dashboards.json
           git checkout ${{ env.OVERRIDE_REFERENCE }} package.json
           git checkout ${{ env.OVERRIDE_REFERENCE }} yarn.lock


### PR DESCRIPTION
### Description
Updated the cypress workflow to support overriding the dependency versions.

This difference between this PR and PR https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/618 is this PR does not adjust the version of this package from `3.0.0`. This preserves the project [branching strategy](https://github.com/opensearch-project/opensearch-plugins/issues/142).

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).