### PR TITLE
[MDS][Part 1] Data source component added to  all pages

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -4,6 +4,7 @@
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["opensearch_security_analytics"],
   "requiredPlugins": ["data"],
+  "optionalPlugins": ["dataSource", "dataSourceManagement"],
   "server": true,
   "ui": true
 }

--- a/public/components/MDS/DataSourceMenuWrapper.tsx
+++ b/public/components/MDS/DataSourceMenuWrapper.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useState } from 'react';
+import { Route, Switch } from 'react-router-dom';
+import {
+  DataSourceManagementPluginSetup,
+  DataSourceOption,
+  DataSourceSelectableConfig,
+  DataSourceViewConfig,
+} from '../../../../../src/plugins/data_source_management/public';
+import { AppMountParameters, CoreStart } from 'opensearch-dashboards/public';
+import { ROUTES } from '../../utils/constants';
+
+export interface DataSourceMenuWrapperProps {
+  core: CoreStart;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
+  setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
+}
+
+export const DataSourceMenuWrapper: React.FC<DataSourceMenuWrapperProps> = ({
+  core,
+  dataSourceManagement,
+  setHeaderActionMenu,
+}) => {
+  if (!dataSourceManagement) {
+    return null;
+  }
+
+  const [activeOption, setActiveOption] = useState({ id: '', label: '', checked: '' });
+  const DataSourceMenuViewComponent = dataSourceManagement.ui?.getDataSourceMenu<
+    DataSourceViewConfig
+  >();
+  const DataSourceMenuSelectableComponent = dataSourceManagement.ui?.getDataSourceMenu<
+    DataSourceSelectableConfig
+  >();
+
+  const onDataSourceSelected = useCallback(
+    (sources: DataSourceOption[]) => {
+      if (
+        sources[0] &&
+        (activeOption.id !== sources[0].id || activeOption.label !== sources[0].label)
+      ) {
+        setActiveOption(sources[0]);
+      }
+    },
+    [setActiveOption, activeOption]
+  );
+
+  return (
+    <Switch>
+      <Route
+        path={[
+          ROUTES.EDIT_DETECTOR_ALERT_TRIGGERS,
+          ROUTES.EDIT_DETECTOR_DETAILS,
+          ROUTES.EDIT_DETECTOR_RULES,
+          ROUTES.EDIT_FIELD_MAPPINGS,
+          ROUTES.RULES_EDIT,
+          ROUTES.CORRELATION_RULE_EDIT,
+          ROUTES.DETECTOR_DETAILS,
+          `${ROUTES.LOG_TYPES}/:logTypeId`,
+          `${ROUTES.ALERTS}/:detectorId`,
+          `${ROUTES.FINDINGS}/:detectorId`,
+        ]}
+        render={() => {
+          return (
+            <DataSourceMenuViewComponent
+              componentConfig={{
+                fullWidth: false,
+                activeOption: [activeOption],
+              }}
+              componentType="DataSourceView"
+              setMenuMountPoint={setHeaderActionMenu}
+            />
+          );
+        }}
+      />
+      <Route
+        path={[
+          ROUTES.OVERVIEW,
+          ROUTES.DETECTORS,
+          ROUTES.ALERTS,
+          ROUTES.FINDINGS,
+          ROUTES.LOG_TYPES,
+          ROUTES.RULES,
+          ROUTES.CORRELATIONS,
+          ROUTES.CORRELATION_RULES,
+          ROUTES.RULES_CREATE,
+          ROUTES.RULES_IMPORT,
+          ROUTES.RULES_DUPLICATE,
+          ROUTES.DETECTORS_CREATE,
+          ROUTES.LOG_TYPES_CREATE,
+          ROUTES.CORRELATION_RULE_CREATE,
+        ]}
+        render={() => {
+          return (
+            <DataSourceMenuSelectableComponent
+              componentType="DataSourceSelectable"
+              setMenuMountPoint={setHeaderActionMenu}
+              componentConfig={{
+                fullWidth: false,
+                activeOption: [activeOption],
+                notifications: core.notifications,
+                onSelectedDataSources: onDataSourceSelected,
+                savedObjects: core.savedObjects.client,
+              }}
+            />
+          );
+        }}
+      />
+    </Switch>
+  );
+};

--- a/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
           "calls": Array [
             Array [
               Object {
-                "text": [TypeError: Cannot read properties of undefined (reading 'detectorsService')],
+                "text": [TypeError: Cannot read property 'detectorsService' of undefined],
                 "title": "Failed to retrieve detector:",
                 "toastLifeTimeMs": 5000,
               },
@@ -489,7 +489,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                 "calls": Array [
                   Array [
                     Object {
-                      "text": [TypeError: Cannot read properties of undefined (reading 'detectorsService')],
+                      "text": [TypeError: Cannot read property 'detectorsService' of undefined],
                       "title": "Failed to retrieve detector:",
                       "toastLifeTimeMs": 5000,
                     },

--- a/public/pages/Detectors/containers/AlertTriggersView/__snapshots__/AlertTriggersView.test.tsx.snap
+++ b/public/pages/Detectors/containers/AlertTriggersView/__snapshots__/AlertTriggersView.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
           "calls": Array [
             Array [
               Object {
-                "text": [TypeError: Cannot read properties of undefined (reading 'notificationsService')],
+                "text": [TypeError: Cannot read property 'notificationsService' of undefined],
                 "title": "Failed to retrieve notification channels and rules:",
                 "toastLifeTimeMs": 5000,
               },

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -54,6 +54,7 @@ import { DataStore } from '../../../store/DataStore';
 import { CorrelationsTable } from './CorrelationsTable/CorrelationsTable';
 import { getSeverityColor } from '../../Correlations/utils/constants';
 import { getLogTypeLabel } from '../../LogTypes/utils/helpers';
+import { RouteComponentProps } from 'react-router-dom';
 
 export interface FindingDetailsFlyoutBaseProps {
   finding: FindingItemType;
@@ -66,7 +67,7 @@ export interface FindingDetailsFlyoutProps extends FindingDetailsFlyoutBaseProps
   opensearchService: OpenSearchService;
   indexPatternsService: IndexPatternsService;
   correlationService: CorrelationService;
-  history: History;
+  history: RouteComponentProps['history'];
 }
 
 interface FindingDetailsFlyoutState {

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -66,7 +66,6 @@ interface FindingsProps extends RouteComponentProps {
   match: match<{ detectorId: string }>;
   dateTimeFilter?: DateTimeFilter;
   setDateTimeFilter?: Function;
-  history: RouteComponentProps['history'];
 }
 
 interface FindingsState {

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -18,7 +18,7 @@ import {
   EuiFlexItem,
 } from '@elastic/eui';
 import { Toast } from '@opensearch-project/oui/src/eui_components/toast/global_toast_list';
-import { CoreStart } from 'opensearch-dashboards/public';
+import { AppMountParameters, CoreStart } from 'opensearch-dashboards/public';
 import { SaContextConsumer } from '../../services';
 import { DEFAULT_DATE_RANGE, DATE_TIME_FILTER_KEY, ROUTES } from '../../utils/constants';
 import { CoreServicesConsumer } from '../../components/core_services';
@@ -50,6 +50,8 @@ import { LogTypes } from '../LogTypes/containers/LogTypes';
 import { LogType } from '../LogTypes/containers/LogType';
 import { CreateLogType } from '../LogTypes/containers/CreateLogType';
 import { SecurityAnalyticsContextType } from '../../../types';
+import { DataSourceManagementPluginSetup } from '../../../../../src/plugins/data_source_management/public';
+import { DataSourceMenuWrapper } from '../../components/MDS/DataSourceMenuWrapper';
 
 enum Navigation {
   SecurityAnalytics = 'Security Analytics',
@@ -82,6 +84,9 @@ const HIDDEN_NAV_ROUTES: string[] = [
 
 interface MainProps extends RouteComponentProps {
   landingPage: string;
+  setActionMenu: AppMountParameters['setHeaderActionMenu'];
+  multiDataSourceEnabled: boolean;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 
 interface MainState {
@@ -200,6 +205,9 @@ export default class Main extends Component<MainProps, MainState> {
       landingPage,
       location: { pathname },
       history,
+      multiDataSourceEnabled,
+      dataSourceManagement,
+      setActionMenu,
     } = this.props;
 
     const { callout, findingFlyout, selectedNavItemId: selectedNavItemIndex } = this.state;
@@ -322,277 +330,295 @@ export default class Main extends Component<MainProps, MainState> {
         {(core: CoreStart | null) =>
           core && (
             <SaContextConsumer>
-              {({ services, metrics }: SecurityAnalyticsContextType | null) =>
-                services && (
-                  <EuiPage restrictWidth={'100%'}>
-                    {/* Hide side navigation bar when on any HIDDEN_NAV_ROUTES pages. */}
-                    {!HIDDEN_NAV_ROUTES.some((route) => pathname.match(route)) && (
-                      <EuiPageSideBar style={{ minWidth: 200 }}>
-                        <EuiSideNav style={{ width: 200 }} items={sideNav} />
-                      </EuiPageSideBar>
+              {(saContext: SecurityAnalyticsContextType | null) => {
+                const services = saContext?.services;
+                const metrics = saContext?.metrics!;
+
+                return (
+                  <>
+                    {multiDataSourceEnabled && (
+                      <DataSourceMenuWrapper
+                        dataSourceManagement={dataSourceManagement}
+                        core={core}
+                        setHeaderActionMenu={setActionMenu}
+                      />
                     )}
-                    <EuiPageBody>
-                      {callout ? <Callout {...callout} /> : null}
-                      {findingFlyout ? (
-                        <FindingDetailsFlyout
-                          {...findingFlyout}
-                          history={history}
-                          indexPatternsService={services.indexPatternsService}
-                          correlationService={services?.correlationsService}
-                          opensearchService={services.opensearchService}
-                        />
-                      ) : null}
-                      <Switch>
-                        <Route
-                          path={`${ROUTES.FINDINGS}/:detectorId?`}
-                          render={(props: RouteComponentProps) => (
-                            <Findings
-                              {...props}
-                              setDateTimeFilter={this.setDateTimeFilter}
-                              dateTimeFilter={this.state.dateTimeFilter}
-                              history={props.history}
+                    {services && (
+                      <EuiPage restrictWidth={'100%'}>
+                        {/* Hide side navigation bar when on any HIDDEN_NAV_ROUTES pages. */}
+                        {!HIDDEN_NAV_ROUTES.some((route) => pathname.match(route)) && (
+                          <EuiPageSideBar style={{ minWidth: 200 }}>
+                            <EuiSideNav style={{ width: 200 }} items={sideNav} />
+                          </EuiPageSideBar>
+                        )}
+                        <EuiPageBody>
+                          {callout ? <Callout {...callout} /> : null}
+                          {findingFlyout ? (
+                            <FindingDetailsFlyout
+                              {...findingFlyout}
+                              history={history}
+                              indexPatternsService={services.indexPatternsService}
                               correlationService={services?.correlationsService}
                               opensearchService={services.opensearchService}
-                              detectorService={services.detectorsService}
-                              notificationsService={services.notificationsService}
-                              indexPatternsService={services.indexPatternsService}
-                              notifications={core?.notifications}
                             />
-                          )}
-                        />
-                        <Route
-                          path={ROUTES.DETECTORS}
-                          render={(props: RouteComponentProps) => (
-                            <Detectors
-                              {...props}
-                              detectorService={services.detectorsService}
-                              notifications={core?.notifications}
+                          ) : null}
+                          <Switch>
+                            <Route
+                              path={`${ROUTES.FINDINGS}/:detectorId?`}
+                              render={(props: RouteComponentProps) => (
+                                <Findings
+                                  {...props}
+                                  setDateTimeFilter={this.setDateTimeFilter}
+                                  dateTimeFilter={this.state.dateTimeFilter}
+                                  correlationService={services?.correlationsService}
+                                  opensearchService={services.opensearchService}
+                                  detectorService={services.detectorsService}
+                                  notificationsService={services.notificationsService}
+                                  indexPatternsService={services.indexPatternsService}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={ROUTES.DETECTORS_CREATE}
-                          render={(props: RouteComponentProps) => (
-                            <CreateDetector
-                              {...props}
-                              isEdit={false}
-                              services={services}
-                              metrics={metrics}
-                              history={props.history}
-                              notifications={core?.notifications}
+                            <Route
+                              path={ROUTES.DETECTORS}
+                              render={(props: RouteComponentProps) => (
+                                <Detectors
+                                  {...props}
+                                  detectorService={services.detectorsService}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={ROUTES.RULES}
-                          render={(props: RouteComponentProps) => (
-                            <Rules {...props} notifications={core?.notifications} />
-                          )}
-                        />
-                        <Route
-                          path={ROUTES.RULES_CREATE}
-                          render={(props: RouteComponentProps) => (
-                            <CreateRule
-                              services={services}
-                              history={props.history}
-                              notifications={core?.notifications}
+                            <Route
+                              path={ROUTES.DETECTORS_CREATE}
+                              render={(props: RouteComponentProps) => (
+                                <CreateDetector
+                                  {...props}
+                                  isEdit={false}
+                                  services={services}
+                                  metrics={metrics}
+                                  history={props.history}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={ROUTES.RULES_EDIT}
-                          render={(props: RouteComponentProps<any, any, any>) => {
-                            if (!props.location.state?.ruleItem) {
-                              props.history.replace(ROUTES.RULES);
-                              return <Rules {...props} notifications={core?.notifications} />;
-                            }
+                            <Route
+                              path={ROUTES.RULES}
+                              render={(props: RouteComponentProps) => (
+                                <Rules {...props} notifications={core?.notifications} />
+                              )}
+                            />
+                            <Route
+                              path={ROUTES.RULES_CREATE}
+                              render={(props: RouteComponentProps) => (
+                                <CreateRule
+                                  services={services}
+                                  history={props.history}
+                                  notifications={core?.notifications}
+                                />
+                              )}
+                            />
+                            <Route
+                              path={ROUTES.RULES_EDIT}
+                              render={(props: RouteComponentProps<any, any, any>) => {
+                                if (!props.location.state?.ruleItem) {
+                                  props.history.replace(ROUTES.RULES);
+                                  return <Rules {...props} notifications={core?.notifications} />;
+                                }
 
-                            return (
-                              <EditRule
-                                services={services}
-                                {...props}
-                                notifications={core?.notifications}
-                              />
-                            );
-                          }}
-                        />
-                        <Route
-                          path={ROUTES.RULES_DUPLICATE}
-                          render={(props: RouteComponentProps<any, any, any>) => {
-                            if (!props.location.state?.ruleItem) {
-                              props.history.replace(ROUTES.RULES);
-                              return <Rules {...props} notifications={core?.notifications} />;
-                            }
+                                return (
+                                  <EditRule
+                                    services={services}
+                                    {...props}
+                                    notifications={core?.notifications}
+                                  />
+                                );
+                              }}
+                            />
+                            <Route
+                              path={ROUTES.RULES_DUPLICATE}
+                              render={(props: RouteComponentProps<any, any, any>) => {
+                                if (!props.location.state?.ruleItem) {
+                                  props.history.replace(ROUTES.RULES);
+                                  return <Rules {...props} notifications={core?.notifications} />;
+                                }
 
-                            return (
-                              <DuplicateRule
-                                services={services}
-                                {...props}
-                                notifications={core?.notifications}
-                              />
-                            );
-                          }}
-                        />
-                        <Route
-                          path={ROUTES.RULES_IMPORT}
-                          render={(props: RouteComponentProps) => (
-                            <ImportRule
-                              services={services}
-                              history={props.history}
-                              notifications={core?.notifications}
+                                return (
+                                  <DuplicateRule
+                                    services={services}
+                                    {...props}
+                                    notifications={core?.notifications}
+                                  />
+                                );
+                              }}
                             />
-                          )}
-                        />
-                        <Route
-                          path={ROUTES.OVERVIEW}
-                          render={(props: RouteComponentProps) => (
-                            <Overview
-                              {...props}
-                              setDateTimeFilter={this.setDateTimeFilter}
-                              dateTimeFilter={this.state.dateTimeFilter}
-                              getStartedDismissedOnce={this.state.getStartedDismissedOnce}
-                              onGetStartedDismissed={this.setGetStartedDismissedOnce}
-                              notifications={core?.notifications}
+                            <Route
+                              path={ROUTES.RULES_IMPORT}
+                              render={(props: RouteComponentProps) => (
+                                <ImportRule
+                                  services={services}
+                                  history={props.history}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.ALERTS}/:detectorId?`}
-                          render={(props: RouteComponentProps) => (
-                            <Alerts
-                              {...props}
-                              setDateTimeFilter={this.setDateTimeFilter}
-                              dateTimeFilter={this.state.dateTimeFilter}
-                              alertService={services.alertService}
-                              detectorService={services.detectorsService}
-                              findingService={services.findingsService}
-                              notifications={core?.notifications}
-                              opensearchService={services.opensearchService}
-                              indexPatternService={services.indexPatternsService}
+                            <Route
+                              path={ROUTES.OVERVIEW}
+                              render={(props: RouteComponentProps) => (
+                                <Overview
+                                  {...props}
+                                  setDateTimeFilter={this.setDateTimeFilter}
+                                  dateTimeFilter={this.state.dateTimeFilter}
+                                  getStartedDismissedOnce={this.state.getStartedDismissedOnce}
+                                  onGetStartedDismissed={this.setGetStartedDismissedOnce}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.DETECTOR_DETAILS}/:id`}
-                          render={(props: RouteComponentProps<{}, any, any>) => (
-                            <DetectorDetails
-                              detectorService={services.detectorsService}
-                              savedObjectsService={services.savedObjectsService}
-                              indexPatternsService={services.indexPatternsService}
-                              {...props}
-                              notifications={core?.notifications}
+                            <Route
+                              path={`${ROUTES.ALERTS}/:detectorId?`}
+                              render={(props: RouteComponentProps) => (
+                                <Alerts
+                                  {...props}
+                                  setDateTimeFilter={this.setDateTimeFilter}
+                                  dateTimeFilter={this.state.dateTimeFilter}
+                                  alertService={services.alertService}
+                                  detectorService={services.detectorsService}
+                                  findingService={services.findingsService}
+                                  notifications={core?.notifications}
+                                  opensearchService={services.opensearchService}
+                                  indexPatternService={services.indexPatternsService}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.EDIT_DETECTOR_DETAILS}/:id`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <UpdateDetectorBasicDetails
-                              {...props}
-                              notifications={core?.notifications}
+                            <Route
+                              path={`${ROUTES.DETECTOR_DETAILS}/:id`}
+                              render={(props: RouteComponentProps<{}, any, any>) => (
+                                <DetectorDetails
+                                  detectorService={services.detectorsService}
+                                  savedObjectsService={services.savedObjectsService}
+                                  indexPatternsService={services.indexPatternsService}
+                                  {...props}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.EDIT_DETECTOR_RULES}/:id`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <UpdateDetectorRules {...props} notifications={core?.notifications} />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.EDIT_FIELD_MAPPINGS}/:id`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <UpdateFieldMappings
-                              {...props}
-                              fieldMappingService={services.fieldMappingService}
-                              detectorService={services.detectorsService}
-                              notifications={core?.notifications}
+                            <Route
+                              path={`${ROUTES.EDIT_DETECTOR_DETAILS}/:id`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <UpdateDetectorBasicDetails
+                                  {...props}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.EDIT_DETECTOR_ALERT_TRIGGERS}/:id`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <UpdateAlertConditions
-                              {...props}
-                              detectorService={services.detectorsService}
-                              notificationsService={services.notificationsService}
-                              notifications={core?.notifications}
-                              opensearchService={services.opensearchService}
+                            <Route
+                              path={`${ROUTES.EDIT_DETECTOR_RULES}/:id`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <UpdateDetectorRules
+                                  {...props}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.CORRELATION_RULES}`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <CorrelationRules {...props} />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.CORRELATION_RULE_CREATE}`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <CreateCorrelationRule
-                              {...props}
-                              indexService={services?.indexService}
-                              fieldMappingService={services?.fieldMappingService}
-                              notifications={core?.notifications}
+                            <Route
+                              path={`${ROUTES.EDIT_FIELD_MAPPINGS}/:id`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <UpdateFieldMappings
+                                  {...props}
+                                  fieldMappingService={services.fieldMappingService}
+                                  detectorService={services.detectorsService}
+                                  notifications={core?.notifications}
+                                />
+                              )}
                             />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.CORRELATION_RULE_EDIT}/:ruleId`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <CreateCorrelationRule
-                              {...props}
-                              indexService={services?.indexService}
-                              fieldMappingService={services?.fieldMappingService}
-                              notifications={core?.notifications}
+                            <Route
+                              path={`${ROUTES.EDIT_DETECTOR_ALERT_TRIGGERS}/:id`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <UpdateAlertConditions
+                                  {...props}
+                                  detectorService={services.detectorsService}
+                                  notificationsService={services.notificationsService}
+                                  notifications={core?.notifications}
+                                  opensearchService={services.opensearchService}
+                                />
+                              )}
                             />
-                          )}
+                            <Route
+                              path={`${ROUTES.CORRELATION_RULES}`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <CorrelationRules {...props} />
+                              )}
+                            />
+                            <Route
+                              path={`${ROUTES.CORRELATION_RULE_CREATE}`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <CreateCorrelationRule
+                                  {...props}
+                                  indexService={services?.indexService}
+                                  fieldMappingService={services?.fieldMappingService}
+                                  notifications={core?.notifications}
+                                />
+                              )}
+                            />
+                            <Route
+                              path={`${ROUTES.CORRELATION_RULE_EDIT}/:ruleId`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <CreateCorrelationRule
+                                  {...props}
+                                  indexService={services?.indexService}
+                                  fieldMappingService={services?.fieldMappingService}
+                                  notifications={core?.notifications}
+                                />
+                              )}
+                            />
+                            <Route
+                              path={`${ROUTES.CORRELATIONS}`}
+                              render={(props: RouteComponentProps<any, any, any>) => {
+                                return (
+                                  <Correlations
+                                    {...props}
+                                    history={props.history}
+                                    onMount={() => this.setState({ selectedNavItemId: 6 })}
+                                    dateTimeFilter={this.state.dateTimeFilter}
+                                    setDateTimeFilter={this.setDateTimeFilter}
+                                  />
+                                );
+                              }}
+                            />
+                            <Route
+                              path={`${ROUTES.LOG_TYPES}/:logTypeId`}
+                              render={(props: RouteComponentProps<any, any, any>) => (
+                                <LogType notifications={core?.notifications} {...props} />
+                              )}
+                            />
+                            <Route
+                              path={`${ROUTES.LOG_TYPES}`}
+                              render={(props: RouteComponentProps<any, any, any>) => {
+                                return <LogTypes notifications={core?.notifications} {...props} />;
+                              }}
+                            />
+                            <Route
+                              path={ROUTES.LOG_TYPES_CREATE}
+                              render={(props: RouteComponentProps<any, any, any>) => {
+                                return (
+                                  <CreateLogType notifications={core?.notifications} {...props} />
+                                );
+                              }}
+                            />
+                            <Redirect from={'/'} to={landingPage} />
+                          </Switch>
+                        </EuiPageBody>
+                        <EuiGlobalToastList
+                          toasts={this.state.toasts}
+                          dismissToast={DataStore.detectors.hideToast}
+                          toastLifeTimeMs={6000}
                         />
-                        <Route
-                          path={`${ROUTES.CORRELATIONS}`}
-                          render={(props: RouteComponentProps<any, any, any>) => {
-                            return (
-                              <Correlations
-                                {...props}
-                                history={props.history}
-                                onMount={() => this.setState({ selectedNavItemId: 6 })}
-                                dateTimeFilter={this.state.dateTimeFilter}
-                                setDateTimeFilter={this.setDateTimeFilter}
-                              />
-                            );
-                          }}
-                        />
-                        <Route
-                          path={`${ROUTES.LOG_TYPES}/:logTypeId`}
-                          render={(props: RouteComponentProps<any, any, any>) => (
-                            <LogType notifications={core?.notifications} {...props} />
-                          )}
-                        />
-                        <Route
-                          path={`${ROUTES.LOG_TYPES}`}
-                          render={(props: RouteComponentProps<any, any, any>) => {
-                            return <LogTypes notifications={core?.notifications} {...props} />;
-                          }}
-                        />
-                        <Route
-                          path={ROUTES.LOG_TYPES_CREATE}
-                          render={(props: RouteComponentProps<any, any, any>) => {
-                            return <CreateLogType notifications={core?.notifications} {...props} />;
-                          }}
-                        />
-                        <Redirect from={'/'} to={landingPage} />
-                      </Switch>
-                    </EuiPageBody>
-                    <EuiGlobalToastList
-                      toasts={this.state.toasts}
-                      dismissToast={DataStore.detectors.hideToast}
-                      toastLifeTimeMs={6000}
-                    />
-                  </EuiPage>
-                )
-              }
+                      </EuiPage>
+                    )}
+                  </>
+                );
+              }}
             </SaContextConsumer>
           )
         }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -15,12 +15,16 @@ import { SecurityAnalyticsPluginSetup, SecurityAnalyticsPluginStart } from './in
 import { DataPublicPluginStart, DataPublicPluginSetup } from '../../../src/plugins/data/public';
 import { SecurityAnalyticsPluginConfigType } from '../config';
 import { setSecurityAnalyticsPluginConfig } from '../common/helpers';
+import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
+import { DataSourcePluginStart } from '../../../src/plugins/data_source/public';
 
 export interface SecurityAnalyticsPluginSetupDeps {
   data: DataPublicPluginSetup;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 export interface SecurityAnalyticsPluginStartDeps {
   data: DataPublicPluginStart;
+  dataSource?: DataSourcePluginStart;
 }
 
 export class SecurityAnalyticsPlugin
@@ -37,7 +41,7 @@ export class SecurityAnalyticsPlugin
 
   public setup(
     core: CoreSetup<SecurityAnalyticsPluginStartDeps>,
-    _plugins: SecurityAnalyticsPluginSetupDeps
+    { dataSourceManagement }: SecurityAnalyticsPluginSetupDeps
   ): SecurityAnalyticsPluginSetup {
     core.application.register({
       id: PLUGIN_NAME,
@@ -51,7 +55,7 @@ export class SecurityAnalyticsPlugin
       mount: async (params: AppMountParameters) => {
         const { renderApp } = await import('./security_analytics_app');
         const [coreStart, depsStart] = await core.getStartServices();
-        return renderApp(coreStart, params, ROUTES.LANDING_PAGE, depsStart);
+        return renderApp(coreStart, params, ROUTES.LANDING_PAGE, depsStart, dataSourceManagement);
       },
     });
     setDarkMode(core.uiSettings.get('theme:darkMode'));

--- a/public/security_analytics_app.tsx
+++ b/public/security_analytics_app.tsx
@@ -33,12 +33,14 @@ import { LogType } from '../types';
 import MetricsService from './services/MetricsService';
 import { MetricsContext } from './metrics/MetricsContext';
 import { CHANNEL_TYPES } from './pages/CreateDetector/components/ConfigureAlerts/utils/constants';
+import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 
 export function renderApp(
   coreStart: CoreStart,
   params: AppMountParameters,
   landingPage: string,
-  depsStart: SecurityAnalyticsPluginStartDeps
+  depsStart: SecurityAnalyticsPluginStartDeps,
+  dataSourceManagement?: DataSourceManagementPluginSetup
 ) {
   const { http, savedObjects } = coreStart;
 
@@ -84,7 +86,13 @@ export function renderApp(
             <DarkModeContext.Provider value={isDarkMode}>
               <SecurityAnalyticsContext.Provider value={{ services, metrics }}>
                 <CoreServicesContext.Provider value={coreStart}>
-                  <Main {...props} landingPage={landingPage} />
+                  <Main
+                    {...props}
+                    landingPage={landingPage}
+                    multiDataSourceEnabled={!!depsStart.dataSource}
+                    dataSourceManagement={dataSourceManagement}
+                    setActionMenu={params.setHeaderActionMenu}
+                  />
                 </CoreServicesContext.Provider>
               </SecurityAnalyticsContext.Provider>
             </DarkModeContext.Provider>


### PR DESCRIPTION
### Description
This PR adds the data source menu component to the chrome header for all the pages of security analytics. Below are screenshots of some pages

- Overview page 
<img width="1512" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/0d4725af-c675-4c92-a5b6-78d0d7f6e91f">

- Create Detector
<img width="1512" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/2df71fef-7103-43a7-8c79-63f40de2dd6e">

- Log type details page (NOTE: It is a read only menu)
<img width="1512" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/5527aa6e-e88d-4a8e-a60d-1541f7292c5c">


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).