### PR TITLE
bug fix getFindingByIds API

### DIFF
--- a/public/services/FindingsService.ts
+++ b/public/services/FindingsService.ts
@@ -20,7 +20,7 @@ export default class FindingsService {
     getFindingsParams: GetFindingsParams
   ): Promise<ServerResponse<GetFindingsResponse>> => {
     const findingIds = getFindingsParams.findingIds
-      ? JSON.stringify(getFindingsParams.findingIds)
+      ? getFindingsParams.findingIds.join(',')
       : undefined;
     const query = {
       sortOrder: 'desc',

--- a/server/routes/FindingsRoutes.ts
+++ b/server/routes/FindingsRoutes.ts
@@ -25,7 +25,7 @@ export function setupFindingsRoutes(services: NodeServices, router: IRouter) {
           detectionType: schema.maybe(schema.string()),
           severity: schema.maybe(schema.string()),
           searchString: schema.maybe(schema.string()),
-          findingIds: schema.maybe(schema.arrayOf(schema.string())),
+          findingIds: schema.maybe(schema.string()),
           startTime: schema.maybe(schema.number()),
           endTime: schema.maybe(schema.number())
         }),


### PR DESCRIPTION
### Description

This PR resolves an issue with the getFindingIds API parameter where a string array was expected as a request parameter, but the backend was sending a comma-separated findingIds string instead. This update aligns the API behavior correctly.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).