### PR TITLE
[UX] Updates to finding flyout for correlations tab

### DIFF
--- a/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
+++ b/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
@@ -47,7 +47,7 @@ export const CorrelationsTable: React.FC<CorrelationsTableProps> = ({
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<{
     [key: string]: JSX.Element;
   }>({});
-  const [findingIdCopied, setFindingIdCopied] = useState(false);
+  const [copiedFindingId, setCopiedFindingId] = useState('');
   const [copyPopoverTimeout, setCopyPopoverTimeout] = useState<number | undefined>(undefined);
 
   const toggleCorrelationDetails = (item: CorrelationFinding) => {
@@ -112,11 +112,11 @@ export const CorrelationsTable: React.FC<CorrelationsTableProps> = ({
     const copyFindingIdToClipboard = (findingId: string) => {
       try {
         window.navigator.clipboard.writeText(findingId);
-        setFindingIdCopied(true);
+        setCopiedFindingId(findingId);
         window.clearTimeout(copyPopoverTimeout);
         setCopyPopoverTimeout(
           window.setTimeout(() => {
-            setFindingIdCopied(false);
+            setCopiedFindingId('');
           }, 1000)
         );
       } catch (error: any) {
@@ -134,8 +134,8 @@ export const CorrelationsTable: React.FC<CorrelationsTableProps> = ({
               iconType="copy"
             />
           }
-          isOpen={findingIdCopied}
-          closePopover={() => setFindingIdCopied(false)}
+          isOpen={copiedFindingId === item.id}
+          closePopover={() => setCopiedFindingId('')}
           anchorPosition="upCenter"
         >
           <EuiText>Finding id copied</EuiText>

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -32,6 +32,7 @@ import {
   EuiTab,
   EuiLoadingContent,
   EuiEmptyPrompt,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import {
   capitalizeFirstLetter,
@@ -620,9 +621,11 @@ export default class FindingDetailsFlyout extends Component<
                   {tab.id === 'Correlations' ? (
                     <>
                       {tab.name} (
-                      {this.state.areCorrelationsLoading
-                        ? DEFAULT_EMPTY_DATA
-                        : this.state.correlatedFindings.length}
+                      {this.state.areCorrelationsLoading ? (
+                        <EuiLoadingSpinner size="s" />
+                      ) : (
+                        this.state.correlatedFindings.length
+                      )}
                       )
                     </>
                   ) : (


### PR DESCRIPTION
### Description
- Added loading spinner for the correlations count in tab header
- Fixed multiple pop-ups showing up when copying finding id for one table entry

### Issues Resolved
#834 partially solved

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).