### PR TITLE
Correlation rules field matching and time window support

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -38,7 +38,7 @@ const renderSubTitleText = (subTitleText: string | JSX.Element): JSX.Element | n
   return subTitleText;
 };
 
-const ContentPanel: React.SFC<ContentPanelProps> = ({
+const ContentPanel = ({
   title = '',
   titleSize = 'm',
   subTitleText = '',
@@ -48,7 +48,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
   children,
   hideHeaderBorder = false,
   className = '',
-}) => (
+}: ContentPanelProps): JSX.Element => (
   <EuiPanel
     style={{ paddingLeft: '0px', paddingRight: '0px', ...panelStyles }}
     className={className}

--- a/public/components/FormFieldHeader/FormFieldHeader.tsx
+++ b/public/components/FormFieldHeader/FormFieldHeader.tsx
@@ -14,13 +14,13 @@ export interface FormFieldHeaderProps {
   toolTipText?: string;
 }
 
-export const FormFieldHeader: React.FC<FormFieldHeaderProps> = ({
+export const FormFieldHeader = ({
   headerTitle = '',
   optionalField = false,
   toolTipIconType = 'questionInCircle',
   toolTipPosition = 'top',
   toolTipText = '',
-}) => {
+}: FormFieldHeaderProps): JSX.Element => {
   return (
     <EuiText size={'s'}>
       <strong>{headerTitle}</strong>

--- a/public/pages/Correlations/containers/CorrelationRuleFormModel.ts
+++ b/public/pages/Correlations/containers/CorrelationRuleFormModel.ts
@@ -7,6 +7,7 @@ import { CorrelationRuleModel } from '../../../../types';
 
 export const correlationRuleStateDefaultValue: CorrelationRuleModel = {
   name: '',
+  time_window: 60000,
   queries: [
     {
       logType: '',
@@ -18,6 +19,7 @@ export const correlationRuleStateDefaultValue: CorrelationRuleModel = {
         },
       ],
       index: '',
+      field: '',
     },
     {
       logType: '',
@@ -29,6 +31,7 @@ export const correlationRuleStateDefaultValue: CorrelationRuleModel = {
         },
       ],
       index: '',
+      field: '',
     },
   ],
 };

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -110,14 +110,14 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
         rule.time_window > 86400000 ||
         rule.time_window < 60000
       ) {
-        return 'Invaid time window';
+        return 'Invalid time window.';
       }
 
       let error = '';
       const invalidQuery = rule.queries.some((query, index) => {
         const invalidIndex = !query.index;
         if (invalidIndex) {
-          error = `Invalid index for query ${index + 1}`;
+          error = `Invalid index for query ${index + 1}.`;
           return true;
         }
 
@@ -508,10 +508,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                           />
                         );
 
-                        const conditionToggleButtons = [
-                          { id: 'AND', label: 'AND' },
-                          // { id: 'OR', label: 'OR' },
-                        ];
+                        const conditionToggleButtons = [{ id: 'AND', label: 'AND' }];
                         const conditionButtonGroup = (
                           <EuiButtonGroup
                             legend=""
@@ -598,7 +595,6 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       <EuiSpacer size="s" />
                       <EuiFormRow
                         label={<EuiText size={'s'}>Field</EuiText>}
-                        // isInvalid={!!(formikErrors.queries?.[queryIdx] as FormikErrors<CorrelationRuleQuery>)?.field}
                         isInvalid={isInvalidInputForQuery('field')}
                         error={
                           (formikErrors.queries?.[queryIdx] as FormikErrors<CorrelationRuleQuery>)
@@ -687,7 +683,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
             values.time_window > 86400000 ||
             values.time_window < 60000
           ) {
-            errors.time_window = 'Invaid time window.';
+            errors.time_window = 'Invalid time window.';
           }
 
           values.queries.forEach((query, idx) => {

--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -128,7 +128,7 @@ export class CorrelationsStore implements ICorrelationsStore {
         return {
           index: queryData.index,
           logType: queryData.category,
-          field: queryData.field,
+          field: queryData.field || '',
           conditions: this.parseRuleQueryString(queryData.query),
         };
       });
@@ -136,7 +136,7 @@ export class CorrelationsStore implements ICorrelationsStore {
       return {
         id: hit._id,
         name: hit._source.name,
-        time_window: hit._source.time_window,
+        time_window: hit._source.time_window || 300000,
         queries,
       };
     }
@@ -159,7 +159,7 @@ export class CorrelationsStore implements ICorrelationsStore {
           return {
             index: queryData.index,
             logType: queryData.category,
-            field: queryData.field,
+            field: queryData.field || '',
             conditions: this.parseRuleQueryString(queryData.query),
           };
         });
@@ -167,7 +167,7 @@ export class CorrelationsStore implements ICorrelationsStore {
         return {
           id: hit._id,
           name: hit._source.name,
-          time_window: hit._source.time_window,
+          time_window: hit._source.time_window || 300000,
           queries,
         };
       }));
@@ -299,6 +299,9 @@ export class CorrelationsStore implements ICorrelationsStore {
 
   private parseRuleQueryString(queryString: string): CorrelationFieldCondition[] {
     const queries: CorrelationFieldCondition[] = [];
+    if (!queryString) {
+      return queries;
+    }
     const orConditions = queryString.trim().split(/ OR /gi);
 
     orConditions.forEach((cond, conditionIndex) => {

--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -69,6 +69,7 @@ export class CorrelationsStore implements ICorrelationsStore {
   public async createCorrelationRule(correlationRule: CorrelationRule): Promise<boolean> {
     const response = await this.invalidateCache().service.createCorrelationRule({
       name: correlationRule.name,
+      time_window: correlationRule.time_window,
       correlate: correlationRule.queries?.map((query) => ({
         index: query.index,
         category: query.logType,
@@ -76,6 +77,7 @@ export class CorrelationsStore implements ICorrelationsStore {
           .map((condition) => `${condition.name}:${condition.value}`)
           // TODO: for the phase one only AND condition is supported, add condition once the correlation engine support is implemented
           .join(' AND '),
+        field: query.field,
       })),
     });
 
@@ -92,12 +94,14 @@ export class CorrelationsStore implements ICorrelationsStore {
       correlationRule.id,
       {
         name: correlationRule.name,
+        time_window: correlationRule.time_window,
         correlate: correlationRule.queries?.map((query) => ({
           index: query.index,
           category: query.logType,
           query: query.conditions
             .map((condition) => `${condition.name}:${condition.value}`)
             .join(' AND '),
+          field: query.field,
         })),
       }
     );
@@ -124,6 +128,7 @@ export class CorrelationsStore implements ICorrelationsStore {
         return {
           index: queryData.index,
           logType: queryData.category,
+          field: queryData.field,
           conditions: this.parseRuleQueryString(queryData.query),
         };
       });
@@ -131,6 +136,7 @@ export class CorrelationsStore implements ICorrelationsStore {
       return {
         id: hit._id,
         name: hit._source.name,
+        time_window: hit._source.time_window,
         queries,
       };
     }
@@ -153,6 +159,7 @@ export class CorrelationsStore implements ICorrelationsStore {
           return {
             index: queryData.index,
             logType: queryData.category,
+            field: queryData.field,
             conditions: this.parseRuleQueryString(queryData.query),
           };
         });
@@ -160,6 +167,7 @@ export class CorrelationsStore implements ICorrelationsStore {
         return {
           id: hit._id,
           name: hit._source.name,
+          time_window: hit._source.time_window,
           queries,
         };
       }));

--- a/types/Correlations.ts
+++ b/types/Correlations.ts
@@ -37,6 +37,7 @@ export type CorrelationFinding = {
 export interface CorrelationRuleQuery {
   logType: string;
   index: string;
+  field: string;
   conditions: CorrelationFieldCondition[];
 }
 
@@ -48,6 +49,7 @@ export interface CorrelationFieldCondition {
 
 export interface CorrelationRuleModel {
   name: string;
+  time_window: number; // Time in milliseconds
   queries: CorrelationRuleQuery[];
 }
 
@@ -62,11 +64,13 @@ export interface CorrelationRuleTableItem extends CorrelationRule {
 export interface CorrelationRuleSourceQueries {
   index: string;
   query: string;
+  field: string;
   category: string;
 }
 
 export interface CorrelationRuleSource {
   name: string;
+  time_window: number;
   correlate: CorrelationRuleSourceQueries[];
 }
 


### PR DESCRIPTION
### Description
This PR enhances support for correlation engine rules by adding support for:
 - Providing time window for which the findings should be correlated
 - Providing a matching group by field across all the data sources which will correlate findings with same value for these fields.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).