### PR TITLE
Minor UI updates for correlations page

### DIFF
--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -469,7 +469,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
               />
               <EuiSpacer />
               <EuiTitle size="xs">
-                <p>Correlated Findings()</p>
+                <p>Correlated Findings ({findingCardsData.correlatedFindings.length})</p>
               </EuiTitle>
               <EuiText color="subdued" size="xs">
                 Higher correlation score indicated stronger correlation.

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -219,13 +219,14 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
       return;
     }
 
+    this.setState({ loadingGraphData: true });
     const allFindings = await DataStore.correlations.fetchAllFindings();
     const detectorType = allFindings[findingId].logType;
     const correlations = await DataStore.correlations.getCorrelatedFindings(
       findingId,
       detectorType
     );
-    this.setState({ specificFindingInfo: correlations });
+    this.setState({ specificFindingInfo: correlations, loadingGraphData: false });
     this.updateGraphDataState(correlations);
   };
 

--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -271,7 +271,7 @@ export class CorrelationsStore implements ICorrelationsStore {
       const correlatedFindings = response.response.findings.map((f) => {
         return {
           ...allFindings[f.finding],
-          correlationScore: f.score.toExponential(2),
+          correlationScore: f.score < 0.01 ? '0.01' : f.score.toFixed(2),
         };
       });
       return {


### PR DESCRIPTION
### Description
- Shows correlation score as regular number with upto 2 fractional digits
- Shows number of correlated findings in the panel on right
- Show loading state on node click in correlations graph since it takes some time to load the data

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).