### PR TITLE
Omit alias matching log field from mapping creation payload

### DIFF
--- a/public/services/FieldMappingService.ts
+++ b/public/services/FieldMappingService.ts
@@ -43,6 +43,10 @@ export default class FieldMappingService {
       properties: {},
     };
     fieldMappings.forEach((mapping) => {
+      if (mapping.ruleFieldName === mapping.indexFieldName) {
+        return;
+      }
+
       alias_mappings.properties[mapping.ruleFieldName] = {
         type: 'alias',
         path: mapping.indexFieldName,


### PR DESCRIPTION
### Description
Alias name should not be same as a log field in the index mapping, so we should remove that from create mapping payload

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).