### PR TITLE
[MDS fixes] Select default data source on load; re-order router paths for correct data source component rendering

### DIFF
--- a/public/components/MDS/DataSourceMenuWrapper.tsx
+++ b/public/components/MDS/DataSourceMenuWrapper.tsx
@@ -18,6 +18,7 @@ export interface DataSourceMenuWrapperProps {
   core: CoreStart;
   dataSourceManagement?: DataSourceManagementPluginSetup;
   dataSourceMenuReadOnly: boolean;
+  dataSourceLoading: boolean;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
 }
 
@@ -25,6 +26,7 @@ export const DataSourceMenuWrapper: React.FC<DataSourceMenuWrapperProps> = ({
   core,
   dataSourceManagement,
   dataSourceMenuReadOnly,
+  dataSourceLoading,
   setHeaderActionMenu,
 }) => {
   if (!dataSourceManagement) {
@@ -38,6 +40,8 @@ export const DataSourceMenuWrapper: React.FC<DataSourceMenuWrapperProps> = ({
   const DataSourceMenuSelectableComponent = dataSourceManagement.ui?.getDataSourceMenu<
     DataSourceSelectableConfig
   >();
+
+  const activeOption = dataSourceLoading ? undefined : [dataSource];
 
   return (
     <Switch>
@@ -68,39 +72,6 @@ export const DataSourceMenuWrapper: React.FC<DataSourceMenuWrapperProps> = ({
         }}
       />
       <Route
-        path={[
-          ROUTES.ROOT,
-          ROUTES.OVERVIEW,
-          ROUTES.DETECTORS,
-          ROUTES.ALERTS,
-          ROUTES.FINDINGS,
-          ROUTES.LOG_TYPES,
-          ROUTES.RULES,
-          ROUTES.CORRELATIONS,
-          ROUTES.CORRELATION_RULES,
-          ROUTES.RULES_CREATE,
-          ROUTES.RULES_IMPORT,
-          ROUTES.RULES_DUPLICATE,
-          ROUTES.LOG_TYPES_CREATE,
-          ROUTES.CORRELATION_RULE_CREATE,
-        ]}
-        render={() => {
-          return (
-            <DataSourceMenuSelectableComponent
-              componentType="DataSourceSelectable"
-              setMenuMountPoint={setHeaderActionMenu}
-              componentConfig={{
-                fullWidth: false,
-                activeOption: [dataSource],
-                notifications: core.notifications,
-                onSelectedDataSources: setDataSource,
-                savedObjects: core.savedObjects.client,
-              }}
-            />
-          );
-        }}
-      />
-      <Route
         path={[ROUTES.DETECTORS_CREATE]}
         render={() => {
           return dataSourceMenuReadOnly ? (
@@ -118,7 +89,40 @@ export const DataSourceMenuWrapper: React.FC<DataSourceMenuWrapperProps> = ({
               setMenuMountPoint={setHeaderActionMenu}
               componentConfig={{
                 fullWidth: false,
-                activeOption: [dataSource],
+                activeOption,
+                notifications: core.notifications,
+                onSelectedDataSources: setDataSource,
+                savedObjects: core.savedObjects.client,
+              }}
+            />
+          );
+        }}
+      />
+      <Route
+        path={[
+          ROUTES.OVERVIEW,
+          ROUTES.DETECTORS,
+          ROUTES.ALERTS,
+          ROUTES.FINDINGS,
+          ROUTES.LOG_TYPES,
+          ROUTES.RULES,
+          ROUTES.CORRELATIONS,
+          ROUTES.CORRELATION_RULES,
+          ROUTES.RULES_CREATE,
+          ROUTES.RULES_IMPORT,
+          ROUTES.RULES_DUPLICATE,
+          ROUTES.LOG_TYPES_CREATE,
+          ROUTES.CORRELATION_RULE_CREATE,
+          ROUTES.ROOT,
+        ]}
+        render={() => {
+          return (
+            <DataSourceMenuSelectableComponent
+              componentType="DataSourceSelectable"
+              setMenuMountPoint={setHeaderActionMenu}
+              componentConfig={{
+                fullWidth: false,
+                activeOption,
                 notifications: core.notifications,
                 onSelectedDataSources: setDataSource,
                 savedObjects: core.savedObjects.client,

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -400,6 +400,7 @@ export default class Main extends Component<MainProps, MainState> {
                               <DataSourceMenuWrapper
                                 dataSourceManagement={dataSourceManagement}
                                 core={core}
+                                dataSourceLoading={this.state.dataSourceLoading}
                                 dataSourceMenuReadOnly={dataSourceMenuReadOnly}
                                 setHeaderActionMenu={setActionMenu}
                               />


### PR DESCRIPTION
### Description
This PR fixes two issues:
1. On security analytics load we are not selecting the default data source
2. For step two of create detector, the data source selectable component is rendered instead of view only.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).