### PR TITLE
Make tags hyperlinks to mitre attack web pages in detection rules 

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,7 +9,7 @@ on:
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.9.0'
   OPENSEARCH_VERSION: '2.9.0-SNAPSHOT'
-  SECURITY_ANALYTICS_BRANCH: '2.x'
+  SECURITY_ANALYTICS_BRANCH: '2.9'
   GRADLE_VERSION: '7.6.1'
 
   # If this variable is not empty, the package.json, opensearch_dashboards.json, and yarn.lock files will be replaced

--- a/public/pages/Rules/components/RuleContentViewer/RuleContentViewer.tsx
+++ b/public/pages/Rules/components/RuleContentViewer/RuleContentViewer.tsx
@@ -129,11 +129,29 @@ export const RuleContentViewer: React.FC<RuleContentViewerProps> = ({
               gutterSize="s"
               data-test-subj={'rule_flyout_rule_tags'}
             >
-              {ruleData.tags.map((tag: any, i: number) => (
-                <EuiFlexItem grow={false} key={i}>
-                  <EuiBadge color={'#DDD'}>{tag.value}</EuiBadge>
-                </EuiFlexItem>
-              ))}
+              {ruleData.tags.map((tag: { value: string }, i: number) => {
+                const isLinkable = !!tag.value.match(/attack\.t[0-9]+/);
+                let tagComponent: React.ReactNode = tag.value;
+
+                if (isLinkable) {
+                  const link = `https://attack.mitre.org/techniques/${tag.value
+                    .split('.')
+                    .slice(1)
+                    .join('/')
+                    .toUpperCase()}`;
+                  tagComponent = (
+                    <EuiLink href={link} target="_blank">
+                      {tag.value}
+                    </EuiLink>
+                  );
+                }
+
+                return (
+                  <EuiFlexItem grow={false} key={i}>
+                    <EuiBadge color={'#DDD'}>{tagComponent}</EuiBadge>
+                  </EuiFlexItem>
+                );
+              })}
             </EuiFlexGroup>
           ) : (
             <div>{DEFAULT_EMPTY_DATA}</div>


### PR DESCRIPTION
### Description
Information about tags with `attack.T[0-9]+` pattern in a detection rule can be provided using the [Mitre](https://attack.mitre.org/) website. In this PR we detect such tags and make them hyperlinks so that users can learn more about the particular attack technique.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).