### PR TITLE
Updates to log types related UX

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,7 +9,7 @@ on:
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.9.0'
   OPENSEARCH_VERSION: '2.9.0-SNAPSHOT'
-  SECURITY_ANALYTICS_BRANCH: '2.x'
+  SECURITY_ANALYTICS_BRANCH: '2.9'
   GRADLE_VERSION: '7.6.1'
 
   # If this variable is not empty, the package.json, opensearch_dashboards.json, and yarn.lock files will be replaced

--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -115,6 +115,7 @@ const validatePendingFieldMappingsPanel = (mappings) => {
 const fillDetailsForm = (detectorName, dataSource) => {
   getNameField().type(detectorName);
   getDataSourceField().selectComboboxItem(dataSource);
+  getDataSourceField().blur();
   getLogTypeField().selectComboboxItem(cypressLogTypeDns);
   getLogTypeField().blur();
 };
@@ -371,7 +372,7 @@ describe('Detectors', () => {
       getDataSourceField().selectComboboxItem(cypressIndexWindows);
       getDataSourceField().focus().blur();
 
-      cy.get('.euiCallOut')
+      cy.get('[data-test-subj="define-detector-diff-log-types-warning"]')
         .should('be.visible')
         .contains(
           'To avoid issues with field mappings, we recommend creating separate detectors for different log types.'

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
@@ -9,6 +9,9 @@ import {
   EuiHorizontalRule,
   CriteriaWithPagination,
   EuiText,
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiIcon,
 } from '@elastic/eui';
 
 import React, { useMemo, useState } from 'react';
@@ -17,6 +20,7 @@ import { RuleItem, RuleItemInfo } from './types/interfaces';
 import { RuleViewerFlyout } from '../../../../../Rules/components/RuleViewerFlyout/RuleViewerFlyout';
 import { RuleTableItem } from '../../../../../Rules/utils/helpers';
 import { RuleItemInfoBase } from '../../../../../../../types';
+import { ROUTES } from '../../../../../../utils/constants';
 
 export interface CreateDetectorRulesState {
   allRules: RuleItemInfo[];
@@ -26,6 +30,7 @@ export interface CreateDetectorRulesState {
 }
 
 export interface DetectionRulesProps {
+  detectorType: string;
   rulesState: CreateDetectorRulesState;
   loading?: boolean;
   onRuleToggle: (changedItem: RuleItem, isActive: boolean) => void;
@@ -34,6 +39,7 @@ export interface DetectionRulesProps {
 }
 
 export const DetectionRules: React.FC<DetectionRulesProps> = ({
+  detectorType,
   rulesState,
   loading,
   onPageChange,
@@ -55,7 +61,7 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
         id: rule._id,
         active: rule.enabled,
         description: rule._source.description,
-        library: rule.prePackaged ? 'Sigma' : 'Custom',
+        library: rule.prePackaged ? 'Standard' : 'Custom',
         logType: rule._source.category,
         name: rule._source.title,
         severity: rule._source.level,
@@ -106,14 +112,42 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
         isLoading={loading}
       >
         <EuiHorizontalRule margin={'xs'} />
-        <DetectionRulesTable
-          pageIndex={rulesState.page.index}
-          ruleItems={ruleItems}
-          onAllRulesToggled={onAllRulesToggle}
-          onRuleActivationToggle={onRuleToggle}
-          onTableChange={onTableChange}
-          onRuleDetails={onRuleDetails}
-        />
+
+        {ruleItems.length ? (
+          <DetectionRulesTable
+            pageIndex={rulesState.page.index}
+            ruleItems={ruleItems}
+            onAllRulesToggled={onAllRulesToggle}
+            onRuleActivationToggle={onRuleToggle}
+            onTableChange={onTableChange}
+            onRuleDetails={onRuleDetails}
+          />
+        ) : (
+          <EuiEmptyPrompt
+            title={
+              <EuiTitle>
+                <h1>No detection rules {detectorType ? 'to display' : 'selected'}</h1>
+              </EuiTitle>
+            }
+            body={
+              <p>
+                {detectorType
+                  ? 'There are no applicable detection rules for the selected log type. Consider creating new detection rules.'
+                  : 'Select a log type to be able to select detection rules.'}
+              </p>
+            }
+            actions={
+              detectorType
+                ? [
+                    <EuiButton href={`#${ROUTES.RULES}`} target="_blank">
+                      Manage&nbsp;
+                      <EuiIcon type={'popout'} />
+                    </EuiButton>,
+                  ]
+                : undefined
+            }
+          />
+        )}
       </EuiAccordion>
     </>
   );

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
@@ -177,6 +177,7 @@ export default class DetectorDataSource extends Component<
             <EuiCallOut
               title="The selected log sources contain different log types"
               color="warning"
+              data-test-subj={'define-detector-diff-log-types-warning'}
             >
               <EuiTextColor color={'default'}>
                 To avoid issues with field mappings, we recommend creating separate detectors for

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
@@ -94,6 +94,7 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
 
         <EuiFormRow fullWidth={true}>
           <DetectionRules
+            detectorType={detectorType}
             rulesState={this.props.rulesState}
             loading={this.props.loadingRules}
             onPageChange={this.props.onPageChange}

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -63,7 +63,10 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
 
     this.state = {
       currentStep: DetectorCreationStep.DEFINE_DETECTOR,
-      detector: EMPTY_DEFAULT_DETECTOR,
+      detector: {
+        ...EMPTY_DEFAULT_DETECTOR,
+        detector_type: '',
+      },
       fieldMappings: [],
       stepDataValid: {
         [DetectorCreationStep.DEFINE_DETECTOR]: false,

--- a/public/pages/Detectors/components/DetectorRulesView/DetectorRulesView.tsx
+++ b/public/pages/Detectors/components/DetectorRulesView/DetectorRulesView.tsx
@@ -33,7 +33,7 @@ const mapRuleItemToRuleTableItem = (ruleItem: RuleItem): RuleTableItem => {
     description: ruleItem.description,
     source: ruleItem.library,
     ruleId: ruleItem.id,
-    ruleInfo: { ...ruleItem.ruleInfo, prePackaged: ruleItem.library === 'Sigma' },
+    ruleInfo: { ...ruleItem.ruleInfo, prePackaged: ruleItem.library === 'Standard' },
   };
 };
 

--- a/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
@@ -478,7 +478,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                       "name": "Source",
                       "options": Array [
                         Object {
-                          "value": "Sigma",
+                          "value": "Standard",
                         },
                         Object {
                           "value": "Custom",
@@ -587,7 +587,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                         "name": "Source",
                         "options": Array [
                           Object {
-                            "value": "Sigma",
+                            "value": "Standard",
                           },
                           Object {
                             "value": "Custom",
@@ -768,7 +768,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                   "name": "Source",
                                   "options": Array [
                                     Object {
-                                      "value": "Sigma",
+                                      "value": "Standard",
                                     },
                                     Object {
                                       "value": "Custom",
@@ -1115,7 +1115,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                       "name": "Source",
                                       "options": Array [
                                         Object {
-                                          "value": "Sigma",
+                                          "value": "Standard",
                                         },
                                         Object {
                                           "value": "Custom",

--- a/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
+++ b/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
@@ -97,7 +97,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
         id: rule._id,
         severity: rule._source.level,
         logType: rule._source.category,
-        library: 'Sigma',
+        library: 'Standard',
         description: rule._source.description,
         active: enabledRuleIds.includes(rule._id),
         ruleInfo: rule,
@@ -140,7 +140,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
           .filter((rule) => rule.active);
         await getRuleFieldsForEnabledRules(withCustomRulesUpdated);
         break;
-      case 'Sigma':
+      case 'Standard':
         const updatedPrePackgedRules: RuleItem[] = prePackagedRuleItems.map((rule) =>
           rule.id === changedItem.id ? { ...rule, active: isActive } : rule
         );

--- a/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
@@ -3032,7 +3032,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           "name": "Source",
                           "options": Array [
                             Object {
-                              "value": "Sigma",
+                              "value": "Standard",
                             },
                             Object {
                               "value": "Custom",
@@ -3141,7 +3141,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             "name": "Source",
                             "options": Array [
                               Object {
-                                "value": "Sigma",
+                                "value": "Standard",
                               },
                               Object {
                                 "value": "Custom",
@@ -3322,7 +3322,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                       "name": "Source",
                                       "options": Array [
                                         Object {
-                                          "value": "Sigma",
+                                          "value": "Standard",
                                         },
                                         Object {
                                           "value": "Custom",
@@ -3669,7 +3669,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                           "name": "Source",
                                           "options": Array [
                                             Object {
-                                              "value": "Sigma",
+                                              "value": "Standard",
                                             },
                                             Object {
                                               "value": "Custom",

--- a/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
@@ -1856,7 +1856,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                         "name": "Source",
                         "options": Array [
                           Object {
-                            "value": "Sigma",
+                            "value": "Standard",
                           },
                           Object {
                             "value": "Custom",
@@ -1965,7 +1965,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           "name": "Source",
                           "options": Array [
                             Object {
-                              "value": "Sigma",
+                              "value": "Standard",
                             },
                             Object {
                               "value": "Custom",
@@ -2146,7 +2146,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                     "name": "Source",
                                     "options": Array [
                                       Object {
-                                        "value": "Sigma",
+                                        "value": "Standard",
                                       },
                                       Object {
                                         "value": "Custom",
@@ -2493,7 +2493,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                         "name": "Source",
                                         "options": Array [
                                           Object {
-                                            "value": "Sigma",
+                                            "value": "Standard",
                                           },
                                           Object {
                                             "value": "Custom",

--- a/public/pages/LogTypes/components/LogTypeDetails.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetails.tsx
@@ -40,9 +40,10 @@ export const LogTypeDetails: React.FC<LogTypeDetailsProps> = ({
   return (
     <ContentPanel
       title="Details"
+      titleSize="l"
       actions={
         !isEditMode &&
-        logTypeDetails.source.toLocaleLowerCase() !== 'sigma' && [
+        logTypeDetails.source.toLocaleLowerCase() !== 'standard' && [
           <EuiButton onClick={() => setIsEditMode(true)}>Edit</EuiButton>,
         ]
       }

--- a/public/pages/LogTypes/components/LogTypeDetectionRules.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetectionRules.tsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { RulesTable } from '../../Rules/components/RulesTable/RulesTable';
 import { RuleTableItem } from '../../Rules/utils/helpers';
 import { ContentPanel } from '../../../components/ContentPanel';
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { RuleViewerFlyout } from '../../Rules/components/RuleViewerFlyout/RuleViewerFlyout';
 
 export interface LogTypeDetectionRulesProps {
   rules: RuleTableItem[];
@@ -20,34 +21,47 @@ export const LogTypeDetectionRules: React.FC<LogTypeDetectionRulesProps> = ({
   loadingRules,
   refreshRules,
 }) => {
+  const [flyoutData, setFlyoutData] = useState<RuleTableItem | undefined>(undefined);
+  const hideFlyout = useCallback(() => {
+    setFlyoutData(undefined);
+  }, []);
+
   return (
-    <ContentPanel
-      title="Detection rules"
-      hideHeaderBorder={true}
-      actions={[<EuiButton onClick={refreshRules}>Refresh</EuiButton>]}
-    >
-      {rules.length === 0 ? (
-        <EuiFlexGroup justifyContent="center" alignItems="center" direction="column">
-          <EuiFlexItem grow={false}>
-            <EuiText color="subdued">
-              <p>There are no detection rules associated with this log type. </p>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              href={`opensearch_security_analytics_dashboards#/create-rule`}
-              target="_blank"
-            >
-              Create detection rule&nbsp;
-              <EuiIcon type={'popout'} />
-            </EuiButton>
-            <EuiSpacer size="xl" />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ) : (
-        <RulesTable loading={loadingRules} ruleItems={rules} showRuleDetails={() => {}} />
-      )}
-    </ContentPanel>
+    <>
+      {flyoutData && <RuleViewerFlyout hideFlyout={hideFlyout} ruleTableItem={flyoutData} />}
+      <ContentPanel
+        title="Detection rules"
+        hideHeaderBorder={true}
+        actions={[<EuiButton onClick={refreshRules}>Refresh</EuiButton>]}
+      >
+        {rules.length === 0 ? (
+          <EuiFlexGroup justifyContent="center" alignItems="center" direction="column">
+            <EuiFlexItem grow={false}>
+              <EuiText color="subdued">
+                <p>There are no detection rules associated with this log type. </p>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                href={`opensearch_security_analytics_dashboards#/create-rule`}
+                target="_blank"
+              >
+                Create detection rule&nbsp;
+                <EuiIcon type={'popout'} />
+              </EuiButton>
+              <EuiSpacer size="xl" />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ) : (
+          <RulesTable
+            loading={loadingRules}
+            ruleItems={rules}
+            columnsToHide={['category']}
+            showRuleDetails={setFlyoutData}
+          />
+        )}
+      </ContentPanel>
+    </>
   );
 };

--- a/public/pages/LogTypes/components/LogTypeForm.tsx
+++ b/public/pages/LogTypes/components/LogTypeForm.tsx
@@ -89,7 +89,14 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
         />
       </EuiFormRow>
       <EuiSpacer />
-      <EuiFormRow label="Description">
+      <EuiFormRow
+        label={
+          <>
+            {'Description - '}
+            <em>optional</em>
+          </>
+        }
+      >
         <EuiTextArea
           value={logTypeDetails?.description}
           onChange={(e) => {

--- a/public/pages/LogTypes/containers/CreateLogType.tsx
+++ b/public/pages/LogTypes/containers/CreateLogType.tsx
@@ -44,7 +44,7 @@ export const CreateLogType: React.FC<CreateLogTypeProps> = ({ history, notificat
       <LogTypeForm
         logTypeDetails={{ ...logTypeDetails, id: '', detectionRulesCount: 0 }}
         isEditMode={true}
-        confirmButtonText={'Create rule category'}
+        confirmButtonText={'Create log type'}
         notifications={notifications}
         setLogTypeDetails={setLogTypeDetails}
         onCancel={() => history.push(ROUTES.LOG_TYPES)}

--- a/public/pages/LogTypes/containers/LogType.tsx
+++ b/public/pages/LogTypes/containers/LogType.tsx
@@ -66,7 +66,7 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
       level: rule._source.level,
       category: rule._source.category,
       description: rule._source.description,
-      source: rule.prePackaged ? 'Sigma' : 'Custom',
+      source: rule.prePackaged ? 'Standard' : 'Custom',
       ruleInfo: rule,
       ruleId: rule._id,
     }));
@@ -193,7 +193,13 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiDescriptionList
-              listItems={[{ title: 'Source', description: logTypeDetails.source }]}
+              listItems={[
+                {
+                  title: 'Source',
+                  description:
+                    logTypeDetails.source === 'Sigma' ? 'Standard' : logTypeDetails.source,
+                },
+              ]}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -214,6 +220,7 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
           );
         })}
       </EuiTabs>
+      <EuiSpacer size="m" />
       {renderTabContent()}
     </>
   );

--- a/public/pages/LogTypes/containers/LogTypes.tsx
+++ b/public/pages/LogTypes/containers/LogTypes.tsx
@@ -10,7 +10,7 @@ import { CoreServicesContext } from '../../../components/core_services';
 import { BREADCRUMBS, ROUTES } from '../../../utils/constants';
 import { LogType } from '../../../../types';
 import { DataStore } from '../../../store/DataStore';
-import { getLogTypesTableColumns } from '../utils/helpers';
+import { getLogTypesTableColumns, getLogTypesTableSearchConfig } from '../utils/helpers';
 import { RouteComponentProps } from 'react-router-dom';
 import { useCallback } from 'react';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -92,6 +92,7 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications }) =>
           pagination={{
             initialPageSize: 25,
           }}
+          search={getLogTypesTableSearchConfig()}
           sorting={true}
         />
       </ContentPanel>

--- a/public/pages/LogTypes/utils/helpers.tsx
+++ b/public/pages/LogTypes/utils/helpers.tsx
@@ -7,6 +7,8 @@ import React from 'react';
 import { EuiButtonIcon, EuiLink, EuiToolTip } from '@elastic/eui';
 import { LogType } from '../../../../types';
 import { capitalize } from 'lodash';
+import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
+import { ruleSource } from '../../Rules/utils/constants';
 
 export const getLogTypesTableColumns = (
   showDetails: (id: string) => void,
@@ -50,3 +52,23 @@ export const getLogTypesTableColumns = (
     ],
   },
 ];
+
+export const getLogTypesTableSearchConfig = (): Search => {
+  return {
+    box: {
+      placeholder: 'Search log types',
+      schema: true,
+    },
+    filters: [
+      {
+        type: 'field_value_selection',
+        field: 'source',
+        name: 'Source',
+        multiSelect: 'or',
+        options: ruleSource.map((source: string) => ({
+          value: source,
+        })),
+      },
+    ],
+  };
+};

--- a/public/pages/Rules/components/RuleContentViewer/RuleContentViewer.tsx
+++ b/public/pages/Rules/components/RuleContentViewer/RuleContentViewer.tsx
@@ -95,7 +95,7 @@ export const RuleContentViewer: React.FC<RuleContentViewerProps> = ({
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem data-test-subj={'rule_flyout_rule_source'}>
               <EuiFormLabel>Source</EuiFormLabel>
-              {prePackaged ? 'Sigma' : 'Custom'}
+              {prePackaged ? 'Standard' : 'Custom'}
             </EuiFlexItem>
             {prePackaged ? (
               <EuiFlexItem>

--- a/public/pages/Rules/components/RuleViewerFlyout/RuleViewFlyoutHeaderActions.tsx
+++ b/public/pages/Rules/components/RuleViewerFlyout/RuleViewFlyoutHeaderActions.tsx
@@ -25,7 +25,7 @@ export const RuleViewerFlyoutHeaderActions: React.FC<RuleViewerFlyoutHeaderActio
   editRule,
   toggleActionsPopover,
 }) => {
-  return ruleSource === 'Sigma' ? (
+  return ruleSource === 'Standard' ? (
     <EuiButton onClick={duplicateRule}>Duplicate</EuiButton>
   ) : (
     <EuiPopover

--- a/public/pages/Rules/components/RulesTable/RulesTable.tsx
+++ b/public/pages/Rules/components/RulesTable/RulesTable.tsx
@@ -10,21 +10,28 @@ import {
   RuleTableItem,
 } from '../../utils/helpers';
 import { CriteriaWithPagination, EuiInMemoryTable } from '@elastic/eui';
+import { RulesTableColumnFields } from '../../../../../types';
 
 export interface RulesTableProps {
   ruleItems: RuleTableItem[];
   loading: boolean;
+  columnsToHide?: RulesTableColumnFields[];
   showRuleDetails: (ruleItem: RuleTableItem) => void;
 }
 
-export const RulesTable: React.FC<RulesTableProps> = ({ ruleItems, loading, showRuleDetails }) => {
+export const RulesTable: React.FC<RulesTableProps> = ({
+  columnsToHide,
+  ruleItems,
+  loading,
+  showRuleDetails,
+}) => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
 
   return (
     <EuiInMemoryTable
       loading={loading}
       items={ruleItems}
-      columns={getRulesTableColumns(showRuleDetails)}
+      columns={getRulesTableColumns(showRuleDetails, columnsToHide)}
       search={getRulesTableSearchConfig()}
       pagination={{ ...pagination, pageSizeOptions: [10, 25, 50] }}
       onTableChange={(nextValues: CriteriaWithPagination<any>) =>

--- a/public/pages/Rules/containers/Rules/Rules.tsx
+++ b/public/pages/Rules/containers/Rules/Rules.tsx
@@ -34,7 +34,7 @@ export const Rules: React.FC<RulesProps> = (props) => {
       level: rule._source.level,
       category: rule._source.category,
       description: rule._source.description,
-      source: rule.prePackaged ? 'Sigma' : 'Custom',
+      source: rule.prePackaged ? 'Standard' : 'Custom',
       ruleInfo: rule,
       ruleId: rule._id,
     }));

--- a/public/pages/Rules/utils/constants.ts
+++ b/public/pages/Rules/utils/constants.ts
@@ -47,6 +47,6 @@ export const ruleSeverity: {
   },
 ];
 
-export const ruleSource: string[] = ['Sigma', 'Custom'];
+export const ruleSource: string[] = ['Standard', 'Custom'];
 
 export const ruleStatus: string[] = ['experimental', 'test', 'stable'];

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -13,7 +13,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { AUTHOR_REGEX, validateDescription, validateName } from '../../../utils/validation';
 import { dump, load } from 'js-yaml';
 import { BREADCRUMBS, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
-import { RuleItemInfoBase } from '../../../../types';
+import { RuleItemInfoBase, RulesTableColumnFields } from '../../../../types';
 
 export interface RuleTableItem {
   title: string;
@@ -26,10 +26,12 @@ export interface RuleTableItem {
 }
 
 export const getRulesTableColumns = (
-  showRuleDetails: (rule: RuleTableItem) => void
+  showRuleDetails: (rule: RuleTableItem) => void,
+  columnsToHide: RulesTableColumnFields[] = []
 ): EuiBasicTableColumn<RuleTableItem>[] => {
-  return [
-    {
+  const fields: RulesTableColumnFields[] = ['title', 'level', 'category', 'source', 'description'];
+  const tableColumnByField: { [field: string]: EuiBasicTableColumn<RuleTableItem> } = {
+    title: {
       field: 'title',
       name: 'Rule name',
       sortable: true,
@@ -41,7 +43,7 @@ export const getRulesTableColumns = (
         </EuiLink>
       ),
     },
-    {
+    level: {
       field: 'level',
       name: 'Rule Severity',
       sortable: true,
@@ -49,7 +51,7 @@ export const getRulesTableColumns = (
       truncateText: true,
       render: (level: string) => capitalizeFirstLetter(level),
     },
-    {
+    category: {
       field: 'category',
       name: 'Log type',
       sortable: true,
@@ -59,20 +61,30 @@ export const getRulesTableColumns = (
         ruleTypes.find((ruleType) => ruleType.label.toLowerCase() === category)?.label ||
         DEFAULT_EMPTY_DATA,
     },
-    {
+    source: {
       field: 'source',
       name: 'Source',
       sortable: true,
       width: '10%',
       truncateText: true,
     },
-    {
+    description: {
       field: 'description',
       name: 'Description',
       sortable: false,
       truncateText: true,
     },
-  ];
+  };
+
+  const columns: EuiBasicTableColumn<RuleTableItem>[] = [];
+
+  fields.forEach((field) => {
+    if (!columnsToHide.includes(field)) {
+      columns.push(tableColumnByField[field]);
+    }
+  });
+
+  return columns;
 };
 
 export const getRulesTableSearchConfig = (): Search => {

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiBreadcrumb, EuiLink } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiBreadcrumb, EuiLink, EuiBadge } from '@elastic/eui';
 import React from 'react';
-import { capitalizeFirstLetter, errorNotificationToast } from '../../../utils/helpers';
+import { errorNotificationToast } from '../../../utils/helpers';
 import { ruleSeverity, ruleSource, ruleTypes } from './constants';
 import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
 import { Rule } from '../../../../models/interfaces';
@@ -14,6 +14,7 @@ import { AUTHOR_REGEX, validateDescription, validateName } from '../../../utils/
 import { dump, load } from 'js-yaml';
 import { BREADCRUMBS, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { RuleItemInfoBase, RulesTableColumnFields } from '../../../../types';
+import { getSeverityColor, getSeverityLabel } from '../../Correlations/utils/constants';
 
 export interface RuleTableItem {
   title: string;
@@ -49,7 +50,14 @@ export const getRulesTableColumns = (
       sortable: true,
       width: '10%',
       truncateText: true,
-      render: (level: string) => capitalizeFirstLetter(level),
+      render: (level: string) => {
+        const { text, background } = getSeverityColor(level);
+        return (
+          <EuiBadge style={{ color: text }} color={background}>
+            {getSeverityLabel(level)}
+          </EuiBadge>
+        );
+      },
     },
     category: {
       field: 'category',

--- a/public/store/LogTypeStore.ts
+++ b/public/store/LogTypeStore.ts
@@ -45,17 +45,22 @@ export class LogTypeStore {
         return {
           id: hit._id,
           ...hit._source,
+          source: hit._source.source.toLowerCase() === 'sigma' ? 'Standard' : hit._source.source,
         };
       });
 
       ruleTypes.splice(
         0,
         ruleTypes.length,
-        ...logTypes.map((logType) => ({
-          label: logType.name,
-          value: logType.name,
-          id: logType.id,
-        }))
+        ...logTypes
+          .map((logType) => ({
+            label: logType.name,
+            value: logType.name,
+            id: logType.id,
+          }))
+          .sort((a, b) => {
+            return a.label < b.label ? -1 : a.label > b.label ? 1 : 0;
+          })
       );
 
       return logTypes;

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -119,7 +119,7 @@ export function ruleItemInfosToItems(
       id: itemInfo._id,
       active: itemInfo.enabled,
       description: itemInfo._source.description,
-      library: itemInfo.prePackaged ? 'Sigma' : 'Custom',
+      library: itemInfo.prePackaged ? 'Standard' : 'Custom',
       logType: detectorType.toLowerCase(),
       name: itemInfo._source.title,
       severity: itemInfo._source.level,

--- a/types/Rule.ts
+++ b/types/Rule.ts
@@ -123,3 +123,5 @@ export interface IRulesStore {
 
   getCustomRules: (terms?: { [key: string]: string[] }) => Promise<RuleItemInfoBase[]>;
 }
+
+export type RulesTableColumnFields = 'title' | 'level' | 'category' | 'source' | 'description';


### PR DESCRIPTION
### Description
In this PR we have updated the UX related to log types to make below changes:
- Sort log type options in dropdowns
- Use empty prompt component to show empty states of Detection rules associated with log type in Create Detector flow
- Mark description as optional for log type
- Change the term `Sigma` used for pre-packaged detection rules to `Standard`

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).