### PR TITLE
Ignore correlated findings whose detector is deleted

### DIFF
--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -273,12 +273,16 @@ export class CorrelationsStore implements ICorrelationsStore {
     );
 
     if (response?.ok) {
-      const correlatedFindings = response.response.findings.map((f) => {
-        return {
-          ...allFindings[f.finding],
-          correlationScore: f.score < 0.01 ? '0.01' : f.score.toFixed(2),
-        };
+      const correlatedFindings: CorrelationFinding[] = [];
+      response.response.findings.forEach((f) => {
+        if (allFindings[f.finding]) {
+          correlatedFindings.push({
+            ...allFindings[f.finding],
+            correlationScore: f.score < 0.01 ? '0.01' : f.score.toFixed(2),
+          });
+        }
       });
+
       return {
         finding: allFindings[finding],
         correlatedFindings,


### PR DESCRIPTION
### Description
When trying to drill down into correlated findings using the correlations graph, there can exist some findings for which the detector does not exist. Today, there is no way for us to fetch such findings, hence we are not able to get their details. Suppressing such findings from the correlated findings list until we fix this in the backend.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).