### PR TITLE
[2.10] Added check for empty action

### DIFF
--- a/public/pages/Detectors/components/AlertTriggerView/AlertTriggerView.tsx
+++ b/public/pages/Detectors/components/AlertTriggerView/AlertTriggerView.tsx
@@ -37,9 +37,9 @@ export const AlertTriggerView: React.FC<AlertTriggerViewProps> = ({
   const { name, sev_levels, types, tags, ids, severity, actions } = alertTrigger;
   const alertSeverity = parseAlertSeverityToOption(severity)?.label || DEFAULT_EMPTY_DATA;
   const action = actions[0];
-  const notificationChannelId = detector.triggers[orderPosition].actions[0].destination_id;
+  const notificationChannelId = detector.triggers[orderPosition]?.actions[0]?.destination_id;
   const notificationChannel = notificationChannels.find(
-    (channel) => channel.config_id === notificationChannelId
+    (channel) => !!notificationChannelId && channel.config_id === notificationChannelId
   );
   const conditionRuleNames = ids.map((ruleId) => rules[ruleId]?._source.title);
   return (


### PR DESCRIPTION
### Description
If user creates a detector without action using APIs, UX fails to render the detector correctly. This PR adds a check for empty action and renders a default empty state.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).