### PR TITLE
Fixed rule object to yaml conversion for timeframe

### DIFF
--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -253,7 +253,9 @@ export class DetectionVisualEditor extends React.Component<
       let selectionMaps: any = {};
 
       selection.data.forEach((datum) => {
-        if (datum.field) {
+        if (selection.name === 'timeframe') {
+          selectionMaps = datum.values[0] || '';
+        } else if (datum.field) {
           const key = `${datum.field}${datum.modifier ? `|${datum.modifier}` : ''}`;
           selectionMaps[key] = datum.values;
         } else {


### PR DESCRIPTION
### Description
Currently the values specified for `Selection` in the visual editor are parsed to lists by default, as a result the timeframe also gets converted to a list in the yaml payload which is incorrect. This PR adds a check for timeframe and parses it as string as expected.

```
timeframe:
  - 1d
```

After this change we get:
```
timeframe: 1d
```

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).