### PR TITLE
Separated fields for every index in correlation rule creation/update

### DIFF
--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -61,7 +61,9 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
 ) => {
   const correlationStore = DataStore.correlations;
   const [indices, setIndices] = useState<CorrelationOptions[]>([]);
-  const [logFields, setLogFields] = useState<CorrelationOptions[]>([]);
+  const [logFieldsByIndex, setLogFieldsByIndex] = useState<{
+    [index: string]: CorrelationOptions[];
+  }>({});
   const validateCorrelationRule = useCallback((rule: CorrelationRuleModel) => {
     if (!rule.name) {
       return 'Invalid rule name';
@@ -128,6 +130,12 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
     setupLogTypeOptions();
   }, []);
 
+  useEffect(() => {
+    initialValues.queries.forEach(({ index }) => {
+      updateLogFieldsForIndex(index);
+    });
+  }, [initialValues]);
+
   const submit = async (values: any) => {
     let error;
     if ((error = validateCorrelationRule(values))) {
@@ -172,23 +180,39 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
 
   const getLogFields = useCallback(
     async (indexName: string) => {
+      let fields: {
+        label: string;
+        value: string;
+      }[] = [];
+
       if (indexName) {
         const result = await props.indexService.getIndexFields(indexName);
         if (result?.ok) {
-          let fields: {
-            label: string;
-            value: string;
-          }[] = result.response?.map((field) => ({
+          fields = result.response?.map((field) => ({
             label: field,
             value: field,
           }));
-
-          setLogFields(fields);
         }
+
+        return fields;
       }
+
+      return fields;
     },
-    [props.fieldMappingService?.getMappingsView]
+    [props.indexService.getIndexFields]
   );
+
+  const updateLogFieldsForIndex = (index: string) => {
+    if (!index) {
+      return;
+    }
+    getLogFields(index).then((fields) => {
+      setLogFieldsByIndex((prevState) => ({
+        ...prevState,
+        [index]: fields,
+      }));
+    });
+  };
 
   const createForm = (
     correlationQueries: CorrelationRuleQuery[],
@@ -199,6 +223,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
     return (
       <>
         {correlationQueries.map((query, queryIdx) => {
+          const fieldOptions = logFieldsByIndex[query.index] || [];
           const isInvalidInputForQuery = (field: 'logType' | 'index'): boolean => {
             return (
               !!touchedInputs.queries?.[queryIdx]?.[field] &&
@@ -259,7 +284,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         props.handleChange(`queries[${queryIdx}].index`)(
                           e[0]?.value ? e[0].value : ''
                         );
-                        getLogFields(e[0]?.value ? e[0].value : '');
+                        updateLogFieldsForIndex(e[0]?.value || '');
                       }}
                       onBlur={props.handleBlur(`queries[${queryIdx}].index`)}
                       selectedOptions={
@@ -320,7 +345,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         // isInvalid={isInvalidInputForQuery('logType')}
                         placeholder="Select a field"
                         data-test-subj={'field_dropdown'}
-                        options={logFields}
+                        options={fieldOptions}
                         singleSelection={{ asPlainText: true }}
                         onChange={(e) => {
                           props.handleChange(


### PR DESCRIPTION
### Description
When creating correlation rule, the UI shows the fields for the index that was last selected which leads to wrong behavior when user changes field under a different data source than the one which was last updated.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).