### PR TITLE
Allow multiple aliases to same field when creating/editing mappings for detector

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldMappingsTable.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldMappingsTable.tsx
@@ -32,7 +32,6 @@ export interface MappingProps {
   [MappingViewType.Edit]: {
     type: MappingViewType.Edit;
     existingMappings: ruleFieldToIndexFieldMap;
-    invalidMappingFieldNames: string[];
     onMappingCreation: (fieldName: string, aliasName: string) => void;
   };
 }
@@ -98,7 +97,7 @@ export default class FieldMappingsTable<T extends MappingViewType> extends Compo
         width: '45%',
         render: (logFieldName: string, entry: FieldMappingsTableItem) => {
           if (this.props.mappingProps.type === MappingViewType.Edit) {
-            const { onMappingCreation, invalidMappingFieldNames, existingMappings } = this.props
+            const { onMappingCreation, existingMappings } = this.props
               .mappingProps as MappingProps[MappingViewType.Edit];
             const onMappingSelected = (selectedField: string) => {
               onMappingCreation(entry.ruleFieldName, selectedField);
@@ -107,7 +106,6 @@ export default class FieldMappingsTable<T extends MappingViewType> extends Compo
               <FieldNameSelector
                 fieldNameOptions={indexFields}
                 selectedField={existingMappings[entry.ruleFieldName]}
-                isInvalid={invalidMappingFieldNames.includes(entry.ruleFieldName)}
                 onChange={onMappingSelected}
               />
             );
@@ -131,14 +129,11 @@ export default class FieldMappingsTable<T extends MappingViewType> extends Compo
         align: 'center',
         width: '15%',
         render: (_status: 'mapped' | 'unmapped', entry: FieldMappingsTableItem) => {
-          const { existingMappings: createdMappings, invalidMappingFieldNames } = this.props
+          const { existingMappings: createdMappings } = this.props
             .mappingProps as MappingProps[MappingViewType.Edit];
           let iconProps = STATUS_ICON_PROPS['unmapped'];
           let iconTooltip = 'This field needs to be mapped with a field from your log source.';
-          if (
-            createdMappings[entry.ruleFieldName] &&
-            !invalidMappingFieldNames.includes(entry.ruleFieldName)
-          ) {
+          if (createdMappings[entry.ruleFieldName]) {
             iconProps = STATUS_ICON_PROPS['mapped'];
             iconTooltip = 'This field has been mapped.';
           }

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldNameSelector.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldNameSelector.tsx
@@ -8,7 +8,6 @@ import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow } from '@elastic/eui';
 
 interface SIEMFieldNameProps {
   fieldNameOptions: string[];
-  isInvalid: boolean;
   selectedField: string;
   onChange: (option: string) => void;
 }
@@ -51,18 +50,14 @@ export default class FieldNameSelector extends Component<SIEMFieldNameProps, SIE
 
   render() {
     const { selectedOptions } = this.state;
-    const { isInvalid, fieldNameOptions } = this.props;
+    const { fieldNameOptions } = this.props;
 
     const comboOptions = fieldNameOptions.map((option) => ({
       label: option,
     }));
 
     return (
-      <EuiFormRow
-        style={{ width: '100%' }}
-        isInvalid={isInvalid}
-        error={isInvalid ? 'Field already used.' : undefined}
-      >
+      <EuiFormRow style={{ width: '100%' }}>
         <EuiComboBox
           data-test-subj={'detector-field-mappings-select'}
           placeholder="Select a mapping field"

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping.tsx
@@ -47,7 +47,6 @@ interface ConfigureFieldMappingState {
   detector: Detector;
   mappingsData: GetFieldMappingViewResponse;
   createdMappings: ruleFieldToIndexFieldMap;
-  invalidMappingFieldNames: string[];
   fieldMappingIsOpen: boolean;
   showMappingEmptyPrompt: boolean;
   selectedTabId: FieldMappingTabId;
@@ -78,7 +77,6 @@ export default class ConfigureFieldMapping extends Component<
       loading: props.loading || false,
       mappingsData: EMPTY_FIELD_MAPPINGS_VIEW,
       createdMappings,
-      invalidMappingFieldNames: [],
       detector: props.detector,
       fieldMappingIsOpen: false,
       tabs: [],
@@ -132,7 +130,6 @@ export default class ConfigureFieldMapping extends Component<
       loading,
       mappingsData,
       createdMappings,
-      invalidMappingFieldNames,
       selectedTabId,
       detector: { detector_type, inputs },
     } = this.state;
@@ -187,7 +184,6 @@ export default class ConfigureFieldMapping extends Component<
               mappingProps={{
                 type: MappingViewType.Edit,
                 existingMappings,
-                invalidMappingFieldNames,
                 onMappingCreation: this.onMappingCreation,
               }}
             />
@@ -220,7 +216,6 @@ export default class ConfigureFieldMapping extends Component<
               mappingProps={{
                 type: MappingViewType.Edit,
                 existingMappings,
-                invalidMappingFieldNames,
                 onMappingCreation: this.onMappingCreation,
               }}
             />
@@ -321,24 +316,6 @@ export default class ConfigureFieldMapping extends Component<
     }
   };
 
-  /**
-   * Returns the fieldName(s) that have duplicate alias assigned to them
-   */
-  getInvalidMappingFieldNames(mappings: ruleFieldToIndexFieldMap): string[] {
-    const seenAliases = new Set();
-    const invalidFields: string[] = [];
-
-    Object.entries(mappings).forEach((entry) => {
-      if (seenAliases.has(entry[1])) {
-        invalidFields.push(entry[0]);
-      }
-
-      seenAliases.add(entry[1]);
-    });
-
-    return invalidFields;
-  }
-
   onMappingCreation = (ruleFieldName: string, indexFieldName: string): void => {
     const newMappings: ruleFieldToIndexFieldMap = {
       ...this.state.createdMappings,
@@ -349,10 +326,8 @@ export default class ConfigureFieldMapping extends Component<
       delete newMappings[ruleFieldName];
     }
 
-    const invalidMappingFieldNames = this.getInvalidMappingFieldNames(newMappings);
     this.setState({
       createdMappings: newMappings,
-      invalidMappingFieldNames: invalidMappingFieldNames,
     });
     this.updateMappingSharedState(newMappings);
     this.context.metrics.detectorMetricsManager.sendMetrics(

--- a/public/pages/Detectors/containers/FieldMappings/EditFieldMapping.tsx
+++ b/public/pages/Detectors/containers/FieldMappings/EditFieldMapping.tsx
@@ -40,7 +40,6 @@ interface EditFieldMappingsProps extends RouteComponentProps {
 interface EditFieldMappingsState {
   loading: boolean;
   createdMappings: ruleFieldToIndexFieldMap;
-  invalidMappingFieldNames: string[];
   mappedRuleFields: string[];
   unmappedRuleFields: string[];
   logFieldOptions: string[];
@@ -61,7 +60,6 @@ export default class EditFieldMappings extends Component<
       ruleQueryFields: props.ruleQueryFields ? props.ruleQueryFields : new Set<string>(),
       loading: props.loading || false,
       createdMappings,
-      invalidMappingFieldNames: [],
       mappedRuleFields: [],
       unmappedRuleFields: [],
       logFieldOptions: [],
@@ -126,7 +124,7 @@ export default class EditFieldMappings extends Component<
           });
 
           items.forEach((ruleField) => {
-            existingMappings[ruleField.ruleFieldName] = ruleField.logFieldName;
+            existingMappings[ruleField.ruleFieldName] = ruleField.logFieldName || '';
           });
 
           for (let key in existingMappings) {
@@ -167,24 +165,6 @@ export default class EditFieldMappings extends Component<
     this.setState({ loading: false });
   };
 
-  /**
-   * Returns the fieldName(s) that have duplicate alias assigned to them
-   */
-  getInvalidMappingFieldNames(mappings: ruleFieldToIndexFieldMap): string[] {
-    const seenAliases = new Set();
-    const invalidFields: string[] = [];
-
-    Object.entries(mappings).forEach((entry) => {
-      if (seenAliases.has(entry[1])) {
-        invalidFields.push(entry[0]);
-      }
-
-      seenAliases.add(entry[1]);
-    });
-
-    return invalidFields;
-  }
-
   onMappingCreation = (ruleFieldName: string, indexFieldName: string): void => {
     const newMappings: ruleFieldToIndexFieldMap = {
       ...this.state.createdMappings,
@@ -193,10 +173,8 @@ export default class EditFieldMappings extends Component<
     if (!indexFieldName) {
       delete newMappings[ruleFieldName];
     }
-    const invalidMappingFieldNames = this.getInvalidMappingFieldNames(newMappings);
     this.setState({
       createdMappings: newMappings,
-      invalidMappingFieldNames: invalidMappingFieldNames,
     });
     this.updateMappingSharedState(newMappings);
   };
@@ -216,7 +194,6 @@ export default class EditFieldMappings extends Component<
     const {
       loading,
       createdMappings,
-      invalidMappingFieldNames,
       mappedRuleFields,
       unmappedRuleFields,
       logFieldOptions,
@@ -253,7 +230,6 @@ export default class EditFieldMappings extends Component<
                 mappingProps={{
                   type: MappingViewType.Edit,
                   existingMappings,
-                  invalidMappingFieldNames,
                   onMappingCreation: this.onMappingCreation,
                 }}
               />
@@ -286,7 +262,6 @@ export default class EditFieldMappings extends Component<
                   mappingProps={{
                     type: MappingViewType.Edit,
                     existingMappings,
-                    invalidMappingFieldNames,
                     onMappingCreation: this.onMappingCreation,
                   }}
                 />

--- a/public/pages/Detectors/containers/FieldMappings/__snapshots__/EditFieldMappings.test.tsx.snap
+++ b/public/pages/Detectors/containers/FieldMappings/__snapshots__/EditFieldMappings.test.tsx.snap
@@ -499,7 +499,6 @@ exports[`<EditFieldMappings /> spec renders the component 1`] = `
                         mappingProps={
                           Object {
                             "existingMappings": Object {},
-                            "invalidMappingFieldNames": Array [],
                             "onMappingCreation": [Function],
                             "type": 1,
                           }


### PR DESCRIPTION
### Description
Allow multiple aliases to same field when creating/editing mappings for detector

### Issues Resolved
#773 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).