### PR TITLE
Added check before running husky install during post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:jest:update-snapshots": "yarn run test:jest -u",
     "build": "yarn plugin-helpers build",
     "postbuild": "echo Renaming build artifact to [$npm_package_config_zip_name-$npm_package_version.zip] && mv build/$npm_package_config_id*.zip build/$npm_package_config_zip_name-$npm_package_version.zip",
-    "postinstall": "husky install"
+    "postinstall": "node -e \"const { execSync } = require('child_process');const { INIT_CWD, PWD = process.cwd() } = process.env; if (INIT_CWD?.startsWith?.(PWD)) {try {execSync('husky install');} catch (e) {}}\""
   },
   "resolutions": {
     "@types/react": "^16.9.8",


### PR DESCRIPTION
### Description
During bootstrap, postinstall script in OSD triggers the postinstall script of all the children repos due to which the path from the security analytics' script gets called is not setup correctly. This PR adds a check to ensure the `husky install` only runs when running from within the SA repo during first time setup for development.

### Issues Resolved
#987 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).