### PR TITLE
Fixed update payload for correlation rule

### DIFF
--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -107,14 +107,26 @@ export class CorrelationsStore implements ICorrelationsStore {
       {
         name: correlationRule.name,
         time_window: correlationRule.time_window,
-        correlate: correlationRule.queries?.map((query) => ({
-          index: query.index,
-          category: query.logType,
-          query: query.conditions
+        correlate: correlationRule.queries?.map((query) => {
+          const queryString = query.conditions
             .map((condition) => `${condition.name}:${condition.value}`)
-            .join(' AND '),
-          field: query.field,
-        })),
+            .join(' AND ');
+
+          const correlationInput: any = {
+            index: query.index,
+            category: query.logType,
+          };
+
+          if (queryString) {
+            correlationInput['query'] = queryString;
+          }
+
+          if (query.field) {
+            correlationInput['field'] = query.field;
+          }
+
+          return correlationInput;
+        }),
       }
     );
 


### PR DESCRIPTION
### Description
If the query or field properties of correlation rule data source are empty, they should be null or not exist in the payload for the correlation rule to work correctly after update.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).