### PR TITLE
Support array of key/value in a selection when creating detection rule using visual editor

### DIFF
--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -61,7 +61,7 @@ interface DetectionVisualEditorState {
 interface SelectionData {
   field: string;
   modifier?: string;
-  values: string[];
+  values: (string | number)[];
   selectedRadioId?: string;
 }
 
@@ -179,16 +179,36 @@ export class DetectionVisualEditor extends React.Component<
       const selectionDataEntries: SelectionData[] = [];
 
       if (Array.isArray(selectionMapJSON)) {
-        selectionDataEntries.push({
-          field: '',
-          modifier: 'all',
-          values: selectionMapJSON,
-          selectedRadioId: `${
-            selectionMapJSON.length <= 1
-              ? SelectionMapValueRadioId.VALUE
-              : SelectionMapValueRadioId.LIST
-          }-${selectionIdx}-0`,
-        });
+        if (selectionMapJSON.length > 0 && typeof selectionMapJSON[0] === 'object') {
+          selectionMapJSON.forEach((map) => {
+            Object.keys(map).forEach((fieldKey, dataIdx) => {
+              const [field, modifier] = fieldKey.split('|');
+              const val = map[fieldKey];
+              const values: any[] = Array.isArray(val) ? val : [val];
+              selectionDataEntries.push({
+                field,
+                modifier,
+                values,
+                selectedRadioId: `${
+                  values.length <= 1
+                    ? SelectionMapValueRadioId.VALUE
+                    : SelectionMapValueRadioId.LIST
+                }-${selectionIdx}-${dataIdx}`,
+              });
+            });
+          });
+        } else {
+          selectionDataEntries.push({
+            field: '',
+            modifier: 'all',
+            values: selectionMapJSON,
+            selectedRadioId: `${
+              selectionMapJSON.length <= 1
+                ? SelectionMapValueRadioId.VALUE
+                : SelectionMapValueRadioId.LIST
+            }-${selectionIdx}-0`,
+          });
+        }
       } else if (typeof selectionMapJSON === 'object') {
         Object.keys(selectionMapJSON).forEach((fieldKey, dataIdx) => {
           const [field, modifier] = fieldKey.split('|');
@@ -202,6 +222,13 @@ export class DetectionVisualEditor extends React.Component<
               values.length <= 1 ? SelectionMapValueRadioId.VALUE : SelectionMapValueRadioId.LIST
             }-${selectionIdx}-${dataIdx}`,
           });
+        });
+      } else if (typeof selectionMapJSON === 'string' || typeof selectionMapJSON === 'number') {
+        selectionDataEntries.push({
+          field: '',
+          modifier: 'all',
+          values: [selectionMapJSON],
+          selectedRadioId: `${SelectionMapValueRadioId.VALUE}-${selectionIdx}-0`,
         });
       }
 


### PR DESCRIPTION
### Description
Some SIGMA rules have detection formatted such that a selection can contain an array of key/value pairs instead of an object with key/values. Added extra parsing logic to support cloning such rules using the visual editor

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).