### PR TITLE
Enhanced UI for rendering multiple documents in finding details flyout

### DIFF
--- a/cypress/integration/3_alerts.spec.js
+++ b/cypress/integration/3_alerts.spec.js
@@ -222,7 +222,7 @@ describe('Alerts', () => {
       // and matches each entry with the corresponding element line.
       const document = JSON.stringify(JSON.parse('{"winlog.event_id": 2003}'), null, 2);
       const documentLines = document.split('\n');
-      cy.get('[data-test-subj="finding-details-flyout-document-toggle-0"]').click({ force: true });
+
       cy.get('[data-test-subj="finding-details-flyout-rule-document-0"]')
         .get('[class="euiCodeBlock__line"]')
         .each((lineElement, lineIndex) => {

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -90,6 +90,13 @@ export default class FindingDetailsFlyout extends Component<
 > {
   constructor(props: FindingDetailsFlyoutProps) {
     super(props);
+    const relatedDocuments: FindingDocumentItem[] = this.getRelatedDocuments();
+    const docIdToExpandedRowMap: FindingDetailsFlyoutState['docIdToExpandedRowMap'] = {};
+
+    if (relatedDocuments.length === 1) {
+      docIdToExpandedRowMap[relatedDocuments[0].id] = this.createDocumentBlock(relatedDocuments[0]);
+    }
+
     this.state = {
       loading: false,
       ruleViewerFlyoutData: null,
@@ -110,7 +117,7 @@ export default class FindingDetailsFlyout extends Component<
       loadingIndexPatternId: true,
       areCorrelationsLoading: true,
       allRules: {},
-      docIdToExpandedRowMap: {},
+      docIdToExpandedRowMap,
     };
   }
 
@@ -319,8 +326,7 @@ export default class FindingDetailsFlyout extends Component<
     return patternId;
   };
 
-  toggleDocumentDetails(item: FindingDocumentItem) {
-    const docIdToExpandedRowMapValues = { ...this.state.docIdToExpandedRowMap };
+  createDocumentBlock = (item: FindingDocumentItem) => {
     let formattedDocument = '';
     try {
       formattedDocument = document ? JSON.stringify(JSON.parse(item.document), null, 2) : '';
@@ -328,30 +334,23 @@ export default class FindingDetailsFlyout extends Component<
       // no-op
     }
 
-    if (docIdToExpandedRowMapValues[item.id]) {
-      delete docIdToExpandedRowMapValues[item.id];
-    } else {
-      docIdToExpandedRowMapValues[item.id] = (
-        <EuiFormRow fullWidth={true}>
-          <EuiCodeBlock
-            language="json"
-            isCopyable
-            data-test-subj={`finding-details-flyout-rule-document-${item.itemIdx}`}
-          >
-            {formattedDocument}
-          </EuiCodeBlock>
-        </EuiFormRow>
-      );
-    }
+    return (
+      <EuiFormRow fullWidth={true} style={{ width: '100%' }}>
+        <EuiCodeBlock
+          language="json"
+          isCopyable
+          data-test-subj={`finding-details-flyout-rule-document-${item.itemIdx}`}
+        >
+          {formattedDocument}
+        </EuiCodeBlock>
+      </EuiFormRow>
+    );
+  };
 
-    this.setState({ docIdToExpandedRowMap: docIdToExpandedRowMapValues });
-  }
-
-  renderFindingDocuments(loadingIndexPatternId: boolean) {
+  getRelatedDocuments() {
     const {
-      finding: { index, document_list, related_doc_ids },
+      finding: { document_list, related_doc_ids },
     } = this.props;
-    const { indexPatternId, docIdToExpandedRowMap } = this.state;
     const relatedDocIdsSet = new Set(related_doc_ids);
     const relatedDocuments: FindingDocumentItem[] = [];
     document_list.forEach((documentInfo) => {
@@ -359,6 +358,28 @@ export default class FindingDetailsFlyout extends Component<
         relatedDocuments.push({ ...documentInfo, itemIdx: relatedDocuments.length });
       }
     });
+
+    return relatedDocuments;
+  }
+
+  toggleDocumentDetails(item: FindingDocumentItem) {
+    const docIdToExpandedRowMapValues = { ...this.state.docIdToExpandedRowMap };
+
+    if (docIdToExpandedRowMapValues[item.id]) {
+      delete docIdToExpandedRowMapValues[item.id];
+    } else {
+      docIdToExpandedRowMapValues[item.id] = this.createDocumentBlock(item);
+    }
+
+    this.setState({ docIdToExpandedRowMap: docIdToExpandedRowMapValues });
+  }
+
+  renderFindingDocuments(loadingIndexPatternId: boolean) {
+    const {
+      finding: { index },
+    } = this.props;
+    const { indexPatternId, docIdToExpandedRowMap } = this.state;
+    const relatedDocuments: FindingDocumentItem[] = this.getRelatedDocuments();
 
     if (relatedDocuments.length === 0) {
       return (
@@ -380,10 +401,10 @@ export default class FindingDetailsFlyout extends Component<
     const actions = [
       {
         render: ({ id }: FindingDocumentItem) => (
-          <EuiToolTip title="View surrounding documents">
+          <EuiToolTip content="View surrounding documents">
             <EuiButtonIcon
               disabled={loadingIndexPatternId}
-              iconType={'popout'}
+              iconType={'inspect'}
               data-test-subj={'finding-details-flyout-view-surrounding-documents'}
               onClick={() => {
                 if (indexPatternId) {
@@ -425,7 +446,7 @@ export default class FindingDetailsFlyout extends Component<
     return (
       <>
         <EuiTitle size={'s'}>
-          <h3>Documents</h3>
+          <h3>Documents ({relatedDocuments.length})</h3>
         </EuiTitle>
         <EuiSpacer />
         <EuiFormRow label={'Index'} data-test-subj={`finding-details-flyout-rule-document-index`}>


### PR DESCRIPTION
### Description
Follow up to PR #1006 to improve the UI when rendering multiple docs

- If there is only one document, we keep it open by default
- Showing number of documents
- Fixed tooltip to use 'content' prop instead of title
- Using inspect icon for `View surrounding documents`
- Document code block uses the full width

<img width="751" alt="image" src="https://github.com/opensearch-project/security-analytics-dashboards-plugin/assets/114732919/1db95bb1-0baf-47ea-b483-9ab842d6a3e8">

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).