### PR TITLE
[Bugfix] Add already mapped log index fields to list of mapping options

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -86,8 +86,7 @@ export default class ConfigureFieldMapping extends Component<
 
   componentDidUpdate(
     prevProps: Readonly<ConfigureFieldMappingProps>,
-    prevState: Readonly<ConfigureFieldMappingState>,
-    snapshot?: any
+    prevState: Readonly<ConfigureFieldMappingState>
   ) {
     if (prevProps.detector !== this.props.detector) {
       this.setState(
@@ -124,6 +123,10 @@ export default class ConfigureFieldMapping extends Component<
 
     Object.keys(mappingsData.properties).forEach((ruleFieldName) => {
       mappedRuleFields.unshift(ruleFieldName);
+
+      if (mappingsData.properties[ruleFieldName].path) {
+        logFields.add(mappingsData.properties[ruleFieldName].path);
+      }
 
       // Need this check to avoid adding undefined value
       // When user removes existing mapping for default mapped values, the mapping will be undefined


### PR DESCRIPTION
### Description
When we have automatically mapped fields, if the user removes the mapped log index field, then it is not added back to the list of available options and user cannot add the same field back without a workaround.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).