### PR TITLE
Added null check for threat intel alias fields

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -250,7 +250,7 @@ export default class ConfigureFieldMapping extends Component<
             mappingsView.response.properties[ruleFieldName].path;
         });
         let threatIntelFeedFields = new Set();
-        mappingsView.response.threat_intel_field_aliases.forEach(({ fields }) => {
+        mappingsView.response.threat_intel_field_aliases?.forEach(({ fields }) => {
           fields.forEach((field) => threatIntelFeedFields.add(field));
         });
         mappingsView.response.unmapped_field_aliases?.forEach((ruleFieldName) => {

--- a/server/models/interfaces/FieldMappings.ts
+++ b/server/models/interfaces/FieldMappings.ts
@@ -11,7 +11,7 @@ export interface GetFieldMapingsViewParams {
 export interface GetFieldMappingViewResponse extends FieldMappingPropertyMap {
   unmapped_index_fields?: string[];
   unmapped_field_aliases?: string[];
-  threat_intel_field_aliases: { ioc: string; fields: string[] }[];
+  threat_intel_field_aliases?: { ioc: string; fields: string[] }[];
 }
 
 export interface CreateMappingsParams {


### PR DESCRIPTION
### Description
In the view mappings API response, `threat_intel_field_aliases` array could be undefined which could fail the get mappings method of Configure field mappings. This PR ensures we have a null check in place to avoid the silent crash

### Issues Resolved
#790 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).