### PR TITLE
Alert severity moved out of notifications toggle

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -500,7 +500,31 @@ export default class AlertConditionPanel extends Component<
           </>
         )}
 
-        <EuiSpacer size="l" />
+        <EuiSpacer size="s" />
+
+        <EuiFormRow
+          label={
+            <EuiText size="s">
+              <p>Alert severity</p>
+            </EuiText>
+          }
+        >
+          <EuiComboBox
+            placeholder={'Select applicable severity levels.'}
+            async={true}
+            options={Object.values(ALERT_SEVERITY_OPTIONS)}
+            selectedOptions={
+              severity ? [parseAlertSeverityToOption(severity)] : [ALERT_SEVERITY_OPTIONS.HIGHEST]
+            }
+            onChange={this.onAlertSeverityChange}
+            singleSelection={{ asPlainText: true }}
+            isClearable={false}
+            data-test-subj={'security-levels-combo-box'}
+          />
+        </EuiFormRow>
+
+        <EuiSpacer size={'l'} />
+
         <EuiSwitch
           label="Send notification"
           checked={showNotificationDetails}
@@ -511,31 +535,6 @@ export default class AlertConditionPanel extends Component<
 
         {showNotificationDetails && (
           <>
-            <EuiFormRow
-              label={
-                <EuiText size="s">
-                  <p>Alert severity</p>
-                </EuiText>
-              }
-            >
-              <EuiComboBox
-                placeholder={'Select applicable severity levels.'}
-                async={true}
-                options={Object.values(ALERT_SEVERITY_OPTIONS)}
-                selectedOptions={
-                  severity
-                    ? [parseAlertSeverityToOption(severity)]
-                    : [ALERT_SEVERITY_OPTIONS.HIGHEST]
-                }
-                onChange={this.onAlertSeverityChange}
-                singleSelection={{ asPlainText: true }}
-                isClearable={false}
-                data-test-subj={'security-levels-combo-box'}
-              />
-            </EuiFormRow>
-
-            <EuiSpacer size={'l'} />
-
             <EuiFlexGroup alignItems={'flexEnd'}>
               <EuiFlexItem style={{ maxWidth: 400 }}>
                 <EuiFormRow

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
@@ -432,42 +432,7 @@ Object {
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiSpacer euiSpacer--l"
-        />
-        <div
-          class="euiSwitch"
-        >
-          <button
-            aria-checked="true"
-            aria-labelledby="some_html_id"
-            class="euiSwitch__button"
-            id="some_html_id"
-            role="switch"
-            type="button"
-          >
-            <span
-              class="euiSwitch__body"
-            >
-              <span
-                class="euiSwitch__thumb"
-              />
-              <span
-                class="euiSwitch__track"
-              >
-                EuiIconMock
-                EuiIconMock
-              </span>
-            </span>
-          </button>
-          <span
-            class="euiSwitch__label"
-            id="some_html_id"
-          >
-            Send notification
-          </span>
-        </div>
-        <div
-          class="euiSpacer euiSpacer--l"
+          class="euiSpacer euiSpacer--s"
         />
         <div
           class="euiFormRow"
@@ -551,6 +516,41 @@ Object {
               </div>
             </div>
           </div>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiSwitch"
+        >
+          <button
+            aria-checked="true"
+            aria-labelledby="some_html_id"
+            class="euiSwitch__button"
+            id="some_html_id"
+            role="switch"
+            type="button"
+          >
+            <span
+              class="euiSwitch__body"
+            >
+              <span
+                class="euiSwitch__thumb"
+              />
+              <span
+                class="euiSwitch__track"
+              >
+                EuiIconMock
+                EuiIconMock
+              </span>
+            </span>
+          </button>
+          <span
+            class="euiSwitch__label"
+            id="some_html_id"
+          >
+            Send notification
+          </span>
         </div>
         <div
           class="euiSpacer euiSpacer--l"
@@ -1263,42 +1263,7 @@ Object {
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiSpacer euiSpacer--l"
-      />
-      <div
-        class="euiSwitch"
-      >
-        <button
-          aria-checked="true"
-          aria-labelledby="some_html_id"
-          class="euiSwitch__button"
-          id="some_html_id"
-          role="switch"
-          type="button"
-        >
-          <span
-            class="euiSwitch__body"
-          >
-            <span
-              class="euiSwitch__thumb"
-            />
-            <span
-              class="euiSwitch__track"
-            >
-              EuiIconMock
-              EuiIconMock
-            </span>
-          </span>
-        </button>
-        <span
-          class="euiSwitch__label"
-          id="some_html_id"
-        >
-          Send notification
-        </span>
-      </div>
-      <div
-        class="euiSpacer euiSpacer--l"
+        class="euiSpacer euiSpacer--s"
       />
       <div
         class="euiFormRow"
@@ -1382,6 +1347,41 @@ Object {
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiSwitch"
+      >
+        <button
+          aria-checked="true"
+          aria-labelledby="some_html_id"
+          class="euiSwitch__button"
+          id="some_html_id"
+          role="switch"
+          type="button"
+        >
+          <span
+            class="euiSwitch__body"
+          >
+            <span
+              class="euiSwitch__thumb"
+            />
+            <span
+              class="euiSwitch__track"
+            >
+              EuiIconMock
+              EuiIconMock
+            </span>
+          </span>
+        </button>
+        <span
+          class="euiSwitch__label"
+          id="some_html_id"
+        >
+          Send notification
+        </span>
       </div>
       <div
         class="euiSpacer euiSpacer--l"


### PR DESCRIPTION
### Description

Before (Alert severity is under `Send notifications` toggle):

<img width="751" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/aaa60386-0230-44f4-8420-75b13ac7e58c">

After (Moved the severity input outside the toggle):

<img width="751" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/46e9a703-36d9-4b58-ad7a-4f13e0738918">


### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).