### PR TITLE
updated selected items state after action

### DIFF
--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -122,8 +122,16 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
     } catch (e: any) {
       errorNotificationToast(notifications, 'update', 'detector', e);
     }
-    this.getDetectors();
-    this.setState({ loadingDetectors: false });
+    await this.getDetectors();
+    const selectedItemIds = new Set(this.state.selectedItems.map(({ _id }) => _id));
+    const updatedSelectedItems: DetectorHit[] = [];
+    this.state.detectorHits.forEach((hit) => {
+      if (selectedItemIds.has(hit._id)) {
+        updatedSelectedItems.push(hit);
+      }
+    });
+
+    this.setState({ loadingDetectors: false, selectedItems: updatedSelectedItems });
   };
 
   onClickDelete = async () => {


### PR DESCRIPTION
### Description
When a detector is stopped using the action menu in the Detectors table, the action menu does not update for the selected item i.e. the menu item still says `Stop detector` even though the detector is stopped.
This PR fixes the issue by updating the selected items state maintained in the Detectors components after the action is complete and we load the updated list of detectors.

![detector-status-action-menu-fix](https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/60e6ada1-32eb-4255-b846-0ca2fff58c82)


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).