### PR TITLE
[2.9] Use log type name as value in detection rule

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.9'
 jobs:
   tests:
     name: Run unit tests

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -76,9 +76,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
   const refreshLogTypeOptions = useCallback(async () => {
     const logTypes = await DataStore.logTypes.getLogTypes();
-    setLogTypeOptions(
-      logTypes.map(({ id, name }) => ({ value: id, label: getLogTypeLabel(name) }))
-    );
+    setLogTypeOptions(logTypes.map(({ name }) => ({ value: name, label: getLogTypeLabel(name) })));
   }, []);
 
   const validateTags = (fields: string[]) => {


### PR DESCRIPTION
### Description
For detection rule creation, when an option is selected from the log type dropdown the value associated with the option is the id of the log type object but it should be name instead since rules require log type name in the backend and users should see the correct label when the option gets selected.

### Issues Resolved
#793 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).