### PR TITLE
Make notifications optional

### DIFF
--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -237,139 +237,139 @@ describe('Detectors', () => {
     }).should('have.property', 'status', 200);
   });
 
-  // describe('...should validate form fields', () => {
-  //   beforeEach(() => {
-  //     cy.intercept('/_plugins/_security_analytics/detectors/_search').as('detectorsSearch');
+  describe('...should validate form fields', () => {
+    beforeEach(() => {
+      cy.intercept('/_plugins/_security_analytics/detectors/_search').as('detectorsSearch');
 
-  //     // Visit Detectors page before any test
-  //     cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
-  //     cy.wait('@detectorsSearch').should('have.property', 'state', 'Complete');
+      // Visit Detectors page before any test
+      cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
+      cy.wait('@detectorsSearch').should('have.property', 'state', 'Complete');
 
-  //     openCreateForm();
-  //   });
+      openCreateForm();
+    });
 
-  //   it('...should validate name field', () => {
-  //     getNameField().should('be.empty');
-  //     getNameField().focus().blur();
-  //     getNameField().parentsUntil('.euiFormRow__fieldWrapper').siblings().contains('Enter a name.');
+    it('...should validate name field', () => {
+      getNameField().should('be.empty');
+      getNameField().focus().blur();
+      getNameField().parentsUntil('.euiFormRow__fieldWrapper').siblings().contains('Enter a name.');
 
-  //     getNameField().type('text').focus().blur();
+      getNameField().type('text').focus().blur();
 
-  //     getNameField()
-  //       .parents('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .contains(
-  //         'Name should only consist of upper and lowercase letters, numbers 0-9, hyphens, spaces, and underscores. Use between 5 and 50 characters.'
-  //       );
+      getNameField()
+        .parents('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .contains(
+          'Name should only consist of upper and lowercase letters, numbers 0-9, hyphens, spaces, and underscores. Use between 5 and 50 characters.'
+        );
 
-  //     getNameField().type('{selectall}').type('{backspace}').type('tex&').focus().blur();
+      getNameField().type('{selectall}').type('{backspace}').type('tex&').focus().blur();
 
-  //     getNameField()
-  //       .parents('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .contains(
-  //         'Name should only consist of upper and lowercase letters, numbers 0-9, hyphens, spaces, and underscores. Use between 5 and 50 characters.'
-  //       );
+      getNameField()
+        .parents('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .contains(
+          'Name should only consist of upper and lowercase letters, numbers 0-9, hyphens, spaces, and underscores. Use between 5 and 50 characters.'
+        );
 
-  //     getNameField()
-  //       .type('{selectall}')
-  //       .type('{backspace}')
-  //       .type('Detector name')
-  //       .focus()
-  //       .blur()
-  //       .parents('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .should('not.exist');
-  //   });
+      getNameField()
+        .type('{selectall}')
+        .type('{backspace}')
+        .type('Detector name')
+        .focus()
+        .blur()
+        .parents('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .should('not.exist');
+    });
 
-  //   it('...should validate description field', () => {
-  //     const longDescriptionText =
-  //       'This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text.';
+    it('...should validate description field', () => {
+      const longDescriptionText =
+        'This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text. This is a long text.';
 
-  //     getDescriptionField().should('be.empty');
+      getDescriptionField().should('be.empty');
 
-  //     getDescriptionField().type(longDescriptionText).focus().blur();
+      getDescriptionField().type(longDescriptionText).focus().blur();
 
-  //     getDescriptionField()
-  //       .parents('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .contains(
-  //         'Description should only consist of upper and lowercase letters, numbers 0-9, commas, hyphens, periods, spaces, and underscores. Max limit of 500 characters.'
-  //       );
+      getDescriptionField()
+        .parents('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .contains(
+          'Description should only consist of upper and lowercase letters, numbers 0-9, commas, hyphens, periods, spaces, and underscores. Max limit of 500 characters.'
+        );
 
-  //     getDescriptionField()
-  //       .type('{selectall}')
-  //       .type('{backspace}')
-  //       .type('Detector description...')
-  //       .focus()
-  //       .blur();
+      getDescriptionField()
+        .type('{selectall}')
+        .type('{backspace}')
+        .type('Detector description...')
+        .focus()
+        .blur();
 
-  //     getDescriptionField()
-  //       .type('{selectall}')
-  //       .type('{backspace}')
-  //       .type('Detector name')
-  //       .focus()
-  //       .blur()
-  //       .parents('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .should('not.exist');
-  //   });
+      getDescriptionField()
+        .type('{selectall}')
+        .type('{backspace}')
+        .type('Detector name')
+        .focus()
+        .blur()
+        .parents('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .should('not.exist');
+    });
 
-  //   it('...should validate data source field', () => {
-  //     getDataSourceField()
-  //       .focus()
-  //       .blur()
-  //       .parentsUntil('.euiFormRow__fieldWrapper')
-  //       .siblings()
-  //       .contains('Select an input source.');
+    it('...should validate data source field', () => {
+      getDataSourceField()
+        .focus()
+        .blur()
+        .parentsUntil('.euiFormRow__fieldWrapper')
+        .siblings()
+        .contains('Select an input source.');
 
-  //     getDataSourceField().selectComboboxItem(cypressIndexDns);
-  //     getDataSourceField()
-  //       .focus()
-  //       .blur()
-  //       .parentsUntil('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .should('not.exist');
-  //   });
+      getDataSourceField().selectComboboxItem(cypressIndexDns);
+      getDataSourceField()
+        .focus()
+        .blur()
+        .parentsUntil('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .should('not.exist');
+    });
 
-  //   it('...should validate next button', () => {
-  //     getNextButton().should('be.disabled');
+    it('...should validate next button', () => {
+      getNextButton().should('be.disabled');
 
-  //     fillDetailsForm(detectorName, cypressIndexDns);
-  //     getNextButton().should('be.enabled');
-  //   });
+      fillDetailsForm(detectorName, cypressIndexDns);
+      getNextButton().should('be.enabled');
+    });
 
-  //   it('...should validate alerts page', () => {
-  //     fillDetailsForm(detectorName, cypressIndexDns);
-  //     getNextButton().click({ force: true });
-  //     // Open the trigger details accordion
-  //     cy.get('[data-test-subj="trigger-details-btn"]').click({ force: true });
-  //     getTriggerNameField().should('have.value', 'Trigger 1');
-  //     getTriggerNameField()
-  //       .parents('.euiFormRow__fieldWrapper')
-  //       .find('.euiFormErrorText')
-  //       .should('not.exist');
+    it('...should validate alerts page', () => {
+      fillDetailsForm(detectorName, cypressIndexDns);
+      getNextButton().click({ force: true });
+      // Open the trigger details accordion
+      cy.get('[data-test-subj="trigger-details-btn"]').click({ force: true });
+      getTriggerNameField().should('have.value', 'Trigger 1');
+      getTriggerNameField()
+        .parents('.euiFormRow__fieldWrapper')
+        .find('.euiFormErrorText')
+        .should('not.exist');
 
-  //     getTriggerNameField().type('{selectall}').type('{backspace}').focus().blur();
-  //     getCreateDetectorButton().should('be.disabled');
+      getTriggerNameField().type('{selectall}').type('{backspace}').focus().blur();
+      getCreateDetectorButton().should('be.disabled');
 
-  //     cy.getButtonByText('Remove').click({ force: true });
-  //     getCreateDetectorButton().should('be.enabled');
-  //   });
+      cy.getButtonByText('Remove').click({ force: true });
+      getCreateDetectorButton().should('be.enabled');
+    });
 
-  //   it('...should show mappings warning', () => {
-  //     fillDetailsForm(detectorName, cypressIndexDns);
+    it('...should show mappings warning', () => {
+      fillDetailsForm(detectorName, cypressIndexDns);
 
-  //     getDataSourceField().selectComboboxItem(cypressIndexWindows);
-  //     getDataSourceField().focus().blur();
+      getDataSourceField().selectComboboxItem(cypressIndexWindows);
+      getDataSourceField().focus().blur();
 
-  //     cy.get('[data-test-subj="define-detector-diff-log-types-warning"]')
-  //       .should('be.visible')
-  //       .contains(
-  //         'To avoid issues with field mappings, we recommend creating separate detectors for different log types.'
-  //       );
-  //   });
-  // });
+      cy.get('[data-test-subj="define-detector-diff-log-types-warning"]')
+        .should('be.visible')
+        .contains(
+          'To avoid issues with field mappings, we recommend creating separate detectors for different log types.'
+        );
+    });
+  });
 
   describe('...validate create detector flow', () => {
     beforeEach(() => {

--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -16,7 +16,6 @@ const cypressIndexDns = 'cypress-index-dns';
 const cypressIndexWindows = 'cypress-index-windows';
 const detectorName = 'test detector';
 const cypressLogTypeDns = 'dns';
-const sampleNotificationChannel = 'sample_chime_channel';
 const creationFailedMessage = 'Create detector failed.';
 
 const cypressDNSRule = dns_name_rule_data.title;
@@ -42,10 +41,6 @@ const getDataSourceField = () => cy.getFieldByLabel(dataSourceLabel);
 const logTypeLabel = 'Log type';
 
 const getLogTypeField = () => cy.getFieldByLabel(logTypeLabel);
-
-const notificationLabel = 'Notification channel';
-
-const getNotificationField = () => cy.getFieldByLabel(notificationLabel);
 
 const openDetectorDetails = (detectorName) => {
   cy.getInputByPlaceholder('Search threat detectors').type(`${detectorName}`).pressEnterKey();
@@ -156,8 +151,6 @@ const createDetector = (detectorName, dataSource, expectFailure) => {
     .focus()
     .blur();
 
-  getNotificationField().selectComboboxItem(`[Channel] ${sampleNotificationChannel}`);
-
   cy.intercept('POST', '/_plugins/_security_analytics/mappings').as('createMappingsRequest');
   cy.intercept('POST', '/_plugins/_security_analytics/detectors').as('createDetectorRequest');
 
@@ -221,20 +214,6 @@ describe('Detectors', () => {
 
     cy.createRule(dns_name_rule_data);
     cy.createRule(dns_type_rule_data);
-
-    cy.request('POST', 'http://localhost:9200/_plugins/_notifications/configs/', {
-      config_id: 'sa_notification-channel_id',
-      name: sampleNotificationChannel,
-      config: {
-        name: sampleNotificationChannel,
-        description: 'This is a sample chime channel',
-        config_type: 'chime',
-        is_enabled: true,
-        chime: {
-          url: 'https://sample-chime-webhook',
-        },
-      },
-    }).should('have.property', 'status', 200);
   });
 
   describe('...should validate form fields', () => {
@@ -515,9 +494,5 @@ describe('Detectors', () => {
 
   after(() => {
     cy.cleanUpTests();
-    cy.request(
-      'DELETE',
-      'http://localhost:9200/_plugins/_notifications/configs/sa_notification-channel_id'
-    );
   });
 });

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -56,7 +56,6 @@ interface AlertConditionPanelState {
   showNotificationDetails: boolean;
   detectionRulesTriggerEnabled: boolean;
   threatIntelTriggerEnabled: boolean;
-  notificationError: string;
 }
 
 export default class AlertConditionPanel extends Component<
@@ -73,7 +72,6 @@ export default class AlertConditionPanel extends Component<
       showNotificationDetails: true,
       detectionRulesTriggerEnabled: props.alertCondition.detection_types.includes('rules'),
       threatIntelTriggerEnabled: props.alertCondition.detection_types.includes('threat_intel'),
-      notificationError: '',
     };
   }
 
@@ -211,7 +209,6 @@ export default class AlertConditionPanel extends Component<
     const actions = alertCondition.actions;
     if (selectedOptions.length > 0) {
       actions[0].destination_id = selectedOptions[0].value!;
-      this.setState({ notificationError: '' });
     } else {
       actions[0].destination_id = '';
     }
@@ -291,7 +288,6 @@ export default class AlertConditionPanel extends Component<
       showNotificationDetails,
       detectionRulesTriggerEnabled,
       threatIntelTriggerEnabled,
-      notificationError,
     } = this.state;
     const { name, sev_levels: ruleSeverityLevels, tags, severity } = alertCondition;
     const uniqueTagsOptions = new Set(
@@ -537,7 +533,7 @@ export default class AlertConditionPanel extends Component<
 
             <EuiSpacer size={'l'} />
 
-            <EuiFlexGroup alignItems={notificationError ? 'center' : 'flexEnd'}>
+            <EuiFlexGroup alignItems={'flexEnd'}>
               <EuiFlexItem style={{ maxWidth: 400 }}>
                 <EuiFormRow
                   label={
@@ -545,8 +541,6 @@ export default class AlertConditionPanel extends Component<
                       <p>Notification channel</p>
                     </EuiText>
                   }
-                  isInvalid={!!notificationError}
-                  error={notificationError}
                 >
                   <EuiComboBox
                     placeholder={'Select notification channel.'}
@@ -559,13 +553,6 @@ export default class AlertConditionPanel extends Component<
                     onChange={this.onNotificationChannelsChange}
                     singleSelection={{ asPlainText: true }}
                     onFocus={refreshNotificationChannels}
-                    onBlur={(_e) => {
-                      this.setState({
-                        notificationError: selectedNotificationChannelOption.length
-                          ? ''
-                          : 'Notification channel is required',
-                      });
-                    }}
                     isDisabled={!hasNotificationPlugin}
                   />
                 </EuiFormRow>

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
@@ -570,7 +570,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -1402,7 +1401,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -53,9 +53,7 @@ const isTriggerValid = (triggers: AlertCondition[], hasNotificationPlugin: boole
         !!trigger.name &&
         validateName(trigger.name) &&
         trigger.severity &&
-        trigger.detection_types.length &&
-        (!hasNotificationPlugin ||
-          (hasNotificationPlugin && trigger.actions.every((action) => !!action.destination_id)))
+        trigger.detection_types.length
       );
     })
   );


### PR DESCRIPTION
### Description
Forward porting changes from #770 to keep Notifications optional in detector creation workflow since there is a possibility that Notification backend plugin exists but not the frontend plugin in which case the user won't be able to create a channel and thus cannot create a detector

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).