### PR TITLE
Update vega-lite specs with theme based colors

### DIFF
--- a/public/pages/Overview/utils/__snapshots__/helper.test.ts.snap
+++ b/public/pages/Overview/utils/__snapshots__/helper.test.ts.snap
@@ -5,11 +5,9 @@ Object {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "config": Object {
     "legend": Object {
-      "labelColor": "#343741",
       "labelFont": "\\"Inter UI\\", -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
       "labelFontSize": 14,
       "rowPadding": 6,
-      "titleColor": "#1a1c21",
       "titleFontSize": 14,
       "titleFontWeight": 600,
       "titleLineHeight": 21,
@@ -128,11 +126,9 @@ Object {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "config": Object {
     "legend": Object {
-      "labelColor": "#343741",
       "labelFont": "\\"Inter UI\\", -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
       "labelFontSize": 14,
       "rowPadding": 6,
-      "titleColor": "#1a1c21",
       "titleFontSize": 14,
       "titleFontWeight": 600,
       "titleLineHeight": 21,
@@ -251,11 +247,9 @@ Object {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "config": Object {
     "legend": Object {
-      "labelColor": "#343741",
       "labelFont": "\\"Inter UI\\", -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
       "labelFontSize": 14,
       "rowPadding": 6,
-      "titleColor": "#1a1c21",
       "titleFontSize": 14,
       "titleFontWeight": 600,
       "titleLineHeight": 21,
@@ -428,11 +422,9 @@ Object {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "config": Object {
     "legend": Object {
-      "labelColor": "#343741",
       "labelFont": "\\"Inter UI\\", -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
       "labelFontSize": 14,
       "rowPadding": 6,
-      "titleColor": "#1a1c21",
       "titleFontSize": 14,
       "titleFontWeight": 600,
       "titleLineHeight": 21,

--- a/public/pages/Overview/utils/helpers.ts
+++ b/public/pages/Overview/utils/helpers.ts
@@ -11,6 +11,7 @@ import _ from 'lodash';
 import { DEFAULT_DATE_RANGE } from '../../../utils/constants';
 import { severityOptions } from '../../Alerts/utils/constants';
 import moment from 'moment';
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 
 export interface TimeUnit {
   unit: string;
@@ -56,7 +57,7 @@ export const defaultTimeUnit = {
 export const defaultDateFormat = '%Y-%m-%d %H:%M';
 
 // euiColorDanger: #BD271E
-export const alertsDefaultColor = '#BD271E';
+export const alertsDefaultColor = euiThemeVars.euiColorDanger;
 
 export const parseDateString = (dateString: string): number => {
   const date = dateMath.parse(dateString);
@@ -102,8 +103,6 @@ export function getVisualizationSpec(description: string, data: any, layers: any
     config: {
       view: { stroke: 'transparent' },
       legend: {
-        labelColor: '#343741',
-        titleColor: '#1a1c21',
         labelFontSize: 14,
         titleFontWeight: 600,
         titleLineHeight: 21,

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -8,6 +8,7 @@ import { Detector, LogType, ServerResponse } from '../../types';
 import { DetectorInput, PeriodSchedule } from '../../models/interfaces';
 import { DetectorHit } from '../../server/models/interfaces';
 import _ from 'lodash';
+import { euiPaletteColorBlind } from '@elastic/eui';
 
 export const DATE_MATH_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 export const MAX_RECENTLY_USED_TIME_RANGES = 5;
@@ -188,3 +189,5 @@ export const logTypeCategoryDescription: { name: string; description: string }[]
 
 export const logTypeCategories: string[] = [];
 export const logTypesByCategories: { [category: string]: LogType[] } = {};
+
+export const defaultColorForVisualizations: string = euiPaletteColorBlind()[0];


### PR DESCRIPTION
### Description
Currently visualizations on overview, findings and alerts pages don't use theme-based colors and hence end up always rendering in light-theme colors. This PR ensures we update the vega-lite specs used for these visualizations with the themed colors provided by OSD core.

### Issues Resolved
#900 

1. Overview
<img width="1310" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/0042c917-711a-4c22-a63c-77443114124f">

2. Findings
<img width="1310" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/12ee7bba-2958-4589-aa50-8b88790a29f7">

3. Alerts
<img width="1310" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/e2b06030-2770-41b8-aff0-88ec45e6da9c">

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).