### PR TITLE
Fixed rule validations to comply with Sigma spec; Import rule validates only based in file content and not type

### DIFF
--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import { getMappingFields } from '../../public/pages/Detectors/utils/helpers';
 import { getLogTypeLabel } from '../../public/pages/LogTypes/utils/helpers';
 import { setupIntercept } from '../support/helpers';
-import { descriptionErrorString } from '../../public/utils/validation';
+import { descriptionError } from '../../public/utils/validation';
 
 const cypressIndexDns = 'cypress-index-dns';
 const cypressIndexWindows = 'cypress-index-windows';
@@ -280,7 +280,7 @@ describe('Detectors', () => {
       getDescriptionField()
         .parents('.euiFormRow__fieldWrapper')
         .find('.euiFormErrorText')
-        .contains(descriptionErrorString);
+        .contains(descriptionError);
 
       getDescriptionField()
         .type('{selectall}')

--- a/cypress/integration/2_rules.spec.js
+++ b/cypress/integration/2_rules.spec.js
@@ -9,6 +9,7 @@ import { setupIntercept } from '../support/helpers';
 import {
   detectionRuleNameError,
   detectionRuleDescriptionError,
+  MAX_RULE_DESCRIPTION_LENGTH,
 } from '../../public/utils/validation';
 
 const uniqueId = Cypress._.random(0, 1e6);
@@ -148,9 +149,6 @@ const getMapListField = () => cy.get('[data-test-subj="selection_field_list"]');
 const getListRadioField = () => cy.get('[for="selection-map-list-0-0"]');
 const getTextRadioField = () => cy.get('[for="selection-map-value-0-0"]');
 const getConditionField = () => cy.get('[data-test-subj="rule_detection_field"]');
-const getConditionAddButton = () => cy.get('[data-test-subj="condition-add-selection-btn"]');
-const getConditionRemoveButton = (index) =>
-  cy.get(`[data-test-subj="selection-exp-field-item-remove-${index}"]`);
 const getRuleSubmitButton = () => cy.get('[data-test-subj="submit_rule_form_button"]');
 const getTagField = (index) => cy.get(`[data-test-subj="rule_tags_field_${index}"]`);
 const getReferenceFieldByIndex = (index) =>
@@ -238,12 +236,7 @@ describe('Rules', () => {
     it('...should validate rule description field', () => {
       getDescriptionField().should('be.empty');
 
-      let invalidDescription = '';
-
-      for (let i = 0; i < 65535; i++) {
-        invalidDescription += 'a';
-      }
-
+      const invalidDescription = 'a'.repeat(MAX_RULE_DESCRIPTION_LENGTH);
       getDescriptionField().focus().invoke('val', invalidDescription).type('b').blur();
 
       getDescriptionField()

--- a/cypress/integration/2_rules.spec.js
+++ b/cypress/integration/2_rules.spec.js
@@ -437,7 +437,6 @@ describe('Rules', () => {
 
       // author field
       getAuthorField().clearValue();
-      toastShouldExist();
       getAuthorField().type('John Doe');
 
       // log field

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -27,7 +27,9 @@ import { ruleSeverity, ruleStatus, ruleTypes } from '../../utils/constants';
 import {
   AUTHOR_REGEX,
   RULE_DESCRIPTION_REGEX,
-  ruleDescriptionErrorString,
+  RULE_NAME_REGEX,
+  detectionRuleNameError,
+  detectionRuleDescriptionError,
   validateDescription,
   validateName,
 } from '../../../../utils/validation';
@@ -110,7 +112,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
         if (!values.name) {
           errors.name = 'Rule name is required';
         } else {
-          if (!validateName(values.name)) {
+          if (!validateName(values.name, RULE_NAME_REGEX)) {
             errors.name = 'Invalid rule name.';
           }
         }
@@ -119,7 +121,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
           values.description &&
           !validateDescription(values.description, RULE_DESCRIPTION_REGEX)
         ) {
-          errors.description = ruleDescriptionErrorString;
+          errors.description = detectionRuleDescriptionError;
         }
 
         if (!values.logType) {
@@ -138,12 +140,8 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
           errors.level = `Invalid rule level. Should be one of critical, high, medium, low, informational`;
         }
 
-        if (!values.author) {
-          errors.author = 'Author name is required';
-        } else {
-          if (!validateName(values.author, AUTHOR_REGEX)) {
-            errors.author = 'Invalid author.';
-          }
+        if (!validateName(values.author, AUTHOR_REGEX)) {
+          errors.author = 'Invalid author.';
         }
 
         if (!values.status) {
@@ -210,12 +208,12 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       <strong>Rule name</strong>
                     </EuiText>
                   }
-                  isInvalid={!!props.errors?.name}
+                  isInvalid={(validateOnMount || props.touched.name) && !!props.errors?.name}
                   error={props.errors.name}
-                  helpText="Rule name must contain 5-50 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores"
+                  helpText={detectionRuleNameError}
                 >
                   <EuiFieldText
-                    isInvalid={!!props.errors?.name}
+                    isInvalid={(validateOnMount || props.touched.name) && !!props.errors?.name}
                     placeholder="My custom rule"
                     data-test-subj={'rule_name_field'}
                     onChange={(e) => {
@@ -235,7 +233,9 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       <i>- optional</i>
                     </EuiText>
                   }
-                  isInvalid={!!props.errors?.description}
+                  isInvalid={
+                    (validateOnMount || props.touched.description) && !!props.errors?.description
+                  }
                   error={props.errors.description}
                 >
                   <EuiFieldText
@@ -258,11 +258,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     </EuiText>
                   }
                   helpText="Combine multiple authors separated with a comma"
-                  isInvalid={!!props.errors?.author}
+                  isInvalid={(validateOnMount || props.touched.author) && !!props.errors?.author}
                   error={props.errors.author}
                 >
                   <EuiFieldText
-                    isInvalid={!!props.errors?.author}
+                    isInvalid={(validateOnMount || props.touched.author) && !!props.errors?.author}
                     placeholder="Enter author name"
                     data-test-subj={'rule_author_field'}
                     onChange={(e) => {
@@ -291,11 +291,15 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                           <strong>Log type</strong>
                         </EuiText>
                       }
-                      isInvalid={!!props.errors?.logType}
+                      isInvalid={
+                        (validateOnMount || props.touched.logType) && !!props.errors?.logType
+                      }
                       error={props.errors.logType}
                     >
                       <EuiComboBox
-                        isInvalid={!!props.errors?.logType}
+                        isInvalid={
+                          (validateOnMount || props.touched.logType) && !!props.errors?.logType
+                        }
                         placeholder="Select a log type"
                         data-test-subj={'rule_type_dropdown'}
                         options={logTypeOptions}
@@ -336,11 +340,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       <strong>Rule level (severity)</strong>
                     </EuiText>
                   }
-                  isInvalid={!!props.errors?.level}
+                  isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
                   error={props.errors.level}
                 >
                   <EuiComboBox
-                    isInvalid={!!props.errors?.level}
+                    isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
                     placeholder="Select a rule level"
                     data-test-subj={'rule_severity_dropdown'}
                     options={ruleSeverity.map(({ name, value }) => ({ label: name, value }))}
@@ -370,11 +374,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       <strong>Rule Status</strong>
                     </EuiText>
                   }
-                  isInvalid={!!props.errors?.status}
+                  isInvalid={(validateOnMount || props.touched.status) && !!props.errors?.status}
                   error={props.errors.status}
                 >
                   <EuiComboBox
-                    isInvalid={!!props.errors?.status}
+                    isInvalid={(validateOnMount || props.touched.status) && !!props.errors?.status}
                     placeholder="Select a rule status"
                     data-test-subj={'rule_status_dropdown'}
                     options={ruleStatus.map((type: string) => ({ value: type, label: type }))}
@@ -405,7 +409,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                 <EuiSpacer />
 
                 <DetectionVisualEditor
-                  isInvalid={isDetectionInvalid}
+                  isInvalid={(validateOnMount || props.touched.detection) && isDetectionInvalid}
                   detectionYml={props.values.detection}
                   goToYamlEditor={setSelectedEditorType}
                   setIsDetectionInvalid={(isInvalid: boolean) => {
@@ -457,7 +461,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                         addButtonName="Add tag"
                         fields={props.values.tags}
                         error={props.errors.tags}
-                        isInvalid={!!props.errors.tags}
+                        isInvalid={(validateOnMount || props.touched.tags) && !!props.errors.tags}
                         onChange={(tags) => {
                           props.touched.tags = true;
                           props.setFieldValue('tags', tags);
@@ -485,7 +489,10 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                         addButtonName="Add URL"
                         fields={props.values.references}
                         error={props.errors.references}
-                        isInvalid={!!props.errors?.references}
+                        isInvalid={
+                          (validateOnMount || props.touched.references) &&
+                          !!props.errors?.references
+                        }
                         onChange={(references) => {
                           props.touched.references = true;
                           props.setFieldValue('references', references);
@@ -513,7 +520,10 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                         addButtonName="Add false positive"
                         fields={props.values.falsePositives}
                         error={props.errors.falsePositives}
-                        isInvalid={!!props.errors?.falsePositives}
+                        isInvalid={
+                          (validateOnMount || props.touched.falsePositives) &&
+                          !!props.errors?.falsePositives
+                        }
                         onChange={(falsePositives) => {
                           props.touched.falsePositives = true;
                           props.setFieldValue('falsePositives', falsePositives);

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorContainer.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorContainer.test.tsx.snap
@@ -116,7 +116,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -153,7 +152,7 @@ Object {
                   class="euiFormHelpText euiFormRow__text"
                   id="some_html_id-help-0"
                 >
-                  Rule name must contain 5-50 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores
+                  Rule name can be max 256 characters.
                 </div>
               </div>
             </div>
@@ -168,7 +167,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -216,7 +214,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -285,7 +282,6 @@ Object {
                     class="euiFormRow__labelWrapper"
                   >
                     <label
-                      aria-invalid="false"
                       class="euiFormLabel euiFormRow__label"
                       for="some_html_id"
                     >
@@ -393,7 +389,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -477,7 +472,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -1167,7 +1161,6 @@ Object {
                             class="euiFormRow__labelWrapper"
                           >
                             <label
-                              aria-invalid="false"
                               class="euiFormLabel euiFormRow__label"
                               for="some_html_id"
                             >
@@ -1251,7 +1244,6 @@ Object {
                             class="euiFormRow__labelWrapper"
                           >
                             <label
-                              aria-invalid="false"
                               class="euiFormLabel euiFormRow__label"
                               for="some_html_id"
                             >
@@ -1335,7 +1327,6 @@ Object {
                             class="euiFormRow__labelWrapper"
                           >
                             <label
-                              aria-invalid="false"
                               class="euiFormLabel euiFormRow__label"
                               for="some_html_id"
                             >
@@ -1581,7 +1572,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1618,7 +1608,7 @@ Object {
                 class="euiFormHelpText euiFormRow__text"
                 id="some_html_id-help-0"
               >
-                Rule name must contain 5-50 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores
+                Rule name can be max 256 characters.
               </div>
             </div>
           </div>
@@ -1633,7 +1623,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1681,7 +1670,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1750,7 +1738,6 @@ Object {
                   class="euiFormRow__labelWrapper"
                 >
                   <label
-                    aria-invalid="false"
                     class="euiFormLabel euiFormRow__label"
                     for="some_html_id"
                   >
@@ -1858,7 +1845,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1942,7 +1928,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -2632,7 +2617,6 @@ Object {
                           class="euiFormRow__labelWrapper"
                         >
                           <label
-                            aria-invalid="false"
                             class="euiFormLabel euiFormRow__label"
                             for="some_html_id"
                           >
@@ -2716,7 +2700,6 @@ Object {
                           class="euiFormRow__labelWrapper"
                         >
                           <label
-                            aria-invalid="false"
                             class="euiFormLabel euiFormRow__label"
                             for="some_html_id"
                           >
@@ -2800,7 +2783,6 @@ Object {
                           class="euiFormRow__labelWrapper"
                         >
                           <label
-                            aria-invalid="false"
                             class="euiFormLabel euiFormRow__label"
                             for="some_html_id"
                           >

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorForm.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorForm.test.tsx.snap
@@ -116,7 +116,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -153,7 +152,7 @@ Object {
                   class="euiFormHelpText euiFormRow__text"
                   id="some_html_id-help-0"
                 >
-                  Rule name must contain 5-50 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores
+                  Rule name can be max 256 characters.
                 </div>
               </div>
             </div>
@@ -168,7 +167,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -216,7 +214,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -285,7 +282,6 @@ Object {
                     class="euiFormRow__labelWrapper"
                   >
                     <label
-                      aria-invalid="false"
                       class="euiFormLabel euiFormRow__label"
                       for="some_html_id"
                     >
@@ -393,7 +389,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -477,7 +472,6 @@ Object {
                 class="euiFormRow__labelWrapper"
               >
                 <label
-                  aria-invalid="false"
                   class="euiFormLabel euiFormRow__label"
                   for="some_html_id"
                 >
@@ -1167,7 +1161,6 @@ Object {
                             class="euiFormRow__labelWrapper"
                           >
                             <label
-                              aria-invalid="false"
                               class="euiFormLabel euiFormRow__label"
                               for="some_html_id"
                             >
@@ -1251,7 +1244,6 @@ Object {
                             class="euiFormRow__labelWrapper"
                           >
                             <label
-                              aria-invalid="false"
                               class="euiFormLabel euiFormRow__label"
                               for="some_html_id"
                             >
@@ -1335,7 +1327,6 @@ Object {
                             class="euiFormRow__labelWrapper"
                           >
                             <label
-                              aria-invalid="false"
                               class="euiFormLabel euiFormRow__label"
                               for="some_html_id"
                             >
@@ -1578,7 +1569,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1615,7 +1605,7 @@ Object {
                 class="euiFormHelpText euiFormRow__text"
                 id="some_html_id-help-0"
               >
-                Rule name must contain 5-50 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores
+                Rule name can be max 256 characters.
               </div>
             </div>
           </div>
@@ -1630,7 +1620,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1678,7 +1667,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1747,7 +1735,6 @@ Object {
                   class="euiFormRow__labelWrapper"
                 >
                   <label
-                    aria-invalid="false"
                     class="euiFormLabel euiFormRow__label"
                     for="some_html_id"
                   >
@@ -1855,7 +1842,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -1939,7 +1925,6 @@ Object {
               class="euiFormRow__labelWrapper"
             >
               <label
-                aria-invalid="false"
                 class="euiFormLabel euiFormRow__label"
                 for="some_html_id"
               >
@@ -2629,7 +2614,6 @@ Object {
                           class="euiFormRow__labelWrapper"
                         >
                           <label
-                            aria-invalid="false"
                             class="euiFormLabel euiFormRow__label"
                             for="some_html_id"
                           >
@@ -2713,7 +2697,6 @@ Object {
                           class="euiFormRow__labelWrapper"
                         >
                           <label
-                            aria-invalid="false"
                             class="euiFormLabel euiFormRow__label"
                             for="some_html_id"
                           >
@@ -2797,7 +2780,6 @@ Object {
                           class="euiFormRow__labelWrapper"
                         >
                           <label
-                            aria-invalid="false"
                             class="euiFormLabel euiFormRow__label"
                             for="some_html_id"
                           >

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -37,14 +37,14 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
           const yamlContent: any = reader.result;
 
           if (!yamlContent) {
-            setFileError('Invalid file content');
+            setFileError('Invalid file content.');
             return;
           }
 
           const jsonContent: { [key: string]: any } = load(yamlContent) as object;
 
           if (!jsonContent) {
-            setFileError('Invalid yaml content');
+            setFileError('Invalid yaml content.');
             return;
           }
 
@@ -82,7 +82,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
             />
           );
         } catch (error: any) {
-          setFileError('Invalid file content');
+          setFileError('Invalid file content.');
         }
       };
     }

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -14,7 +14,6 @@ import { ContentPanel } from '../../../../components/ContentPanel';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { setBreadCrumb } from '../../utils/helpers';
-import { yamlMediaTypes } from '../../utils/constants';
 import { Rule } from '../../../../../types';
 import { DEFAULT_RULE_UUID } from '../../../../../common/constants';
 
@@ -27,10 +26,10 @@ export interface ImportRuleProps {
 export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notifications }) => {
   const context = useContext(CoreServicesContext);
   const [fileError, setFileError] = useState('');
-  const onChange = useCallback((files: any) => {
+  const onChange = useCallback((files: FileList | null) => {
     setFileError('');
 
-    if (yamlMediaTypes.has(files[0]?.type)) {
+    if (!!files?.item(0)) {
       let reader = new FileReader();
       reader.readAsText(files[0]);
       reader.onload = function () {
@@ -38,11 +37,11 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
           const yamlContent: any = reader.result;
 
           if (!yamlContent) {
-            setFileError('Invalid content in file');
+            setFileError('Invalid file content');
             return;
           }
 
-          const jsonContent = load(yamlContent);
+          const jsonContent: { [key: string]: any } = load(yamlContent) as object;
 
           if (!jsonContent) {
             setFileError('Invalid yaml content');
@@ -86,8 +85,6 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
           setFileError('Invalid file content');
         }
       };
-    } else {
-      setFileError(files.length > 0 ? 'Only yaml files are accepted' : '');
     }
   }, []);
 

--- a/public/pages/Rules/utils/constants.ts
+++ b/public/pages/Rules/utils/constants.ts
@@ -58,5 +58,3 @@ export const ruleSource: string[] = ['Standard', 'Custom'];
 export const ruleStatus: string[] = ['experimental', 'test', 'stable'];
 
 export const sigmaRuleLogSourceFields = ['product', 'category', 'service'];
-
-export const yamlMediaTypes = new Set(['application/x-yaml', 'text/yaml', 'text/x-yaml']);

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -16,6 +16,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import {
   AUTHOR_REGEX,
   RULE_DESCRIPTION_REGEX,
+  RULE_NAME_REGEX,
   validateDescription,
   validateName,
 } from '../../../utils/validation';
@@ -142,14 +143,14 @@ export function validateRule(
 ): boolean {
   const invalidFields = [];
 
-  if (!rule.title || !validateName(rule.title)) invalidFields.push('Rule name');
+  if (!rule.title || !validateName(rule.title, RULE_NAME_REGEX)) invalidFields.push('Rule name');
   if (!validateDescription(rule.description, RULE_DESCRIPTION_REGEX)) {
     invalidFields.push('Description');
   }
   if (!rule.category) invalidFields.push('Log type');
   if (!rule.detection) invalidFields.push('Detection');
   if (!rule.level) invalidFields.push('Rule level');
-  if (!rule.author || !validateName(rule.author, AUTHOR_REGEX)) invalidFields.push('Author');
+  if (!validateName(rule.author, AUTHOR_REGEX)) invalidFields.push('Author');
   if (!rule.status) invalidFields.push('Rule status');
 
   if (rule.detection) {

--- a/public/utils/validation.ts
+++ b/public/utils/validation.ts
@@ -78,8 +78,10 @@ export function getNameErrorMessage(
 // numbers 0-9, hyphens, periods, spaces, and underscores.
 export const DESCRIPTION_REGEX = new RegExp(/^[a-zA-Z0-9 _.,-]{0,500}$/);
 
+export const MAX_RULE_DESCRIPTION_LENGTH = 65535;
+
 // This regex pattern support MIN to MAX character limit for detection rule description.
-export const RULE_DESCRIPTION_REGEX = new RegExp(/^.{0,65535}$/);
+export const RULE_DESCRIPTION_REGEX = new RegExp(`^.{0,${MAX_RULE_DESCRIPTION_LENGTH}}$`);
 
 /**
  * Validates a string against NAME_REGEX.

--- a/public/utils/validation.ts
+++ b/public/utils/validation.ts
@@ -10,6 +10,9 @@ export const MAX_NAME_CHARACTERS = 50;
 // numbers 0-9, hyphens, spaces, and underscores.
 export const NAME_REGEX = new RegExp(/^[a-zA-Z0-9 _-]{5,50}$/);
 
+// This regex pattern support MIN to MAX character limit for detection rule name
+export const RULE_NAME_REGEX = new RegExp(/^.{1,256}$/);
+
 export const LOG_TYPE_NAME_REGEX = new RegExp(/^[a-z0-9_-]{2,50}$/);
 
 // This regex pattern support MIN to MAX character limit, capital and lowercase letters,
@@ -20,9 +23,8 @@ export const DETECTION_CONDITION_REGEX = new RegExp(
   /^((not )?.+)?( (and|or|and not|or not|not) ?(.+))*(?<!and|or|not)$/
 );
 
-// This regex pattern support MIN to MAX character limit, capital and lowercase letters,
-// numbers 0-9, hyphens, spaces, and underscores.
-export const AUTHOR_REGEX = new RegExp(/^[a-zA-Z0-9 _,-.\\(\\)@#$&;]{1,50}$/);
+// This regex pattern support MIN to MAX character limit.
+export const AUTHOR_REGEX = new RegExp(/^.{0,256}$/);
 
 /**
  * Validates a string against NAME_REGEX.
@@ -76,9 +78,8 @@ export function getNameErrorMessage(
 // numbers 0-9, hyphens, periods, spaces, and underscores.
 export const DESCRIPTION_REGEX = new RegExp(/^[a-zA-Z0-9 _.,-]{0,500}$/);
 
-// This regex pattern support MIN to MAX character limit, capital and lowercase letters,
-// numbers 0-9, hyphens, periods, spaces, and underscores.
-export const RULE_DESCRIPTION_REGEX = new RegExp(/^[a-zA-Z0-9 _.,-\\(\\)@#$&;]{0,65535}$/);
+// This regex pattern support MIN to MAX character limit for detection rule description.
+export const RULE_DESCRIPTION_REGEX = new RegExp(/^.{0,65535}$/);
 
 /**
  * Validates a string against NAME_REGEX.
@@ -92,9 +93,9 @@ export function validateDescription(
   return name.trim().match(descriptionRegex) !== null;
 }
 
-export const descriptionErrorString = `Description should only consist of upper and lowercase letters, numbers 0-9, commas, hyphens, periods, spaces, and underscores. Max limit of 500 characters.`;
+export const descriptionError = `Description should only consist of upper and lowercase letters, numbers 0-9, commas, hyphens, periods, spaces, and underscores. Max limit of 500 characters.`;
 
-export const ruleDescriptionErrorString = `Description should only consist of upper and lowercase letters, numbers 0-9, commas, hyphens, periods, spaces, and underscores. Max limit of 65,535 characters.`;
+export const detectionRuleDescriptionError = `Description has max limit of 65,535 characters.`;
 
 export function getDescriptionErrorMessage(
   _description: string,
@@ -102,10 +103,12 @@ export function getDescriptionErrorMessage(
   descriptionFieldTouched: boolean
 ) {
   if (descriptionFieldTouched && descriptionIsInvalid) {
-    return descriptionErrorString;
+    return descriptionError;
   }
 }
 
 export function validateField(hasSubmitted: boolean, fieldTouched: boolean) {
   return hasSubmitted || fieldTouched;
 }
+
+export const detectionRuleNameError = 'Rule name can be max 256 characters.';


### PR DESCRIPTION
### Description
This PR fixes 2 issues:
1. Drops strict validation for rule name, description and author and follows Sigma rule specification
2. When importing yaml files since the Mime time is not reliably defined and varies by platform (windows, linux, etc.), there could be false errors

### Issues Resolved
#941, #943 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).