### PR TITLE
Check for empty document in the finding flyout

### DIFF
--- a/cypress/integration/4_findings.spec.js
+++ b/cypress/integration/4_findings.spec.js
@@ -144,9 +144,6 @@ describe('Findings', () => {
     });
   });
 
-  // TODO - upon reaching rules page, trigger appropriate rules detail flyout
-  // see github issue #124 at https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/124
-
   it('opens rule details flyout when rule name inside accordion drop down is clicked', () => {
     // filter table to show only sample_detector findings
     cy.get(`input[placeholder="Search findings"]`).ospSearch(indexName);
@@ -165,6 +162,27 @@ describe('Findings', () => {
     cy.get(`[data-test-subj="rule_flyout_${ruleName}"]`).within(() => {
       cy.get('[data-test-subj="rule_flyout_rule_name"]').contains(ruleName);
     });
+  });
+
+  it('shows document not found warning when the document is empty', () => {
+    cy.deleteIndex(indexName);
+    cy.reload();
+
+    // Wait for page to load
+    cy.waitForPageLoad('findings', {
+      contains: 'Findings',
+    });
+
+    // filter table to show only sample_detector findings
+    cy.get(`input[placeholder="Search findings"]`).ospSearch(indexName);
+
+    // open Finding details flyout via finding id link. cy.wait essential, timeout insufficient.
+    cy.getTableFirstRow('[data-test-subj="view-details-icon"]').then(($el) => {
+      cy.get($el).click({ force: true });
+    });
+
+    // Flyout should show 'Document not found' warning
+    cy.contains('Document not found');
   });
 
   after(() => cy.cleanUpTests());

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -31,6 +31,7 @@ import {
   EuiTabs,
   EuiTab,
   EuiLoadingContent,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import {
   capitalizeFirstLetter,
@@ -308,7 +309,7 @@ export default class FindingDetailsFlyout extends Component<
     const document = matchedDocuments.length > 0 ? matchedDocuments[0].document : '';
     const { indexPatternId } = this.state;
 
-    return (
+    return document ? (
       <>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem>
@@ -370,6 +371,19 @@ export default class FindingDetailsFlyout extends Component<
             {JSON.stringify(JSON.parse(document), null, 2)}
           </EuiCodeBlock>
         </EuiFormRow>
+      </>
+    ) : (
+      <>
+        <EuiTitle size={'s'}>
+          <h3>Documents</h3>
+        </EuiTitle>
+        <EuiSpacer />
+        <EuiEmptyPrompt
+          iconType="alert"
+          iconColor="danger"
+          title={<h2>Document not found</h2>}
+          body={<p>The document that generated this finding could not be loaded.</p>}
+        />
       </>
     );
   }

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -307,6 +307,13 @@ export default class FindingDetailsFlyout extends Component<
     const docId = related_doc_ids[0];
     const matchedDocuments = documents.filter((doc) => doc.id === docId);
     const document = matchedDocuments.length > 0 ? matchedDocuments[0].document : '';
+    let formattedDocument = '';
+    try {
+      formattedDocument = document ? JSON.stringify(JSON.parse(document), null, 2) : '';
+    } catch {
+      // no-op
+    }
+
     const { indexPatternId } = this.state;
 
     return document ? (
@@ -368,7 +375,7 @@ export default class FindingDetailsFlyout extends Component<
             isCopyable
             data-test-subj={'finding-details-flyout-rule-document'}
           >
-            {JSON.stringify(JSON.parse(document), null, 2)}
+            {formattedDocument}
           </EuiCodeBlock>
         </EuiFormRow>
       </>


### PR DESCRIPTION
### Description
If the document for a finding is not found, it crashes the app since JSON parser throws an exception. Adding check to fix the issue

### Issues Resolved
#839 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).