### PR TITLE
When sending partial alerts results extend them with the detector name and id as well

### DIFF
--- a/public/store/AlertsStore.ts
+++ b/public/store/AlertsStore.ts
@@ -44,9 +44,10 @@ export class AlertsStore {
       }
       
       if (getAlertsRes.ok) {
-        onPartialAlertsFetched?.(getAlertsRes.response.alerts)
-        allAlerts = allAlerts.concat(getAlertsRes.response.alerts);
-        alertsCount = getAlertsRes.response.alerts.length;
+        const alerts = this.extendAlerts(getAlertsRes.response.alerts, detectorId, detectorName);
+        onPartialAlertsFetched?.(alerts);
+        allAlerts = allAlerts.concat(alerts);
+        alertsCount = alerts.length;
       } else {
         alertsCount = 0;
         errorNotificationToast(this.notifications, 'retrieve', 'alerts', getAlertsRes.error);
@@ -59,7 +60,11 @@ export class AlertsStore {
       alertsCount === maxAlertsReturned
     );
 
-    allAlerts = allAlerts.map((alert) => {
+    return allAlerts;
+  }
+
+  private extendAlerts(allAlerts: any[], detectorId: string, detectorName: string) {
+    return allAlerts.map((alert) => {
       if (!alert.detector_id) {
         alert.detector_id = detectorId;
       }
@@ -69,7 +74,5 @@ export class AlertsStore {
         detectorName: detectorName,
       };
     });
-
-    return allAlerts;
   }
 }


### PR DESCRIPTION
### Description
Currently, when getting alerts we add additional fields to the alerts in the store before returning but when we introduced sending partial alerts results we missed extending the alerts. This can result in info like Detector name not showing up.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).