### PR TITLE
Ask for mapping of threat intel feeds related fields only when threat intel is enabled

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -250,9 +250,14 @@ export default class ConfigureFieldMapping extends Component<
             mappingsView.response.properties[ruleFieldName].path;
         });
         let threatIntelFeedFields = new Set();
-        mappingsView.response.threat_intel_field_aliases?.forEach(({ fields }) => {
-          fields.forEach((field) => threatIntelFeedFields.add(field));
-        });
+
+        // Only if threat_intel is enabled, we want to show the relevant fields for mapping
+        if (this.state.detector.threat_intel_enabled) {
+          mappingsView.response.threat_intel_field_aliases?.forEach(({ fields }) => {
+            fields.forEach((field) => threatIntelFeedFields.add(field));
+          });
+        }
+
         mappingsView.response.unmapped_field_aliases?.forEach((ruleFieldName) => {
           if (
             !ruleFieldsForEnabledRules.has(ruleFieldName) &&


### PR DESCRIPTION
### Description
Currently the configure field mappings section asks for threat intel related fields to be mapped even when threat intel is unchecked. This PR ensures we remove those fields from pending mappings.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).