### PR TITLE
Added spinner to better indicate that rules are loading during detector creation

### DIFF
--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
@@ -11,6 +11,7 @@ import {
   EuiEmptyPrompt,
   EuiButton,
   EuiIcon,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 
 import React, { useMemo, useState } from 'react';
@@ -47,12 +48,20 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
 }) => {
   const [flyoutData, setFlyoutData] = useState<RuleTableItem | null>(null);
 
-  let enabledRulesCount = 0;
-  rulesState.allRules.forEach((ruleItem) => {
-    if (ruleItem.enabled) {
-      enabledRulesCount++;
-    }
-  });
+  let enabledRulesCountDisplay: React.ReactNode;
+
+  if (loading) {
+    enabledRulesCountDisplay = <EuiLoadingSpinner size="m" />;
+  } else {
+    let count = 0;
+    rulesState.allRules.forEach((ruleItem) => {
+      if (ruleItem.enabled) {
+        count++;
+      }
+    });
+
+    enabledRulesCountDisplay = <span>{count}</span>;
+  }
 
   const ruleItems: RuleItem[] = useMemo(
     () =>
@@ -98,7 +107,11 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
         buttonContent={
           <div data-test-subj="detection-rules-btn">
             <EuiTitle size={'s'}>
-              <h4>{`Selected detection rules (${enabledRulesCount})`}</h4>
+              <h4>
+                {'Selected detection rules ('}
+                <>{enabledRulesCountDisplay}</>
+                {')'}
+              </h4>
             </EuiTitle>
             <EuiText size="s" color="subdued">
               Add or remove detection rules for this detector.


### PR DESCRIPTION
### Description
Added spinner to better indicate that rules are loading during detector creation

<img width="688" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/7625e5a9-45f0-446f-9bcf-e081b2d2a2e4">


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).