### PR TITLE
[Backport 2.7] Check for empty document in the finding flyout (#841)

### DIFF
--- a/cypress/integration/4_findings.spec.js
+++ b/cypress/integration/4_findings.spec.js
@@ -162,6 +162,27 @@ describe('Findings', () => {
     });
   });
 
+  it('shows document not found warning when the document is empty', () => {
+    cy.deleteIndex(indexName);
+    cy.reload();
+
+    // Wait for page to load
+    cy.waitForPageLoad('findings', {
+      contains: 'Findings',
+    });
+
+    // filter table to show only sample_detector findings
+    cy.get(`input[placeholder="Search findings"]`).ospSearch(indexName);
+
+    // open Finding details flyout via finding id link. cy.wait essential, timeout insufficient.
+    cy.getTableFirstRow('[data-test-subj="view-details-icon"]').then(($el) => {
+      cy.get($el).click({ force: true });
+    });
+
+    // Flyout should show 'Document not found' warning
+    cy.contains('Document not found');
+  });
+
   it('...can delete detector', () => {
     // Visit Detectors page
     cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
@@ -200,27 +221,6 @@ describe('Findings', () => {
           cy.contains('There are no existing detectors.');
         });
     });
-  });
-
-  it('shows document not found warning when the document is empty', () => {
-    cy.deleteIndex(indexName);
-    cy.reload();
-
-    // Wait for page to load
-    cy.waitForPageLoad('findings', {
-      contains: 'Findings',
-    });
-
-    // filter table to show only sample_detector findings
-    cy.get(`input[placeholder="Search findings"]`).ospSearch(indexName);
-
-    // open Finding details flyout via finding id link. cy.wait essential, timeout insufficient.
-    cy.getTableFirstRow('[data-test-subj="view-details-icon"]').then(($el) => {
-      cy.get($el).click({ force: true });
-    });
-
-    // Flyout should show 'Document not found' warning
-    cy.contains('Document not found');
   });
 
   after(() => cy.cleanUpTests());

--- a/cypress/integration/4_findings.spec.js
+++ b/cypress/integration/4_findings.spec.js
@@ -142,9 +142,6 @@ describe('Findings', () => {
     });
   });
 
-  // TODO - upon reaching rules page, trigger appropriate rules detail flyout
-  // see github issue #124 at https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/124
-
   it('opens rule details flyout when rule name inside accordion drop down is clicked', () => {
     // filter table to show only sample_detector findings
     cy.get(`input[placeholder="Search findings"]`).ospSearch('sample_detector');
@@ -203,6 +200,27 @@ describe('Findings', () => {
           cy.contains('There are no existing detectors.');
         });
     });
+  });
+
+  it('shows document not found warning when the document is empty', () => {
+    cy.deleteIndex(indexName);
+    cy.reload();
+
+    // Wait for page to load
+    cy.waitForPageLoad('findings', {
+      contains: 'Findings',
+    });
+
+    // filter table to show only sample_detector findings
+    cy.get(`input[placeholder="Search findings"]`).ospSearch(indexName);
+
+    // open Finding details flyout via finding id link. cy.wait essential, timeout insufficient.
+    cy.getTableFirstRow('[data-test-subj="view-details-icon"]').then(($el) => {
+      cy.get($el).click({ force: true });
+    });
+
+    // Flyout should show 'Document not found' warning
+    cy.contains('Document not found');
   });
 
   after(() => cy.cleanUpTests());

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -32,6 +32,7 @@ import {
   EuiTab,
   EuiInMemoryTable,
   EuiBasicTableColumn,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import { capitalizeFirstLetter, renderTime } from '../../../utils/helpers';
 import { DEFAULT_EMPTY_DATA, ROUTES } from '../../../utils/constants';
@@ -254,9 +255,16 @@ export default class FindingDetailsFlyout extends Component<
     const docId = related_doc_ids[0];
     const matchedDocuments = documents.filter((doc) => doc.id === docId);
     const document = matchedDocuments.length > 0 ? matchedDocuments[0].document : '';
+    let formattedDocument = '';
+    try {
+      formattedDocument = document ? JSON.stringify(JSON.parse(document), null, 2) : '';
+    } catch {
+      // no-op
+    }
+
     const { indexPatternId } = this.state;
 
-    return (
+    return document ? (
       <>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem>
@@ -314,9 +322,22 @@ export default class FindingDetailsFlyout extends Component<
             isCopyable
             data-test-subj={'finding-details-flyout-rule-document'}
           >
-            {JSON.stringify(JSON.parse(document), null, 2)}
+            {formattedDocument}
           </EuiCodeBlock>
         </EuiFormRow>
+      </>
+    ) : (
+      <>
+        <EuiTitle size={'s'}>
+          <h3>Documents</h3>
+        </EuiTitle>
+        <EuiSpacer />
+        <EuiEmptyPrompt
+          iconType="alert"
+          iconColor="danger"
+          title={<h2>Document not found</h2>}
+          body={<p>The document that generated this finding could not be loaded.</p>}
+        />
       </>
     );
   }


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/security-analytics-dashboards-plugin/commit/7837a99e26f356542a1006a4329eecbcb3fe44ce from https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/841.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).