### PR TITLE
Extend yaml mime type

### DIFF
--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -16,6 +16,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { setBreadCrumb, validateRule } from '../../utils/helpers';
 import { DataStore } from '../../../../store/DataStore';
+import { yamlMediaTypes } from '../../utils/constants';
 
 export interface ImportRuleProps {
   services: BrowserServices;
@@ -29,7 +30,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
   const onChange = useCallback((files: any) => {
     setFileError('');
 
-    if (files[0]?.type === 'application/x-yaml') {
+    if (yamlMediaTypes.has(files[0]?.type)) {
       let reader = new FileReader();
       reader.readAsText(files[0]);
       reader.onload = function () {

--- a/public/pages/Rules/utils/constants.ts
+++ b/public/pages/Rules/utils/constants.ts
@@ -56,3 +56,5 @@ export const ruleSeverity: {
 export const ruleSource: string[] = ['Standard', 'Custom'];
 
 export const ruleStatus: string[] = ['experimental', 'test', 'stable'];
+
+export const yamlMediaTypes = new Set(['application/x-yaml', 'text/yaml', 'text/x-yaml']);


### PR DESCRIPTION
### Description
Sometimes the file type for the imported yaml file can be one of the deprecated types (text/yaml, text/x-yaml) based on user's browser due to which we report the error for unsupported file. This PR also checks for these MIME types for yaml.

### Issues Resolved
#844 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).