### PR TITLE
Add check for mappings view API call during create detector

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -80,23 +80,20 @@ export default class ConfigureFieldMapping extends Component<
   }
 
   componentDidMount = async () => {
-    await this.getAllMappings();
-    this.setupTabs();
+    await this.getAllMappings(this.setupTabs);
   };
 
   componentDidUpdate(
     prevProps: Readonly<ConfigureFieldMappingProps>,
-    prevState: Readonly<ConfigureFieldMappingState>,
-    snapshot?: any
+    prevState: Readonly<ConfigureFieldMappingState>
   ) {
-    if (prevProps.detector !== this.props.detector) {
+    if (this.shouldUpdateMappingsState(prevProps)) {
       this.setState(
         {
           detector: this.props.detector,
         },
         async () => {
-          await this.getAllMappings();
-          this.setupTabs();
+          await this.getAllMappings(this.setupTabs);
         }
       );
     } else if (prevState.createdMappings !== this.state.createdMappings) {
@@ -104,7 +101,24 @@ export default class ConfigureFieldMapping extends Component<
     }
   }
 
-  setupTabs() {
+  private shouldUpdateMappingsState(prevProps: ConfigureFieldMappingProps) {
+    const prevDetector = prevProps.detector;
+    const newDetector = this.props.detector;
+
+    return (
+      !!newDetector.detector_type &&
+      newDetector.inputs[0]?.detector_input.indices.length > 0 &&
+      (prevDetector.detector_type !== newDetector.detector_type ||
+        prevDetector.inputs[0].detector_input.indices !==
+          newDetector.inputs[0].detector_input.indices ||
+        prevDetector.inputs[0].detector_input.pre_packaged_rules !==
+          newDetector.inputs[0].detector_input.pre_packaged_rules ||
+        prevDetector.inputs[0].detector_input.custom_rules !==
+          newDetector.inputs[0].detector_input.custom_rules)
+    );
+  }
+
+  setupTabs = () => {
     const {
       loading,
       mappingsData,
@@ -213,7 +227,7 @@ export default class ConfigureFieldMapping extends Component<
       selectedTabContent:
         tabs[selectedTabId === FieldMappingTabId.AutomaticMappings ? 0 : 1].content,
     });
-  }
+  };
 
   private getRuleFieldsForEnabledRules(): Set<string> {
     const ruleFieldsForEnabledRules = new Set<string>();
@@ -226,8 +240,11 @@ export default class ConfigureFieldMapping extends Component<
     return ruleFieldsForEnabledRules;
   }
 
-  getAllMappings = async () => {
-    if (this.state.detector.inputs[0]?.detector_input.indices[0]) {
+  getAllMappings = async (onMappingsUpdate: () => void) => {
+    if (
+      this.state.detector.inputs[0]?.detector_input.indices[0] &&
+      !!this.state.detector.detector_type
+    ) {
       this.setState({ loading: true });
       const mappingsView = await this.props.fieldMappingService.getMappingsView(
         this.state.detector.inputs[0].detector_input.indices[0],
@@ -262,17 +279,22 @@ export default class ConfigureFieldMapping extends Component<
           }
         });
 
-        this.setState({
-          createdMappings: existingMappings,
-          mappingsData: {
-            ...mappingsView.response,
-            unmapped_field_aliases: Array.from(unmappedRuleFields),
+        this.setState(
+          {
+            createdMappings: existingMappings,
+            mappingsData: {
+              ...mappingsView.response,
+              unmapped_field_aliases: Array.from(unmappedRuleFields),
+            },
+            fieldMappingIsOpen: !!unmappedRuleFields.size,
+            loading: false,
           },
-          fieldMappingIsOpen: !!unmappedRuleFields.size,
-        });
+          onMappingsUpdate
+        );
         this.updateMappingSharedState(existingMappings);
+      } else {
+        this.setState({ loading: false });
       }
-      this.setState({ loading: false });
     }
   };
 

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
@@ -106,14 +106,16 @@ export default class DetectorDataSource extends Component<
       }
     }
 
-    for (const indexName of allIndices) {
-      if (!this.indicesMappings[indexName]) {
-        const detectorType = this.props.detector_type.toLowerCase();
-        const result = await this.props.fieldMappingService?.getMappingsView(
-          indexName,
-          detectorType
-        );
-        result?.ok && (this.indicesMappings[indexName] = result.response.unmapped_field_aliases);
+    const detectorType = this.props.detector_type.toLowerCase();
+    if (detectorType) {
+      for (const indexName of allIndices) {
+        if (!this.indicesMappings[indexName]) {
+          const result = await this.props.fieldMappingService?.getMappingsView(
+            indexName,
+            detectorType
+          );
+          result?.ok && (this.indicesMappings[indexName] = result.response.unmapped_field_aliases);
+        }
       }
     }
 


### PR DESCRIPTION
### Description
Currently the field mapping configuration component does a blanket check on changes made to the detector and tries to fetch the updated mappings for any change made to the detector.
This PR ensures we only check for relevant changes like the data source, log type or detection rules.

### Issues Resolved
#861 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).