### PR TITLE
Updated get findings & alerts to use duration filter and start showing results as they come in

### DIFF
--- a/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
+++ b/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
@@ -17,7 +17,7 @@ import {
   EuiSpacer,
   EuiTitle,
 } from '@elastic/eui';
-import { AlertItem, RuleSource } from '../../../../../server/models/interfaces';
+import { RuleSource } from '../../../../../server/models/interfaces';
 import React from 'react';
 import { ContentPanel } from '../../../../components/ContentPanel';
 import { ALERT_STATE, DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
@@ -30,10 +30,9 @@ import {
 } from '../../../../utils/helpers';
 import { IndexPatternsService, OpenSearchService } from '../../../../services';
 import { parseAlertSeverityToOption } from '../../../CreateDetector/components/ConfigureAlerts/utils/helpers';
-import { Finding } from '../../../Findings/models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { DataStore } from '../../../../store/DataStore';
-import { Detector } from '../../../../../types';
+import { AlertItem, Detector, Finding } from '../../../../../types';
 
 export interface AlertFlyoutProps {
   alertItem: AlertItem;
@@ -135,7 +134,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
         name: 'Finding ID',
         sortable: true,
         dataType: 'string',
-        render: (id, finding: any) =>
+        render: (id: string, finding: any) =>
           (
             <EuiLink
               onClick={() => {
@@ -159,7 +158,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
               }}
               data-test-subj={'finding-details-flyout-button'}
             >
-              {`${(id as string).slice(0, 7)}...`}
+              {id.length > 7 ? `${id.slice(0, 7)}...` : id}
             </EuiLink>
           ) || DEFAULT_EMPTY_DATA,
       },

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -1182,6 +1182,24 @@ exports[`<Alerts /> spec renders the component 1`] = `
                       itemId={[Function]}
                       items={Array []}
                       loading={true}
+                      message={
+                        <EuiEmptyPrompt
+                          body={
+                            <p>
+                              <span
+                                style={
+                                  Object {
+                                    "display": "block",
+                                  }
+                                }
+                              >
+                                No alerts.
+                              </span>
+                              Adjust the time range to see more results.
+                            </p>
+                          }
+                        />
+                      }
                       pagination={true}
                       responsive={true}
                       search={
@@ -1745,7 +1763,24 @@ exports[`<Alerts /> spec renders the component 1`] = `
                           itemId={[Function]}
                           items={Array []}
                           loading={true}
-                          noItemsMessage="No items found"
+                          noItemsMessage={
+                            <EuiEmptyPrompt
+                              body={
+                                <p>
+                                  <span
+                                    style={
+                                      Object {
+                                        "display": "block",
+                                      }
+                                    }
+                                  >
+                                    No alerts.
+                                  </span>
+                                  Adjust the time range to see more results.
+                                </p>
+                              }
+                            />
+                          }
                           onChange={[Function]}
                           pagination={
                             Object {
@@ -2408,7 +2443,53 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                 <span
                                                   className="euiTableCellContent__text"
                                                 >
-                                                  No items found
+                                                  <EuiEmptyPrompt
+                                                    body={
+                                                      <p>
+                                                        <span
+                                                          style={
+                                                            Object {
+                                                              "display": "block",
+                                                            }
+                                                          }
+                                                        >
+                                                          No alerts.
+                                                        </span>
+                                                        Adjust the time range to see more results.
+                                                      </p>
+                                                    }
+                                                  >
+                                                    <div
+                                                      className="euiEmptyPrompt"
+                                                    >
+                                                      <EuiTextColor
+                                                        color="subdued"
+                                                      >
+                                                        <span
+                                                          className="euiTextColor euiTextColor--subdued"
+                                                        >
+                                                          <EuiText>
+                                                            <div
+                                                              className="euiText euiText--medium"
+                                                            >
+                                                              <p>
+                                                                <span
+                                                                  style={
+                                                                    Object {
+                                                                      "display": "block",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  No alerts.
+                                                                </span>
+                                                                Adjust the time range to see more results.
+                                                              </p>
+                                                            </div>
+                                                          </EuiText>
+                                                        </span>
+                                                      </EuiTextColor>
+                                                    </div>
+                                                  </EuiEmptyPrompt>
                                                 </span>
                                               </div>
                                             </td>

--- a/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
+++ b/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { CorrelationFinding } from '../../../../../types';
+import { CorrelationFinding, FindingItemType } from '../../../../../types';
 import { ruleTypes } from '../../../Rules/utils/constants';
 import { DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
 import {
@@ -20,7 +20,6 @@ import {
   EuiPopover,
 } from '@elastic/eui';
 import { FieldValueSelectionFilterConfigType } from '@elastic/eui/src/components/search_bar/filters/field_value_selection_filter';
-import { FindingItemType } from '../../containers/Findings/Findings';
 import { RouteComponentProps } from 'react-router-dom';
 import { DataStore } from '../../../../store/DataStore';
 import { capitalizeFirstLetter, formatRuleType, getSeverityBadge } from '../../../../utils/helpers';

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -48,8 +48,7 @@ import { RuleSource } from '../../../../server/models/interfaces';
 import { OpenSearchService, IndexPatternsService, CorrelationService } from '../../../services';
 import { RuleTableItem } from '../../Rules/utils/helpers';
 import { CreateIndexPatternForm } from './CreateIndexPatternForm';
-import { FindingItemType } from '../containers/Findings/Findings';
-import { CorrelationFinding, FindingDocumentItem, RuleItemInfoBase } from '../../../../types';
+import { CorrelationFinding, FindingDocumentItem, RuleItemInfoBase, FindingItemType, AbortSignal } from '../../../../types';
 import { FindingFlyoutTabId, FindingFlyoutTabs } from '../utils/constants';
 import { DataStore } from '../../../store/DataStore';
 import { CorrelationsTable } from './CorrelationsTable/CorrelationsTable';
@@ -88,6 +87,8 @@ export default class FindingDetailsFlyout extends Component<
   FindingDetailsFlyoutProps,
   FindingDetailsFlyoutState
 > {
+  private abortGetFindingsSignals: AbortSignal[] = []; 
+
   constructor(props: FindingDetailsFlyoutProps) {
     super(props);
     const relatedDocuments: FindingDocumentItem[] = this.getRelatedDocuments();
@@ -121,12 +122,21 @@ export default class FindingDetailsFlyout extends Component<
     };
   }
 
+  componentWillUnmount(): void {
+    this.abortGetFindingsSignals.forEach(abort => {
+      abort.signal = true;
+    })
+    this.abortGetFindingsSignals = [];
+  }
+
   getCorrelations = async () => {
     const { id, detector } = this.props.finding;
     let allFindings = this.props.findings;
     if (this.props.shouldLoadAllFindings) {
       // if findings come from the alerts fly-out, we need to get all the findings to match those with the correlations
-      allFindings = await DataStore.findings.getAllFindings();
+      const abort = { signal: false };
+      this.abortGetFindingsSignals.push(abort);
+      allFindings = await DataStore.findings.getAllFindings(abort);
     }
 
     DataStore.correlations.getCorrelationRules().then((correlationRules) => {

--- a/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
@@ -30,14 +30,13 @@ import {
   IndexPatternsService,
   CorrelationService,
 } from '../../../../services';
-import { Finding } from '../../models/interfaces';
 import CreateAlertFlyout from '../CreateAlertFlyout';
 import { NotificationChannelTypeOptions } from '../../../CreateDetector/components/ConfigureAlerts/models/interfaces';
-import { FindingItemType } from '../../containers/Findings/Findings';
 import { parseAlertSeverityToOption } from '../../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { RuleSource } from '../../../../../server/models/interfaces';
 import { DataStore } from '../../../../store/DataStore';
 import { getSeverityColor } from '../../../Correlations/utils/constants';
+import { Finding, FindingItemType } from '../../../../../types';
 
 interface FindingsTableProps extends RouteComponentProps {
   detectorService: DetectorsService;

--- a/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
@@ -176,13 +176,13 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
         name: 'Finding ID',
         sortable: true,
         dataType: 'string',
-        render: (id, finding) =>
+        render: (id: string, finding) =>
           (
             <EuiLink
               onClick={() => DataStore.findings.openFlyout(finding, this.state.filteredFindings)}
               data-test-subj={'finding-details-flyout-button'}
             >
-              {`${(id as string).slice(0, 7)}...`}
+              {id.length > 7 ? `${id.slice(0, 7)}...` : id}
             </EuiLink>
           ) || DEFAULT_EMPTY_DATA,
       },

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -150,9 +150,9 @@ class Findings extends Component<FindingsProps, FindingsState> {
   }
 
   onRefresh = async () => {
-    await this.getFindings();
     await this.getNotificationChannels();
     await this.getPlugins();
+    await this.getFindings();
     renderVisualization(this.generateVisualizationSpec(), 'findings-view');
   };
 

--- a/public/pages/Findings/models/interfaces.ts
+++ b/public/pages/Findings/models/interfaces.ts
@@ -3,17 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface Finding {
-  id: string;
-  detectorId: string;
-  document_list: FindingDocument[];
-  index: string;
-  queries: Query[];
-  related_doc_ids: string[];
-  timestamp: number;
-  detectionType: string;
-}
-
 export interface Query {
   id: string;
   name: string;

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -674,6 +674,7 @@ export default class Main extends Component<MainProps, MainState> {
                                             dateTimeFilter={this.state.dateTimeFilter}
                                             setDateTimeFilter={this.setDateTimeFilter}
                                             dataSource={selectedDataSource}
+                                            notifications={core?.notifications}
                                           />
                                         );
                                       }}

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -73,13 +73,16 @@ export const Overview: React.FC<OverviewProps> = (props) => {
     return fireAbortSignals;
   }, [fireAbortSignals]);
 
-  const updateState = (overviewViewModel: OverviewViewModel) => {
+  const updateState = (overviewViewModel: OverviewViewModel, modelLoadingComplete: boolean) => {
     setState({
       ...state,
       overviewViewModel: { ...overviewViewModel },
     });
-    setLoading(false);
   };
+
+  const onLoadingComplete = (_overviewViewModel: OverviewViewModel, modelLoadingComplete: boolean) => {
+    setLoading(!modelLoadingComplete);
+  }
 
   const overviewViewModelActor = useMemo(
     () => new OverviewViewModelActor(saContext?.services, context?.notifications!),
@@ -89,6 +92,7 @@ export const Overview: React.FC<OverviewProps> = (props) => {
   useEffect(() => {
     context?.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.OVERVIEW]);
     overviewViewModelActor.registerRefreshHandler(updateState, true /* allowPartialResults */);
+    overviewViewModelActor.registerRefreshHandler(onLoadingComplete, false /* allowPartialResults */);
   }, []);
 
   useEffect(() => {

--- a/public/pages/Overview/models/OverviewViewModel.ts
+++ b/public/pages/Overview/models/OverviewViewModel.ts
@@ -192,19 +192,19 @@ export class OverviewViewModelActor {
     await this.runSteps([
       async () => {
         await this.updateDetectors();
-        this.updateResults(this.partialUpdateHandlers);
+        this.updateResults(this.partialUpdateHandlers, false);
       },
       async () => {
         await this.updateFindings(signal);
-        this.updateResults(this.partialUpdateHandlers);
+        this.updateResults(this.partialUpdateHandlers, false);
       },
       async (signal: AbortSignal) => {
         await this.updateAlerts(signal);
-        this.updateResults(this.partialUpdateHandlers);
+        this.updateResults(this.partialUpdateHandlers, false);
       }
     ], signal);
 
-    this.updateResults(this.fullUpdateHandlers);
+    this.updateResults(this.fullUpdateHandlers, true);
     this.refreshState = 'Complete';
   }
 
@@ -216,9 +216,9 @@ export class OverviewViewModelActor {
     });
   };
 
-  private updateResults(handlers: OverviewViewModelRefreshHandler[]) {
+  private updateResults(handlers: OverviewViewModelRefreshHandler[], modelLoadingComplete: boolean) {
     handlers.forEach((handler) => {
-      handler(this.overviewViewModel);
+      handler(this.overviewViewModel, modelLoadingComplete);
     });
   }
 

--- a/public/react-graph-vis.d.ts
+++ b/public/react-graph-vis.d.ts
@@ -4,10 +4,14 @@
  */
 
 declare module 'react-graph-vis' {
-  import { Network, NetworkEvents, Options, Node, Edge, DataSet, Data } from 'vis';
+  import { Network as NetworkBase, NetworkEvents, Options, Node, Edge, DataSet, Data } from 'vis';
   import { Component } from 'react';
 
-  export { Network, NetworkEvents, Options, Node, Edge, DataSet, Data } from 'vis';
+  export interface Network extends NetworkBase {
+    canvas: any;
+  }
+
+  export { NetworkEvents, Options, Node, Edge, DataSet, Data } from 'vis';
 
   export type GraphEvents = {
     [event in NetworkEvents]?: (params?: any) => void;

--- a/public/services/AlertsService.ts
+++ b/public/services/AlertsService.ts
@@ -19,12 +19,14 @@ export default class AlertsService {
   getAlerts = async (
     getAlertsParams: GetAlertsParams
   ): Promise<ServerResponse<GetAlertsResponse>> => {
-    const { detectorType, detector_id, size, sortOrder, startIndex } = getAlertsParams;
+    const { detectorType, detector_id, size, sortOrder, startIndex, startTime, endTime } = getAlertsParams;
     const baseQuery = {
       sortOrder: sortOrder || 'desc',
       size: size || 10000,
       startIndex: startIndex || 0,
       dataSourceId: dataSourceInfo.activeDataSource.id,
+      startTime,
+      endTime
     };
     let query;
 

--- a/public/services/FindingsService.ts
+++ b/public/services/FindingsService.ts
@@ -17,15 +17,15 @@ export default class FindingsService {
   }
 
   getFindings = async (
-    detectorParams: GetFindingsParams
+    getFindingsParams: GetFindingsParams
   ): Promise<ServerResponse<GetFindingsResponse>> => {
-    const findingIds = detectorParams.findingIds
-      ? JSON.stringify(detectorParams.findingIds)
+    const findingIds = getFindingsParams.findingIds
+      ? JSON.stringify(getFindingsParams.findingIds)
       : undefined;
     const query = {
       sortOrder: 'desc',
       size: 10000,
-      ...detectorParams,
+      ...getFindingsParams,
       findingIds,
       dataSourceId: dataSourceInfo.activeDataSource.id,
     };

--- a/public/store/AlertsStore.ts
+++ b/public/store/AlertsStore.ts
@@ -6,7 +6,7 @@
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { AlertsService } from '../services';
 import { errorNotificationToast } from '../utils/helpers';
-import { AbortSignal, AlertResponse, Duration } from '../../types';
+import { AlertResponse, Duration } from '../../types';
 
 export class AlertsStore {
   constructor(
@@ -17,7 +17,7 @@ export class AlertsStore {
   public async getAlertsByDetector(
     detectorId: string, 
     detectorName: string, 
-    abort: AbortSignal,
+    signal: AbortSignal,
     duration: Duration,
     onPartialAlertsFetched?: (alerts: AlertResponse[]) => void
   ) {
@@ -27,7 +27,7 @@ export class AlertsStore {
     let alertsCount = 0;
 
     do {
-      if (abort.signal) {
+      if (signal.aborted) {
         break;
       }
 
@@ -39,7 +39,7 @@ export class AlertsStore {
         endTime: duration.endTime
       });
 
-      if (abort.signal) {
+      if (signal.aborted) {
         break;
       }
       

--- a/public/store/CorrelationsStore.ts
+++ b/public/store/CorrelationsStore.ts
@@ -8,6 +8,7 @@ import {
   CorrelationFinding,
   CorrelationRule,
   CorrelationRuleQuery,
+  DetectorHit,
   ICorrelationsStore,
   IRulesStore,
 } from '../../types';
@@ -195,12 +196,32 @@ export class CorrelationsStore implements ICorrelationsStore {
       start_time,
       end_time
     );
-    const allFindings = await this.fetchAllFindings();
-
+    
     const result: { finding1: CorrelationFinding; finding2: CorrelationFinding }[] = [];
-
+    
     if (allCorrelationsRes.ok) {
-      allCorrelationsRes.response.findings.forEach(({ finding1, finding2 }) => {
+      const firstTenGrandCorrelations = allCorrelationsRes.response.findings.slice(0, 10000);
+      const allFindingIdsSet = new Set<string>();
+      firstTenGrandCorrelations.forEach(({ finding1, finding2 }) => {
+        allFindingIdsSet.add(finding1);
+        allFindingIdsSet.add(finding2);
+      });
+
+      const allFindingIds = Array.from(allFindingIdsSet);
+      let allFindings: { [id: string]: CorrelationFinding } = {};
+      const maxFindingsFetchedInSingleCall = 10000;
+
+      for (let i = 0; i < allFindingIds.length; i+= maxFindingsFetchedInSingleCall) {
+        const findingIds = allFindingIds.slice(i, i + maxFindingsFetchedInSingleCall);
+        const findings = await this.fetchAllFindings(findingIds);
+        allFindings = {
+          ...allFindings,
+          ...findings
+        }
+      }
+
+      const maxNumberOfCorrelationsDisplayed = 10000;
+      allCorrelationsRes.response.findings.slice(0, maxNumberOfCorrelationsDisplayed).forEach(({ finding1, finding2 }) => {
         const f1 = allFindings[finding1];
         const f2 = allFindings[finding2];
         if (f1 && f2)
@@ -222,55 +243,58 @@ export class CorrelationsStore implements ICorrelationsStore {
 
   public allFindings: { [id: string]: CorrelationFinding } = {};
 
-  public async fetchAllFindings(): Promise<{ [id: string]: CorrelationFinding }> {
+  private async fetchAllFindings(findingIds: string[]): Promise<{ [id: string]: CorrelationFinding }> {
     const detectorsRes = await this.detectorsService.getDetectors();
     const allRules = await this.rulesStore.getAllRules();
 
     if (detectorsRes.ok) {
-      const detectors = detectorsRes.response.hits.hits;
-      let findings: { [id: string]: CorrelationFinding } = {};
-      for (let detector of detectors) {
-        const detectorFindings = await DataStore.findings.getFindingsPerDetector(detector._id);
-        detectorFindings.forEach((f) => {
-          const rule = allRules.find((rule) => rule._id === f.queries[0].id);
-          findings[f.id] = {
-            ...f,
-            id: f.id,
-            logType: detector._source.detector_type,
-            detector: detector,
-            detectorName: detector._source.name,
-            timestamp: new Date(f.timestamp).toLocaleString(),
-            detectionRule: rule
-              ? {
-                  name: rule._source.title,
-                  severity: rule._source.level,
-                  tags: rule._source.tags,
-                }
-              : { name: DEFAULT_EMPTY_DATA, severity: DEFAULT_EMPTY_DATA },
-          };
-        });
+      const detectorsMap: { [id: string]: DetectorHit } = {};
+      detectorsRes.response.hits.hits.forEach(detector => {
+        detectorsMap[detector._id] = detector;
+      });
+      let findingsMap: { [id: string]: CorrelationFinding } = {};
+      const findings = await DataStore.findings.getFindingsByIds(findingIds);
+      findings.forEach((f) => {
+        const detector = detectorsMap[f.detectorId];
+        const rule = allRules.find((rule) => rule._id === f.queries[0].id);
+        findingsMap[f.id] = {
+          ...f,
+          id: f.id,
+          logType: detector._source.detector_type,
+          detector: detector,
+          detectorName: detector._source.name,
+          timestamp: new Date(f.timestamp).toLocaleString(),
+          detectionRule: rule
+            ? {
+                name: rule._source.title,
+                severity: rule._source.level,
+                tags: rule._source.tags,
+              }
+            : { name: DEFAULT_EMPTY_DATA, severity: DEFAULT_EMPTY_DATA },
+        };
+      });
 
-        this.allFindings = findings;
-      }
+      this.allFindings = findingsMap;
     }
 
     return this.allFindings;
   }
 
   public async getCorrelatedFindings(
-    finding: string,
+    findingId: string,
     detector_type: string,
     nearby_findings = 20
   ): Promise<{ finding: CorrelationFinding; correlatedFindings: CorrelationFinding[] }> {
-    const allFindings = await this.fetchAllFindings();
     const response = await this.service.getCorrelatedFindings(
-      finding,
+      findingId,
       detector_type,
       nearby_findings
     );
 
     if (response?.ok) {
       const correlatedFindings: CorrelationFinding[] = [];
+      const allFindingIds = response.response.findings.map(f => f.finding);
+      const allFindings = await this.fetchAllFindings(allFindingIds);      
       response.response.findings.forEach((f) => {
         if (allFindings[f.finding]) {
           correlatedFindings.push({
@@ -282,15 +306,17 @@ export class CorrelationsStore implements ICorrelationsStore {
       });
 
       return {
-        finding: allFindings[finding],
+        finding: allFindings[findingId],
         correlatedFindings,
       };
     }
 
+    const finding = (await DataStore.findings.getFindingsByIds([findingId]))[0];
+
     return {
       finding: {
-        ...allFindings[finding],
-        id: finding,
+        ...finding,
+        id: findingId,
         logType: detector_type,
         timestamp: '',
         detectionRule: { name: '', severity: 'high' },

--- a/public/store/FindingsStore.ts
+++ b/public/store/FindingsStore.ts
@@ -8,9 +8,8 @@ import { DetectorsService, FindingsService } from '../services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { RouteComponentProps } from 'react-router-dom';
 import { errorNotificationToast } from '../utils/helpers';
-import { FindingItemType } from '../pages/Findings/containers/Findings/Findings';
 import { FindingDetailsFlyoutBaseProps } from '../pages/Findings/components/FindingDetailsFlyout';
-import { Finding, GetFindingsResponse, ServerResponse } from '../../types';
+import { AbortSignal, DetectorHit, Duration, Finding, FindingItemType, GetFindingsResponse, ServerResponse } from '../../types';
 
 export interface IFindingsStore {
   readonly service: FindingsService;
@@ -23,9 +22,15 @@ export interface IFindingsStore {
 
   getFindingsByIds: (findingIds: string[]) => Promise<Finding[]>;
 
-  getFindingsPerDetector: (detectorId: string) => Promise<Finding[]>;
+  getFindingsPerDetector: (
+    detectorId: string, 
+    detector: DetectorHit,
+    abort: AbortSignal,
+    duration?: Duration, 
+    onPartialFindingsFetched?: (findings: Finding[]) => void
+  ) => Promise<Finding[]>;
 
-  getAllFindings: () => Promise<FindingItemType[]>;
+  getAllFindings: (abort: AbortSignal, duration?: { startTime: number; endTime: number; }, onPartialFindingsFetched?: (findings: Finding[]) => void) => Promise<FindingItemType[]>;
 
   setFlyoutCallback: (
     flyoutCallback: (findingFlyout: FindingDetailsFlyoutBaseProps | null) => void
@@ -111,25 +116,60 @@ export class FindingsStore implements IFindingsStore {
     return [];
   };
 
-  public getFindingsPerDetector = async (detectorId: string): Promise<Finding[]> => {
-    let allFindings: Finding[] = [];
+  public getFindingsPerDetector = async (
+    detectorId: string,
+    detector: DetectorHit,
+    abort: AbortSignal,
+    duration?: Duration,
+    onPartialFindingsFetched?: (findings: FindingItemType[]) => void
+  ): Promise<FindingItemType[]> => {
+    let allFindings: FindingItemType[] = [];
     const findingsSize = 10000;
-    const firstGetFindingsRes = await this.service.getFindings({
+    const getFindingsQueryParams = {
       detector_id: detectorId,
       startIndex: 0,
       size: findingsSize,
-    });
+      startTime: duration?.startTime,
+      endTime: duration?.endTime
+    }
+
+    if (abort.signal) {
+      return allFindings;
+    }
+
+    const firstGetFindingsRes = await this.service.getFindings(getFindingsQueryParams);
 
     if (firstGetFindingsRes.ok) {
-      allFindings = [...firstGetFindingsRes.response.findings];
+      const extendedFindings = this.extendFindings(firstGetFindingsRes.response.findings, detector);
+      onPartialFindingsFetched?.(extendedFindings);
+      allFindings = [...extendedFindings];
       let remainingFindings = firstGetFindingsRes.response.total_findings - findingsSize;
       let startIndex = findingsSize + 1;
       const getFindingsPromises: Promise<ServerResponse<GetFindingsResponse>>[] = [];
 
       while (remainingFindings > 0) {
+
+        if (abort.signal) {
+          return allFindings;
+        }
+
+        const getFindingsPromise = this.service.getFindings({ 
+          ...getFindingsQueryParams,
+          startIndex
+        });
+
+        if (abort.signal) {
+          return allFindings;
+        }
+
         getFindingsPromises.push(
-          this.service.getFindings({ detector_id: detectorId, startIndex, size: findingsSize })
+          getFindingsPromise
         );
+        getFindingsPromise.then((res): any => {
+          if (res.ok) {
+            onPartialFindingsFetched?.(this.extendFindings(res.response.findings, detector));
+          }
+        });
         remainingFindings -= findingsSize;
         startIndex += findingsSize;
       }
@@ -138,7 +178,7 @@ export class FindingsStore implements IFindingsStore {
 
       findingsPromisesRes.forEach((response) => {
         if (response.status === 'fulfilled' && response.value.ok) {
-          allFindings = allFindings.concat(response.value.response.findings);
+          allFindings = allFindings.concat(this.extendFindings(response.value.response.findings, detector));
         }
       });
     } else {
@@ -148,23 +188,19 @@ export class FindingsStore implements IFindingsStore {
     return allFindings;
   };
 
-  public getAllFindings = async (): Promise<FindingItemType[]> => {
+  public getAllFindings = async (
+    abort: AbortSignal,
+    duration?: Duration,
+    onPartialFindingsFetched?: (findings: FindingItemType[]) => void
+  ): Promise<FindingItemType[]> => {
     let allFindings: FindingItemType[] = [];
     const detectorsRes = await this.detectorsService.getDetectors();
     if (detectorsRes.ok) {
       const detectors = detectorsRes.response.hits.hits;
 
       for (let detector of detectors) {
-        const findings = await this.getFindingsPerDetector(detector._id);
-        const findingsPerDetector: FindingItemType[] = findings.map((finding) => {
-          return {
-            ...finding,
-            detectorName: detector._source.name,
-            logType: detector._source.detector_type,
-            detector: detector,
-            correlations: [],
-          };
-        });
+        const findings = await this.getFindingsPerDetector(detector._id, detector, abort, duration, onPartialFindingsFetched);
+        const findingsPerDetector: FindingItemType[] = this.extendFindings(findings, detector);
         allFindings = allFindings.concat(findingsPerDetector);
       }
     }
@@ -196,4 +232,16 @@ export class FindingsStore implements IFindingsStore {
     } as FindingDetailsFlyoutBaseProps;
     this.openFlyoutCallback(flyout);
   };
+
+  private extendFindings(findings: Finding[], detector: DetectorHit): FindingItemType[] {
+    return findings.map((finding) => {
+      return {
+        ...finding,
+        detectorName: detector._source.name,
+        logType: detector._source.detector_type,
+        detector: detector,
+        correlations: [],
+      };
+    });
+  }
 }

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -39,11 +39,12 @@ import { IndexService, OpenSearchService } from '../services';
 import { ruleSeverity, ruleTypes } from '../pages/Rules/utils/constants';
 import { Handler } from 'vega-tooltip';
 import _ from 'lodash';
-import { AlertCondition, LogType } from '../../types';
+import { AlertCondition, DateTimeFilter, Duration, LogType } from '../../types';
 import { DataStore } from '../store/DataStore';
 import { LogCategoryOptionView } from '../components/Utility/LogCategoryOption';
 import { getLogTypeLabel } from '../pages/LogTypes/utils/helpers';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
+import dateMath from '@elastic/datemath';
 
 export const parseStringsToOptions = (strings: string[]) => {
   return strings.map((str) => ({ id: str, label: str }));
@@ -551,4 +552,14 @@ function getValueSetter(baseObject: any) {
       o[lastField] = value;
     }
   };
+}
+
+export function getDuration({ startTime, endTime }: DateTimeFilter): Duration {
+  const startMoment = dateMath.parse(startTime)!;
+  const endMoment = dateMath.parse(endTime)!;
+
+  return {
+    startTime: startMoment.valueOf(),
+    endTime: endMoment.valueOf()
+  }
 }

--- a/server/routes/AlertRoutes.ts
+++ b/server/routes/AlertRoutes.ts
@@ -22,6 +22,8 @@ export function setupAlertsRoutes(services: NodeServices, router: IRouter) {
           sortOrder: schema.maybe(schema.string()),
           size: schema.maybe(schema.number()),
           startIndex: schema.maybe(schema.number()),
+          startTime: schema.maybe(schema.number()),
+          endTime: schema.maybe(schema.number())
         }),
       },
     },

--- a/server/routes/FindingsRoutes.ts
+++ b/server/routes/FindingsRoutes.ts
@@ -26,6 +26,8 @@ export function setupFindingsRoutes(services: NodeServices, router: IRouter) {
           severity: schema.maybe(schema.string()),
           searchString: schema.maybe(schema.string()),
           findingIds: schema.maybe(schema.arrayOf(schema.string())),
+          startTime: schema.maybe(schema.number()),
+          endTime: schema.maybe(schema.number())
         }),
       },
     },

--- a/server/services/AlertService.ts
+++ b/server/services/AlertService.ts
@@ -30,10 +30,12 @@ export default class AlertService extends MDSEnabledClientService {
     response: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<ServerResponse<GetAlertsResponse> | ResponseError>> => {
     try {
-      const { detectorType, detector_id, sortOrder, size } = request.query;
+      const { detectorType, detector_id, sortOrder, size, startTime, endTime } = request.query;
       const defaultParams = {
         sortOrder,
         size,
+        startTime,
+        endTime
       };
       let params: GetAlertsParams;
 

--- a/types/Alert.ts
+++ b/types/Alert.ts
@@ -51,6 +51,8 @@ export type GetAlertsParams = {
   sortOrder?: string;
   size?: number;
   startIndex?: number;
+  startTime?: number;
+  endTime?: number;
 } & (
   | {
       detector_id: string;

--- a/types/Correlations.ts
+++ b/types/Correlations.ts
@@ -137,7 +137,6 @@ export interface ICorrelationsStore {
     end_time: string
   ): Promise<{ finding1: CorrelationFinding; finding2: CorrelationFinding }[]>;
   allFindings: { [id: string]: CorrelationFinding };
-  fetchAllFindings(): Promise<{ [id: string]: CorrelationFinding }>;
 }
 
 export type CorrelationLevelInfo =

--- a/types/Overview.ts
+++ b/types/Overview.ts
@@ -21,7 +21,7 @@ export interface OverviewViewModel {
   alerts: OverviewAlertItem[];
 }
 
-export type OverviewViewModelRefreshHandler = (overviewState: OverviewViewModel) => void;
+export type OverviewViewModelRefreshHandler = (overviewState: OverviewViewModel, modelUpdateComplete: boolean) => void;
 
 export interface OverviewProps extends RouteComponentProps, DataSourceProps {
   getStartedDismissedOnce: boolean;

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,3 +19,4 @@ export * from './Metrics';
 export * from './SecurityAnalyticsContext';
 export * from './DataSourceContext';
 export * from './DataSource';
+export * from './shared';

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -7,10 +7,6 @@ import { CorrelationFinding } from "./Correlations";
 import { DetectorHit } from "./Detector";
 import { Finding } from "./Finding";
 
-export interface AbortSignal {
-  signal: boolean;
-}
-
 export interface Duration { 
   startTime: number; 
   endTime: number; 

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -1,0 +1,31 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import { CorrelationFinding } from "./Correlations";
+import { DetectorHit } from "./Detector";
+import { Finding } from "./Finding";
+
+export interface AbortSignal {
+  signal: boolean;
+}
+
+export interface Duration { 
+  startTime: number; 
+  endTime: number; 
+}
+
+export type FindingItemType = Finding & {
+  logType: string;
+  detectorName: string;
+  detector: DetectorHit;
+  correlations: CorrelationFinding[];
+};
+
+export interface FindingDetectorMetadata {
+  detectorName: string;
+  logType: string;
+  detector: DetectorHit
+  correlations: []
+}


### PR DESCRIPTION
### Description
This PR improves the UI experience for the cases when there are huge numbers of alerts/findings by showing partial results as they come in. The PR also updates the logic to abort fetch calls when the user moves away from the alerts/findings pages or hits refresh so that we don't end up make redundant calls in the background.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).