### PR TITLE
Fixing codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @amsiglan @awshurneyt @getsaurabh02 @lezzago @praveensameneni @sbcd90 @eirsep
+*   @amsiglan @AWSHurneyt @getsaurabh02 @lezzago @praveensameneni @sbcd90 @eirsep


### PR DESCRIPTION
### Description
Changes codeowners to match the Maintainers file for AWSHurneyt

### Issues Resolved
N/A

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).