### PR TITLE
Pass sortOrder and size params when getting findings and alerts

### DIFF
--- a/public/services/AlertsService.ts
+++ b/public/services/AlertsService.ts
@@ -23,14 +23,19 @@ export default class AlertsService {
     detectorParams: GetAlertsParams
   ): Promise<ServerResponse<GetAlertsResponse>> => {
     const { detectorType, detector_id } = detectorParams;
-    let query: GetAlertsParams | {} = {};
+    let query: GetAlertsParams | {} = {
+      sortOrder: 'desc',
+      size: 10000,
+    };
 
     if (detector_id) {
       query = {
+        ...query,
         detector_id,
       };
     } else if (detectorType) {
       query = {
+        ...query,
         detectorType,
       };
     }

--- a/public/services/FindingsService.ts
+++ b/public/services/FindingsService.ts
@@ -19,14 +19,19 @@ export default class FindingsService {
     detectorParams: GetFindingsParams
   ): Promise<ServerResponse<GetFindingsResponse>> => {
     const { detectorType, detectorId } = detectorParams;
-    let query: GetFindingsParams | {} = {};
+    let query: GetFindingsParams | {} = {
+      sortOrder: 'desc',
+      size: 10000,
+    };
 
     if (detectorId) {
       query = {
+        ...query,
         detectorId,
       };
     } else if (detectorType) {
       query = {
+        ...query,
         detectorType,
       };
     }

--- a/server/clusters/addAlertsMethods.ts
+++ b/server/clusters/addAlertsMethods.ts
@@ -8,10 +8,18 @@ import { METHOD_NAMES, API, BASE_API_PATH } from '../utils/constants';
 export function addAlertsMethods(securityAnalytics: any, createAction: any): void {
   securityAnalytics[METHOD_NAMES.GET_ALERTS] = createAction({
     url: {
-      fmt: `${API.GET_ALERTS}?detector_id=<%=detector_id%>`,
+      fmt: `${API.GET_ALERTS}?detector_id=<%=detector_id%>&sortOrder=<%=sortOrder%>&size=<%=size%>`,
       req: {
         detector_id: {
           type: 'string',
+          required: false,
+        },
+        sortOrder: {
+          type: 'string',
+          required: false,
+        },
+        size: {
+          type: 'number',
           required: false,
         },
       },

--- a/server/clusters/addFindingsMethods.ts
+++ b/server/clusters/addFindingsMethods.ts
@@ -8,10 +8,18 @@ import { METHOD_NAMES, API } from '../utils/constants';
 export function addFindingsMethods(securityAnalytics: any, createAction: any): void {
   securityAnalytics[METHOD_NAMES.GET_FINDINGS] = createAction({
     url: {
-      fmt: `${API.GET_FINDINGS}?detector_id=<%=detectorId%>`,
+      fmt: `${API.GET_FINDINGS}?detector_id=<%=detectorId%>&sortOrder=<%=sortOrder%>&size=<%=size%>`,
       req: {
         detectorId: {
           type: 'string',
+          required: false,
+        },
+        sortOrder: {
+          type: 'string',
+          required: false,
+        },
+        size: {
+          type: 'number',
           required: false,
         },
       },

--- a/server/models/interfaces/Alerts.ts
+++ b/server/models/interfaces/Alerts.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export type GetAlertsParams =
+export type GetAlertsParams = {
+  sortOrder?: string;
+  size?: number;
+} & (
   | {
       detector_id: string;
       detectorType?: string;
@@ -11,7 +14,8 @@ export type GetAlertsParams =
   | {
       detectorType: string;
       detector_id?: string;
-    };
+    }
+);
 
 export interface GetAlertsResponse {
   alerts: AlertResponse[];

--- a/server/models/interfaces/Findings.ts
+++ b/server/models/interfaces/Findings.ts
@@ -5,7 +5,10 @@
 
 import { Finding } from '../../../public/pages/Findings/models/interfaces';
 
-export type GetFindingsParams =
+export type GetFindingsParams = {
+  sortOrder?: string;
+  size?: number;
+} & (
   | {
       detectorId: string;
       detectorType?: string;
@@ -13,7 +16,8 @@ export type GetFindingsParams =
   | {
       detectorType: string;
       detectorId?: string;
-    };
+    }
+);
 
 export interface GetFindingsResponse {
   total_findings: number;

--- a/server/routes/AlertRoutes.ts
+++ b/server/routes/AlertRoutes.ts
@@ -18,6 +18,8 @@ export function setupAlertsRoutes(services: NodeServices, router: IRouter) {
         query: schema.object({
           detectorType: schema.maybe(schema.string()),
           detector_id: schema.maybe(schema.string()),
+          sortOrder: schema.maybe(schema.string()),
+          size: schema.maybe(schema.number()),
         }),
       },
     },

--- a/server/routes/FindingsRoutes.ts
+++ b/server/routes/FindingsRoutes.ts
@@ -18,6 +18,8 @@ export function setupFindingsRoutes(services: NodeServices, router: IRouter) {
         query: schema.object({
           detectorType: schema.maybe(schema.string()),
           detectorId: schema.maybe(schema.string()),
+          sortOrder: schema.maybe(schema.string()),
+          size: schema.maybe(schema.number()),
         }),
       },
     },

--- a/server/services/AlertService.ts
+++ b/server/services/AlertService.ts
@@ -36,15 +36,21 @@ export default class AlertService {
     response: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<ServerResponse<GetAlertsResponse> | ResponseError>> => {
     try {
-      const { detectorType, detector_id } = request.query;
+      const { detectorType, detector_id, sortOrder, size } = request.query;
+      const defaultParams = {
+        sortOrder,
+        size,
+      };
       let params: GetAlertsParams;
 
       if (detector_id) {
         params = {
+          ...defaultParams,
           detector_id,
         };
       } else if (detectorType) {
         params = {
+          ...defaultParams,
           detectorType,
         };
       } else {

--- a/server/services/FindingsService.ts
+++ b/server/services/FindingsService.ts
@@ -33,15 +33,21 @@ export default class FindingsService {
     IOpenSearchDashboardsResponse<ServerResponse<GetFindingsResponse> | ResponseError>
   > => {
     try {
-      const { detectorType, detectorId } = request.query;
+      const { detectorType, detectorId, sortOrder, size } = request.query;
+      const defaultParams = {
+        sortOrder,
+        size,
+      };
       let params: GetFindingsParams;
 
       if (detectorId) {
         params = {
+          ...defaultParams,
           detectorId,
         };
       } else if (detectorType) {
         params = {
+          ...defaultParams,
           detectorType,
         };
       } else {


### PR DESCRIPTION
### Description
We want to get all alerts and findings for a detector, so we are passing a high default number for size and sorting them in descending order by timestamp

### Issues Resolved
#664 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).