### PR TITLE
Added addition check for filtering rendered rules in finding flyout

### DIFF
--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -234,79 +234,88 @@ export default class FindingDetailsFlyout extends Component<
     this.setState({ ...this.state, ruleViewerFlyoutData: null });
   };
 
+  shouldRenderRule = ({ id }: Query) => {
+    const { allRules = {} } = this.state;
+    const isSigmaRule = !!allRules[id];
+
+    if (!isSigmaRule) {
+      return false;
+    }
+
+    return !isThreatIntelQuery(id);
+  };
+
   renderRuleDetails = (rules: Query[] = []) => {
     const { allRules = {} } = this.state;
-    return rules
-      .filter(({ id }) => !isThreatIntelQuery(id))
-      .map((rule, key) => {
-        const fullRule = allRules[rule.id];
-        const severity = capitalizeFirstLetter(fullRule.level);
-        return (
-          <div key={key}>
-            <EuiAccordion
-              id={`${key}`}
-              buttonClassName="euiAccordionForm__button"
-              buttonContent={
-                <div data-test-subj={'finding-details-flyout-rule-accordion-button'}>
-                  <EuiText size={'s'}>{fullRule.title}</EuiText>
-                  <EuiText size={'s'} color={'subdued'}>
-                    Severity: {severity}
-                  </EuiText>
-                </div>
-              }
-              initialIsOpen={rules.length === 1}
-              data-test-subj={`finding-details-flyout-rule-accordion-${key}`}
-            >
-              <EuiPanel color="subdued">
-                <EuiFlexGroup>
-                  <EuiFlexItem>
-                    <EuiFormRow label={'Rule name'}>
-                      <EuiLink
-                        onClick={() => this.showRuleDetails(fullRule, rule.id)}
-                        data-test-subj={`finding-details-flyout-${fullRule.title}-details`}
-                      >
-                        {fullRule.title || DEFAULT_EMPTY_DATA}
-                      </EuiLink>
-                    </EuiFormRow>
-                  </EuiFlexItem>
-
-                  <EuiFlexItem>
-                    <EuiFormRow
-                      label={'Rule severity'}
-                      data-test-subj={'finding-details-flyout-rule-severity'}
+    return rules.filter(this.shouldRenderRule).map((rule, key) => {
+      const fullRule = allRules[rule.id];
+      const severity = capitalizeFirstLetter(fullRule.level);
+      return (
+        <div key={key}>
+          <EuiAccordion
+            id={`${key}`}
+            buttonClassName="euiAccordionForm__button"
+            buttonContent={
+              <div data-test-subj={'finding-details-flyout-rule-accordion-button'}>
+                <EuiText size={'s'}>{fullRule.title}</EuiText>
+                <EuiText size={'s'} color={'subdued'}>
+                  Severity: {severity}
+                </EuiText>
+              </div>
+            }
+            initialIsOpen={rules.length === 1}
+            data-test-subj={`finding-details-flyout-rule-accordion-${key}`}
+          >
+            <EuiPanel color="subdued">
+              <EuiFlexGroup>
+                <EuiFlexItem>
+                  <EuiFormRow label={'Rule name'}>
+                    <EuiLink
+                      onClick={() => this.showRuleDetails(fullRule, rule.id)}
+                      data-test-subj={`finding-details-flyout-${fullRule.title}-details`}
                     >
-                      <EuiText>{severity || DEFAULT_EMPTY_DATA}</EuiText>
-                    </EuiFormRow>
-                  </EuiFlexItem>
+                      {fullRule.title || DEFAULT_EMPTY_DATA}
+                    </EuiLink>
+                  </EuiFormRow>
+                </EuiFlexItem>
 
-                  <EuiFlexItem>
-                    <EuiFormRow
-                      label={'Log type'}
-                      data-test-subj={'finding-details-flyout-rule-category'}
-                    >
-                      <EuiText>{getLogTypeLabel(fullRule.category) || DEFAULT_EMPTY_DATA}</EuiText>
-                    </EuiFormRow>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
+                <EuiFlexItem>
+                  <EuiFormRow
+                    label={'Rule severity'}
+                    data-test-subj={'finding-details-flyout-rule-severity'}
+                  >
+                    <EuiText>{severity || DEFAULT_EMPTY_DATA}</EuiText>
+                  </EuiFormRow>
+                </EuiFlexItem>
 
-                <EuiFormRow
-                  label={'Description'}
-                  data-test-subj={'finding-details-flyout-rule-description'}
-                >
-                  <EuiText>{fullRule.description || DEFAULT_EMPTY_DATA}</EuiText>
-                </EuiFormRow>
+                <EuiFlexItem>
+                  <EuiFormRow
+                    label={'Log type'}
+                    data-test-subj={'finding-details-flyout-rule-category'}
+                  >
+                    <EuiText>{getLogTypeLabel(fullRule.category) || DEFAULT_EMPTY_DATA}</EuiText>
+                  </EuiFormRow>
+                </EuiFlexItem>
+              </EuiFlexGroup>
 
-                <EuiSpacer size={'m'} />
+              <EuiFormRow
+                label={'Description'}
+                data-test-subj={'finding-details-flyout-rule-description'}
+              >
+                <EuiText>{fullRule.description || DEFAULT_EMPTY_DATA}</EuiText>
+              </EuiFormRow>
 
-                <EuiFormRow label={'Tags'} data-test-subj={'finding-details-flyout-rule-tags'}>
-                  <EuiText>{this.renderTags(rule.tags) || DEFAULT_EMPTY_DATA}</EuiText>
-                </EuiFormRow>
-              </EuiPanel>
-            </EuiAccordion>
-            {rules.length > 1 && <EuiHorizontalRule margin={'xs'} />}
-          </div>
-        );
-      });
+              <EuiSpacer size={'m'} />
+
+              <EuiFormRow label={'Tags'} data-test-subj={'finding-details-flyout-rule-tags'}>
+                <EuiText>{this.renderTags(rule.tags) || DEFAULT_EMPTY_DATA}</EuiText>
+              </EuiFormRow>
+            </EuiPanel>
+          </EuiAccordion>
+          {rules.length > 1 && <EuiHorizontalRule margin={'xs'} />}
+        </div>
+      );
+    });
   };
 
   getIndexPatternId = async () => {


### PR DESCRIPTION
### Description
Sometimes we get an alert which was generated by a child monitor created for the bucket level monitor used for Detector with aggregation based rule. The findings in these alerts don't have Sigma rules but instead internal queries created for detection, hence when trying to render the details of these rules we fail to find a Sigma rule and the flyout page crashes.

This PR filters out rules that are not present in the Sigma rules we fetched from the server to avoid page crash.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).