### PR TITLE
Load log type from log source if present

### DIFF
--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -6,7 +6,11 @@
 export interface Rule {
   id: string;
   category: string;
-  log_source: string;
+  log_source: {
+    product?: string;
+    category?: string;
+    service?: string;
+  };
   title: string;
   description: string;
   tags: Array<{ value: string }>;

--- a/public/pages/Rules/components/RuleContentViewer/RuleContentYamlViewer.test.tsx
+++ b/public/pages/Rules/components/RuleContentViewer/RuleContentYamlViewer.test.tsx
@@ -34,7 +34,7 @@ describe('<RuleContentYamlViewer /> spec', () => {
               value: 'attack.t1543.003',
             },
           ],
-          log_source: '',
+          log_source: {},
           detection:
             'selection:\n  Provider_Name: Service Control Manager\n  EventID: 7045\n  ServiceName: ZzNetSvc\ncondition: selection\n',
           level: 'high',

--- a/public/pages/Rules/components/RuleEditor/RuleEditorFormModel.ts
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorFormModel.ts
@@ -7,7 +7,7 @@ import { ruleStatus } from '../../utils/constants';
 
 export interface RuleEditorFormModel {
   id: string;
-  log_source: string;
+  log_source: { product?: string; category?: string; service?: string };
   logType: string;
   name: string;
   description: string;
@@ -22,7 +22,7 @@ export interface RuleEditorFormModel {
 
 export const ruleEditorStateDefaultValue: RuleEditorFormModel = {
   id: '25b9c01c-350d-4b95-bed1-836d04a4f324',
-  log_source: '',
+  log_source: {},
   logType: '',
   name: '',
   description: '',

--- a/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/YamlRuleEditorComponent.test.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/YamlRuleEditorComponent.test.tsx
@@ -35,7 +35,7 @@ describe('<YamlRuleEditorComponent /> spec', () => {
               value: 'attack.t1543.003',
             },
           ],
-          log_source: '',
+          log_source: {},
           detection:
             'selection:\n  Provider_Name: Service Control Manager\n  EventID: 7045\n  ServiceName: ZzNetSvc\ncondition: selection\n',
           level: 'high',
@@ -80,7 +80,7 @@ describe('<YamlRuleEditorComponent /> spec', () => {
               value: 'attack.t1543.003',
             },
           ],
-          log_source: '',
+          log_source: {},
           detection:
             'selection:\n  Provider_Name: Service Control Manager\n  EventID: 7045\n  ServiceName: ZzNetSvc\ncondition: selection\n',
           level: 'high',

--- a/public/pages/Rules/components/RuleEditor/mappers.ts
+++ b/public/pages/Rules/components/RuleEditor/mappers.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Rule } from '../../../../../models/interfaces';
+import { getLogTypeFromLogSource } from '../../utils/helpers';
 import { RuleEditorFormModel, ruleEditorStateDefaultValue } from './RuleEditorFormModel';
 
 export const mapFormToRule = (formState: RuleEditorFormModel): Rule => {
@@ -25,10 +26,13 @@ export const mapFormToRule = (formState: RuleEditorFormModel): Rule => {
 };
 
 export const mapRuleToForm = (rule: Rule): RuleEditorFormModel => {
+  // get category from log_source
+  const logType = rule.category || getLogTypeFromLogSource(rule.log_source);
+
   return {
     id: rule.id,
     log_source: rule.log_source,
-    logType: rule.category,
+    logType: logType || '',
     name: rule.title,
     description: rule.description,
     status: rule.status,

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -14,8 +14,7 @@ import { dump, load } from 'js-yaml';
 import { ContentPanel } from '../../../../components/ContentPanel';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { CoreServicesContext } from '../../../../components/core_services';
-import { setBreadCrumb, validateRule } from '../../utils/helpers';
-import { DataStore } from '../../../../store/DataStore';
+import { setBreadCrumb } from '../../utils/helpers';
 
 export interface ImportRuleProps {
   services: BrowserServices;
@@ -63,7 +62,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
             references:
               jsonContent.references?.map((reference: string) => ({ value: reference })) || [],
             tags: jsonContent.tags?.map((tag: string) => ({ value: tag })) || [],
-            log_source: jsonContent.logsource || '',
+            log_source: jsonContent.logsource || {},
             detection: detectionYaml,
             level: jsonContent.level || '',
             false_positives:
@@ -117,32 +116,6 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
     );
     setBreadCrumb(BREADCRUMBS.RULES_IMPORT, context?.chrome.setBreadcrumbs);
   }, [fileError, onChange]);
-
-  const footerActions: React.FC<{ rule: Rule }> = ({ rule }) => {
-    const onCreate = async () => {
-      if (!validateRule(rule, notifications!, 'create')) {
-        return;
-      }
-      const response = await DataStore.rules.createRule(rule);
-
-      if (response) {
-        history.replace(ROUTES.RULES);
-      }
-    };
-
-    return (
-      <EuiFlexGroup justifyContent="flexEnd">
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => history.replace(ROUTES.RULES)}>Cancel</EuiButton>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={onCreate}>
-            Create
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    );
-  };
 
   return content;
 };

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -179,17 +179,12 @@ export function setBreadCrumb(
 }
 
 export function getLogTypeFromLogSource(logSource: { [k: string]: string }) {
-  const possibleLogType = new Set();
-  for (let key in logSource) {
-    if (logSource[key]) {
-      possibleLogType.add(logSource[key]);
-    }
-  }
+  const logTypes = new Set(ruleTypes.map(({ value }) => value));
 
-  let logType: string | undefined;
-  ruleTypes.some(({ value }) => {
-    if (possibleLogType.has(value)) {
-      logType = value;
+  let logType;
+  ['product', 'category', 'service'].some((key) => {
+    if (logSource[key] && logTypes.has(logSource[key])) {
+      logType = logSource[key];
       return true;
     }
 

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -10,7 +10,7 @@ import {
   formatRuleType,
   getLogTypeFilterOptions,
 } from '../../../utils/helpers';
-import { ruleSeverity, ruleSource } from './constants';
+import { ruleSeverity, ruleSource, ruleTypes } from './constants';
 import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
 import { Rule } from '../../../../models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -176,4 +176,25 @@ export function setBreadCrumb(
   breadCrumbSetter?: (breadCrumbs: EuiBreadcrumb[]) => void
 ) {
   breadCrumbSetter?.([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES, breadCrumb]);
+}
+
+export function getLogTypeFromLogSource(logSource: { [k: string]: string }) {
+  const possibleLogType = new Set();
+  for (let key in logSource) {
+    if (logSource[key]) {
+      possibleLogType.add(logSource[key]);
+    }
+  }
+
+  let logType: string | undefined;
+  ruleTypes.some(({ value }) => {
+    if (possibleLogType.has(value)) {
+      logType = value;
+      return true;
+    }
+
+    return false;
+  });
+
+  return logType;
 }

--- a/public/pages/Rules/utils/mappers.ts
+++ b/public/pages/Rules/utils/mappers.ts
@@ -50,7 +50,7 @@ export const mapYamlObjectToRule = (obj: any): Rule => {
   const rule: Rule = {
     id: obj.id,
     category: obj.logsource ? obj.logsource.product : undefined,
-    log_source: '',
+    log_source: {},
     title: obj.title,
     description: obj.description,
     tags: obj.tags ? obj.tags.map((tag: string) => ({ value: tag })) : undefined,

--- a/test/mocks/Rules/components/RuleEditor/RuleEditorForm.mock.ts
+++ b/test/mocks/Rules/components/RuleEditor/RuleEditorForm.mock.ts
@@ -10,7 +10,7 @@ import { ruleStatus } from '../../../../../public/pages/Rules/utils/constants';
 export default {
   initialValue: {
     id: '25b9c01c-350d-4b95-bed1-836d04a4f324',
-    log_source: '',
+    log_source: {},
     logType: '',
     name: '',
     description: '',


### PR DESCRIPTION
### Description
When user imports a SIGMA rule, there is a chance that the `log_source` field in the rule provides the log type we should use in security analytics. This PR extracts that and sets the log type by default. However, since there are three possible values that can come from `category`, `product` or `service` under the `log_source` we go by the preference
1. product
2. category
3. service

i.e. if both product and category have a valid log type, we chose the one under `product`

![load-log-type](https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/01c8eea5-7772-4056-986a-2b7a41f8c86b)


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).