### PR TITLE
Omit field from mapping payload if it matches index field; Abort detector creation when mapping has failed

### DIFF
--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -30,6 +30,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { getPlugins } from '../../../utils/helpers';
 import { Detector, DetectorCreationStep } from '../../../../types';
 import { DataStore } from '../../../store/DataStore';
+import { errorNotificationToast } from '../../../utils/helpers';
 
 interface CreateDetectorProps extends RouteComponentProps {
   isEdit: boolean;
@@ -107,7 +108,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
     this.setState({ fieldMappings });
   };
 
-  onCreateClick = () => {
+  onCreateClick = async () => {
     const { creatingDetector, detector, fieldMappings } = this.state;
     if (creatingDetector) {
       return;
@@ -120,6 +121,19 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
       detector.detector_type,
       fieldMappings
     );
+
+    const fieldMappingRes = await fieldsMappingPromise;
+
+    if (!fieldMappingRes.ok) {
+      errorNotificationToast(
+        this.props.notifications,
+        'create',
+        'detector',
+        'Invalid field mappings.'
+      );
+      this.setState({ creatingDetector: false });
+      return;
+    }
 
     const createDetectorPromise = this.props.services.detectorsService.createDetector(detector);
 

--- a/public/services/FieldMappingService.ts
+++ b/public/services/FieldMappingService.ts
@@ -43,6 +43,10 @@ export default class FieldMappingService {
       properties: {},
     };
     fieldMappings.forEach((mapping) => {
+      if (mapping.ruleFieldName === mapping.indexFieldName) {
+        return;
+      }
+
       alias_mappings.properties[mapping.ruleFieldName] = {
         type: 'alias',
         path: mapping.indexFieldName,


### PR DESCRIPTION
### Description
In this PR we have updated two behaviors:
1. A fix was made as part of https://github.com/opensearch-project/security-analytics/pull/652 where rule fields that match with index fields are now shown as part of automatic mappings in the `view mappings` API. However, a field cannot be mapped backed to itself in an index i.e. an alias name cannot be same as the index field name, so as part of create mapping API payload we should omit the automatically mapped field that matched an index field.
2. If `create mapping` fails when user hits Create Detector, then we should abort the creation altogether. This behavior was regressed in an earlier version. This PR fixes that.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).