### PR TITLE
Do send query/field in the correlation rule payload if they are empty

### DIFF
--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -70,15 +70,27 @@ export class CorrelationsStore implements ICorrelationsStore {
     const response = await this.invalidateCache().service.createCorrelationRule({
       name: correlationRule.name,
       time_window: correlationRule.time_window,
-      correlate: correlationRule.queries?.map((query) => ({
-        index: query.index,
-        category: query.logType,
-        query: query.conditions
+      correlate: correlationRule.queries?.map((query) => {
+        const queryString = query.conditions
           .map((condition) => `${condition.name}:${condition.value}`)
           // TODO: for the phase one only AND condition is supported, add condition once the correlation engine support is implemented
-          .join(' AND '),
-        field: query.field,
-      })),
+          .join(' AND ');
+
+        const correlationInput: any = {
+          index: query.index,
+          category: query.logType,
+        };
+
+        if (queryString) {
+          correlationInput['query'] = queryString;
+        }
+
+        if (query.field) {
+          correlationInput['field'] = query.field;
+        }
+
+        return correlationInput;
+      }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
### Description
The backend does not generate correlations if we send empty query string as part of rule payload. This PR filters out empty field/query from the payload

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).