### PR TITLE
[Cypress test fix] Wait longer for action button to become enabled

### DIFF
--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -491,8 +491,9 @@ describe('Detectors', () => {
       cy.get('[data-test-subj="toggleDetectorButton').click({ force: true });
 
       cy.wait('@detectorsSearch').should('have.property', 'state', 'Complete');
+
       // Need this extra wait time for the Actions button to become enabled again
-      cy.wait(1000);
+      cy.wait(2000);
 
       setupIntercept(cy, '/_plugins/_security_analytics/detectors/_search', 'detectorsSearch');
       cy.get('[data-test-subj="detectorsActionsButton').click({ force: true });
@@ -500,8 +501,9 @@ describe('Detectors', () => {
       cy.get('[data-test-subj="toggleDetectorButton').click({ force: true });
 
       cy.wait('@detectorsSearch').should('have.property', 'state', 'Complete');
+
       // Need this extra wait time for the Actions button to become enabled again
-      cy.wait(1000);
+      cy.wait(2000);
 
       cy.get('[data-test-subj="detectorsActionsButton').click({ force: true });
       cy.get('[data-test-subj="toggleDetectorButton').contains('Stop');


### PR DESCRIPTION
### Description
The detector cypress tests are failing for windows runner at the test `can be stopped and started back from detectors list action menu`. This happens when trying to check that after restarting a detector the toggle button contains the correct text (Stop) but we fail to open the Action menu as the action button looks to be disabled when we try to click. This PR increases the wait period for the Action menu button to be enabled.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).