### PR TITLE
Fixed view surrounding logs for aliases

### DIFF
--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -415,7 +415,7 @@ export default class FindingDetailsFlyout extends Component<
             <CreateIndexPatternForm
               indexPatternsService={this.props.indexPatternsService}
               initialValue={{
-                name: this.props.finding.detector._source.inputs[0].detector_input.indices[0] + '*',
+                name: this.props.finding.index + '*',
               }}
               close={() =>
                 this.setState({ ...this.state, isCreateIndexPatternModalVisible: false })


### PR DESCRIPTION
### Description
When using an alias to create a detector, it abstracts away the actual index from which the documents are searched for generating finding. However, the finding returns the actual index name and hence when creating index pattern for showing surrounding logs we need to use the data source name stored in the finding and not the detector config because that would give us the alias name which won't work in the Discover plugin surrounding docs page

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).