### PR TITLE
[Backport 2.10] Allow empty field name for supporting timeframe and keywords when validating rule during creation/update

### DIFF
--- a/cypress/integration/2_rules.spec.js
+++ b/cypress/integration/2_rules.spec.js
@@ -325,13 +325,20 @@ describe('Rules', () => {
     it('...should validate selection map key field', () => {
       getSelectionPanelByIndex(0).within(() => {
         getMapKeyField().should('be.empty');
-        getMapKeyField().focus().blur();
+        getMapKeyField()
+          .focus()
+          .blur()
+          .parents('.euiFormRow__fieldWrapper')
+          .find('.euiFormErrorText')
+          .should('not.exist');
+
+        getMapKeyField().type('hello@');
         getMapKeyField()
           .parentsUntil('.euiFormRow__fieldWrapper')
           .siblings()
           .contains('Invalid key name');
 
-        getMapKeyField().type('FieldKey');
+        getMapKeyField().focus().type('{selectall}').type('FieldKey');
         getMapKeyField()
           .focus()
           .blur()
@@ -441,7 +448,6 @@ describe('Rules', () => {
       getSelectionPanelByIndex(0).within(() =>
         getMapKeyField().type('{selectall}').type('{backspace}')
       );
-      toastShouldExist();
       getSelectionPanelByIndex(0).within(() => getMapKeyField().type('FieldKey'));
 
       // selection map value field

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -307,7 +307,8 @@ export class DetectionVisualEditor extends React.Component<
         if ('field' in data) {
           const fieldName = `field_${selIdx}_${idx}`;
           delete errors.fields[fieldName];
-          if (!validateDetectionFieldName(data.field)) {
+
+          if (data.field && !validateDetectionFieldName(data.field)) {
             errors.fields[fieldName] =
               'Invalid key name. Valid characters are a-z, A-Z, 0-9, hyphen, period, and underscore.';
           }


### PR DESCRIPTION
### Description
Backport #823 to 2.10

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).