### PR TITLE
change in findingsAPI call to accommodate backend findings enhancement

### DIFF
--- a/public/services/FindingsService.ts
+++ b/public/services/FindingsService.ts
@@ -16,12 +16,13 @@ export default class FindingsService {
   }
 
   getFindings = async (
-    detectorParams: GetFindingsParams
+    detectorParams: GetFindingsParams = {}
   ): Promise<ServerResponse<GetFindingsResponse>> => {
     const { detectorType, detectorId } = detectorParams;
-    let query: GetFindingsParams | {} = {
+    let query: GetFindingsParams = {
       sortOrder: 'desc',
       size: 10000,
+      ...detectorParams, // Include other properties from detectorParams
     };
 
     if (detectorId) {
@@ -35,7 +36,6 @@ export default class FindingsService {
         detectorType,
       };
     }
-
     return await this.httpClient.get(`..${API.GET_FINDINGS}`, { query });
   };
 }

--- a/server/clusters/addFindingsMethods.ts
+++ b/server/clusters/addFindingsMethods.ts
@@ -8,12 +8,8 @@ import { METHOD_NAMES, API } from '../utils/constants';
 export function addFindingsMethods(securityAnalytics: any, createAction: any): void {
   securityAnalytics[METHOD_NAMES.GET_FINDINGS] = createAction({
     url: {
-      fmt: `${API.GET_FINDINGS}?detector_id=<%=detectorId%>&sortOrder=<%=sortOrder%>&size=<%=size%>`,
+      fmt: `${API.GET_FINDINGS}?sortOrder=<%=sortOrder%>&size=<%=size%>`,
       req: {
-        detectorId: {
-          type: 'string',
-          required: false,
-        },
         sortOrder: {
           type: 'string',
           required: false,

--- a/server/models/interfaces/Findings.ts
+++ b/server/models/interfaces/Findings.ts
@@ -8,16 +8,9 @@ import { Finding } from '../../../public/pages/Findings/models/interfaces';
 export type GetFindingsParams = {
   sortOrder?: string;
   size?: number;
-} & (
-  | {
-      detectorId: string;
-      detectorType?: string;
-    }
-  | {
-      detectorType: string;
-      detectorId?: string;
-    }
-);
+  detectorId?: string;
+  detectorType?: string;
+};
 
 export interface GetFindingsResponse {
   total_findings: number;

--- a/server/services/FindingsService.ts
+++ b/server/services/FindingsService.ts
@@ -38,28 +38,11 @@ export default class FindingsService {
         sortOrder,
         size,
       };
-      let params: GetFindingsParams;
-
-      if (detectorId) {
-        params = {
-          ...defaultParams,
-          detectorId,
-        };
-      } else if (detectorType) {
-        params = {
-          ...defaultParams,
-          detectorType,
-        };
-      } else {
-        throw Error(`Invalid request params: detectorId or detectorType must be specified`);
-      }
-
       const { callAsCurrentUser: callWithRequest } = this.osDriver.asScoped(request);
       const getFindingsResponse: GetFindingsResponse = await callWithRequest(
         CLIENT_DETECTOR_METHODS.GET_FINDINGS,
-        params
+        defaultParams
       );
-
       getFindingsResponse.findings.forEach((finding: any) => {
         const types: string[] = [];
         if (!finding.queries.every((query: any) => query.id.startsWith('threat_intel_'))) {
@@ -69,7 +52,6 @@ export default class FindingsService {
           types.push('Threat intelligence');
           finding['ruleSeverity'] = 'high';
         }
-
         finding['detectionType'] = types.join(', ');
       });
 

--- a/types/Finding.ts
+++ b/types/Finding.ts
@@ -33,15 +33,10 @@ export interface FindingDocument {
 /**
  * API interfaces
  */
-export type GetFindingsParams =
-  | {
-      detectorId: string;
-      detectorType?: string;
-    }
-  | {
-      detectorType: string;
-      detectorId?: string;
-    };
+export type GetFindingsParams = {
+  detectorId?: string;
+  detectorType?: string;
+};
 
 export interface GetFindingsResponse {
   total_findings: number;


### PR DESCRIPTION
### Description

* Earlier the findings page only shows the latest 10000 findings per detector. So, if there are 10 detectors there will be latest 100000 findings shown in the UI. With this enhancement, findings page will have the latest 100000 findings for all the detectors collectively or irrespective of all the detectors.
* The above change will reflect on Findings ad Overview Page
* Backend PR:  https://github.com/opensearch-project/security-analytics/pull/803 

### Issues Resolved
https://github.com/opensearch-project/security-analytics/issues/795

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).