### PR TITLE
Show aliases in data source options for detector and correlation rule creation

### DIFF
--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -113,9 +113,15 @@ const validatePendingFieldMappingsPanel = (mappings) => {
   });
 };
 
-const fillDetailsForm = (detectorName, dataSource) => {
+const fillDetailsForm = (detectorName, dataSource, isCustomDataSource = false) => {
   getNameField().type(detectorName);
-  getDataSourceField().selectComboboxItem(dataSource);
+  if (isCustomDataSource) {
+    getDataSourceField()
+      .focus()
+      .type(dataSource + '{enter}');
+  } else {
+    getDataSourceField().selectComboboxItem(dataSource);
+  }
   getDataSourceField().focus().blur();
   getLogTypeField().selectComboboxItem(getLogTypeLabel(cypressLogTypeDns));
   getLogTypeField().focus().blur();
@@ -124,7 +130,7 @@ const fillDetailsForm = (detectorName, dataSource) => {
 const createDetector = (detectorName, dataSource, expectFailure) => {
   getCreateDetectorButton().click({ force: true });
 
-  fillDetailsForm(detectorName, dataSource);
+  fillDetailsForm(detectorName, dataSource, expectFailure);
 
   cy.getElementByText('.euiAccordion .euiTitle', 'Selected detection rules (14)')
     .click({ force: true, timeout: 5000 })

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
@@ -105,6 +105,11 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
             </EuiText>
           </div>
         }
+        extraAction={
+          <EuiButton href={`#${ROUTES.RULES}`} target="_blank">
+            Manage <EuiIcon type={'popout'} />
+          </EuiButton>
+        }
         id={'detectorRulesAccordion'}
         initialIsOpen={false}
         isLoading={loading}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
@@ -18,7 +18,7 @@ import { IndexOption } from '../../../../../Detectors/models/interfaces';
 import { MIN_NUM_DATA_SOURCES } from '../../../../../Detectors/utils/constants';
 import IndexService from '../../../../../../services/IndexService';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { errorNotificationToast } from '../../../../../../utils/helpers';
+import { getDataSources } from '../../../../../../utils/helpers';
 import _ from 'lodash';
 import { FieldMappingService } from '../../../../../../services';
 
@@ -57,41 +57,28 @@ export default class DetectorDataSource extends Component<
   }
 
   componentDidMount = async () => {
-    this.getIndices();
+    this.getDataSources();
   };
 
-  getIndices = async () => {
+  getDataSources = async () => {
     this.setState({ loading: true });
-    try {
-      const indicesResponse = await this.props.indexService.getIndices();
-      if (indicesResponse.ok) {
-        const indices = indicesResponse.response.indices;
-        const indicesNames = indices.map((index) => index.index);
+    const res = await getDataSources(this.props.indexService, this.props.notifications);
 
-        this.setState({
-          loading: false,
-          indexOptions: this.parseOptions(indicesNames),
-        });
-      } else {
-        errorNotificationToast(
-          this.props.notifications,
-          'retrieve',
-          'indices',
-          indicesResponse.error
-        );
-        this.setState({ errorMessage: indicesResponse.error });
-      }
-    } catch (error: any) {
-      errorNotificationToast(this.props.notifications, 'retrieve', 'indices', error);
+    if (res.ok) {
+      this.setState({
+        loading: false,
+        indexOptions: res.dataSources,
+      });
+    } else {
+      this.setState({ loading: false, errorMessage: res.error });
     }
-    this.setState({ loading: false });
   };
 
-  parseOptions = (indices: string[]) => {
-    return indices.map((index) => ({ label: index }));
+  parseOptions = (options: string[]) => {
+    return options.map((option) => ({ label: option }));
   };
 
-  onCreateOption = (searchValue: string, options: EuiComboBoxOptionOption[]) => {
+  onCreateOption = (searchValue: string) => {
     const parsedOptions = this.parseOptions(this.props.detectorIndices);
     parsedOptions.push({ label: searchValue });
     this.onSelectionChange(parsedOptions);
@@ -172,6 +159,9 @@ export default class DetectorDataSource extends Component<
             isInvalid={!!errorMessage}
             isClearable={true}
             data-test-subj={'define-detector-select-data-source'}
+            renderOption={(option: IndexOption) => {
+              return option.index ? `${option.label} (${option.index})` : option.label;
+            }}
           />
         </EuiFormRow>
         {differentLogTypesDetected ? (

--- a/public/pages/Detectors/models/interfaces.ts
+++ b/public/pages/Detectors/models/interfaces.ts
@@ -5,4 +5,5 @@
 
 export interface IndexOption {
   label: string;
+  index?: string;
 }

--- a/public/services/IndexService.ts
+++ b/public/services/IndexService.ts
@@ -5,7 +5,7 @@
 
 import { HttpSetup } from 'opensearch-dashboards/public';
 import { ServerResponse } from '../../server/models/types';
-import { GetIndicesResponse } from '../../server/models/interfaces';
+import { GetAliasesResponse, GetIndicesResponse } from '../../server/models/interfaces';
 import { API } from '../../server/utils/constants';
 import { IIndexService } from '../../types';
 
@@ -28,6 +28,13 @@ export default class IndexService implements IIndexService {
   getIndices = async (): Promise<ServerResponse<GetIndicesResponse>> => {
     const url = `..${API.INDICES_BASE}`;
     const response = (await this.httpClient.get(url)) as ServerResponse<GetIndicesResponse>;
+
+    return response;
+  };
+
+  getAliases = async (): Promise<ServerResponse<GetAliasesResponse>> => {
+    const url = `..${API.ALIASES_BASE}`;
+    const response = (await this.httpClient.get(url)) as ServerResponse<GetAliasesResponse>;
 
     return response;
   };

--- a/server/models/interfaces/index.ts
+++ b/server/models/interfaces/index.ts
@@ -21,6 +21,7 @@ export interface SecurityAnalyticsApi {
   readonly CORRELATION_BASE: string;
   readonly SEARCH_DETECTORS: string;
   readonly INDICES_BASE: string;
+  readonly ALIASES_BASE: string;
   readonly FINDINGS_BASE: string;
   readonly GET_FINDINGS: string;
   readonly DOCUMENT_IDS_QUERY: string;
@@ -54,6 +55,10 @@ export interface GetIndicesResponse {
   indices: CatIndex[];
 }
 
+export interface GetAliasesResponse {
+  aliases: CatAlias[];
+}
+
 // Default _cat index response
 export interface CatIndex {
   'docs.count': string;
@@ -67,6 +72,11 @@ export interface CatIndex {
   'store.size': string;
   uuid: string;
   data_stream: string | null;
+}
+
+export interface CatAlias {
+  alias: string;
+  index: string;
 }
 
 export interface SearchResponse<T> {

--- a/server/routes/IndexRoutes.ts
+++ b/server/routes/IndexRoutes.ts
@@ -19,6 +19,14 @@ export function setupIndexRoutes(services: NodeServices, router: IRouter) {
     indexService.getIndices
   );
 
+  router.get(
+    {
+      path: API.ALIASES_BASE,
+      validate: {},
+    },
+    indexService.getAliases
+  );
+
   router.post(
     {
       path: `${API.INDICES_BASE}`,

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -18,6 +18,7 @@ export const API: SecurityAnalyticsApi = {
   CORRELATION_BASE: `${BASE_API_PATH}/correlation/rules`,
   SEARCH_DETECTORS: `${BASE_API_PATH}/detectors/_search`,
   INDICES_BASE: `${BASE_API_PATH}/indices`,
+  ALIASES_BASE: `${BASE_API_PATH}/aliases`,
   FINDINGS_BASE: `${BASE_API_PATH}/findings`,
   GET_FINDINGS: `${BASE_API_PATH}/findings/_search`,
   DOCUMENT_IDS_QUERY: `${BASE_API_PATH}/document_ids_query`,


### PR DESCRIPTION
### Description
Currently, we only show indices inside the data source options for create/update Detector and Correlation rule. This PR adds aliases to that list and categorizes the two for more options.

This PR also adds an external link to the Rules page to provide an entry point to rules management in case Users don't see the rule they want to setup in the detector
![image](https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/919cfdcc-13a4-4488-9ad0-a009e51ed9a5)


### Issues Resolved
#863 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).