### PR TITLE
Fixed logic to get all alerts for a detector

### DIFF
--- a/public/store/AlertsStore.ts
+++ b/public/store/AlertsStore.ts
@@ -6,7 +6,6 @@
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { AlertsService } from '../services';
 import { errorNotificationToast } from '../utils/helpers';
-import { GetAlertsResponse, ServerResponse } from '../../types';
 
 export class AlertsStore {
   constructor(
@@ -16,49 +15,42 @@ export class AlertsStore {
 
   public async getAlertsByDetector(detectorId: string, detectorName: string) {
     let allAlerts: any[] = [];
-    const alertsSize = 10000;
+    const maxAlertsReturned = 10000;
+    let startIndex = 0;
+    let alertsCount = 0;
 
-    const firstGetAlertsRes = await this.service.getAlerts({
-      detector_id: detectorId,
-      startIndex: 0,
-      size: alertsSize,
-    });
+    do {
+      const getAlertsRes = await this.service.getAlerts({
+        detector_id: detectorId,
+        startIndex,
+        size: maxAlertsReturned,
+      });
 
-    if (firstGetAlertsRes.ok) {
-      allAlerts = [...firstGetAlertsRes.response.alerts];
-      let remainingAlerts = firstGetAlertsRes.response.total_alerts - alertsSize;
-      let startIndex = alertsSize + 1;
-      const getAlertsPromises: Promise<ServerResponse<GetAlertsResponse>>[] = [];
-
-      while (remainingAlerts > 0) {
-        getAlertsPromises.push(
-          this.service.getAlerts({ detector_id: detectorId, startIndex, size: alertsSize })
-        );
-        remainingAlerts -= alertsSize;
-        startIndex += alertsSize;
+      if (getAlertsRes.ok) {
+        allAlerts = allAlerts.concat(getAlertsRes.response.alerts);
+        alertsCount = getAlertsRes.response.alerts.length;
+      } else {
+        alertsCount = 0;
+        errorNotificationToast(this.notifications, 'retrieve', 'alerts', getAlertsRes.error);
       }
 
-      const alertsPromisesRes = await Promise.allSettled(getAlertsPromises);
+      startIndex += alertsCount;
+    } while (
+      // If we get 10,000 alerts as part of the previous call then there might be more alerts to fetch,
+      // hence we make another call until the number of alerts is less then 10,000
+      alertsCount === maxAlertsReturned
+    );
 
-      alertsPromisesRes.forEach((response) => {
-        if (response.status === 'fulfilled' && response.value.ok) {
-          allAlerts = allAlerts.concat(response.value.response.alerts);
-        }
-      });
+    allAlerts = allAlerts.map((alert) => {
+      if (!alert.detector_id) {
+        alert.detector_id = detectorId;
+      }
 
-      allAlerts = allAlerts.map((alert) => {
-        if (!alert.detector_id) {
-          alert.detector_id = detectorId;
-        }
-
-        return {
-          ...alert,
-          detectorName: detectorName,
-        };
-      });
-    } else {
-      errorNotificationToast(this.notifications, 'retrieve', 'alerts', firstGetAlertsRes.error);
-    }
+      return {
+        ...alert,
+        detectorName: detectorName,
+      };
+    });
 
     return allAlerts;
   }


### PR DESCRIPTION
### Description
The `total_alerts` count of getAlerts API is capped at 10000, so we cannot rely on that count to find the total number of alerts. As a mitigation, the logic has been refactored to fetch alerts until we get less than 10k alerts which would mean there are no more alerts remaining.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).