### PR TITLE
[Threat intel][part 3]  Support for source type URL_Download and logic to activate/deactivate source

### DIFF
--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -27,6 +27,7 @@ import {
   ThreatIntelS3CustomSourcePayload,
   ThreatIntelSourceItem,
   ThreatIntelSourcePayload,
+  URLDownloadSource,
 } from '../../../../../types';
 import { defaultIntervalUnitOptions } from '../../../../utils/constants';
 import { readIocsFromFile, threatIntelSourceItemToBasePayload } from '../../utils/helpers';
@@ -331,6 +332,14 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 )}
               </>
             )}
+            {type === 'URL_DOWNLOAD' && (
+              <EuiFormRow label="Source URL">
+                <EuiFieldText
+                  readOnly={isReadOnly}
+                  value={(sourceItem.source as URLDownloadSource).url_download?.url}
+                />
+              </EuiFormRow>
+            )}
             <EuiFormRow label="Types of malicious indicators">
               <>
                 <EuiSpacer size="s" />
@@ -344,14 +353,16 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
             </EuiFormRow>
             <EuiSpacer />
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              style={{ visibility: isReadOnly ? 'visible' : 'hidden' }}
-              onClick={() => setIsReadOnly(false)}
-            >
-              Edit
-            </EuiButton>
-          </EuiFlexItem>
+          {type !== 'URL_DOWNLOAD' && (
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                style={{ visibility: isReadOnly ? 'visible' : 'hidden' }}
+                onClick={() => setIsReadOnly(false)}
+              >
+                Edit
+              </EuiButton>
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       </EuiPanel>
       {!isReadOnly && (

--- a/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
+++ b/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
@@ -194,7 +194,7 @@ export const ThreatIntelOverview: React.FC<ThreatIntelOverviewProps> = ({
         initialIsOpen={threatIntelSources.length === 0 || logSources.length === 0}
       >
         <EuiSpacer />
-        <EuiFlexGroup>
+        <EuiFlexGroup wrap>
           {threatIntelNextStepsProps.map(
             ({ id, title, description, footerButtonProps: { text, disabled } }) => (
               <EuiFlexItem key={id}>

--- a/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
@@ -11,14 +11,17 @@ import { useEffect } from 'react';
 import { CoreServicesContext } from '../../../../components/core_services';
 import {
   EuiButton,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiLoadingContent,
   EuiPanel,
   EuiSpacer,
   EuiTabbedContent,
   EuiTabbedContentTab,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { DescriptionGroup } from '../../../../components/Utility/DescriptionGroup';
 import { IoCsTable } from '../../components/IoCsTable/IoCsTable';
@@ -138,7 +141,25 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
     }
   };
 
-  const { name, description, type, ioc_types, last_update_time, enabled } = source;
+  const toggleActiveState = async () => {
+    const updateRes = await threatIntelService.updateThreatIntelSource(source.id, {
+      ...source,
+      enabled_for_scan: !source.enabled_for_scan,
+    });
+    if (updateRes.ok) {
+      onSourceUpdate();
+    }
+  };
+
+  const {
+    name,
+    description,
+    type,
+    ioc_types,
+    last_update_time,
+    enabled,
+    enabled_for_scan,
+  } = source;
   const schedule = type === 'S3_CUSTOM' ? source.schedule : undefined;
 
   return (
@@ -150,7 +171,32 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center">
+          <EuiFlexGroup alignItems="center" wrap>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={
+                  'When Active, the indicators of compromise from this source are used to scan the log data as part of the threat intel scan.'
+                }
+              >
+                <span>
+                  <EuiIcon
+                    type={'dot'}
+                    color={enabled_for_scan ? 'success' : 'text'}
+                    style={{ marginBottom: 4 }}
+                  />{' '}
+                  {enabled_for_scan ? 'Active' : 'Inactive'}&nbsp;
+                  <EuiIcon type={'iInCircle'} />
+                </span>
+              </EuiToolTip>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color={enabled_for_scan ? 'danger' : 'primary'}
+                onClick={toggleActiveState}
+              >
+                {enabled_for_scan ? 'Deactivate' : 'Activate'}
+              </EuiButton>
+            </EuiFlexItem>
             {type === 'S3_CUSTOM' && (
               <EuiFlexItem grow={false}>
                 <EuiButton fill onClick={onRefresh}>
@@ -159,9 +205,9 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>
-              <EuiButton color="danger" onClick={onDeleteButtonClick}>
-                Delete
-              </EuiButton>
+              <EuiToolTip content={'Delete'}>
+                <EuiButtonIcon iconType={'trash'} color="danger" onClick={onDeleteButtonClick} />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
@@ -161,6 +161,7 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
     enabled_for_scan,
   } = source;
   const schedule = type === 'S3_CUSTOM' ? source.schedule : undefined;
+  const showActivateControls = 'enabled_for_scan' in source;
 
   return (
     <>
@@ -172,31 +173,35 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" wrap>
-            <EuiFlexItem grow={false}>
-              <EuiToolTip
-                content={
-                  'When Active, the indicators of compromise from this source are used to scan the log data as part of the threat intel scan.'
-                }
-              >
-                <span>
-                  <EuiIcon
-                    type={'dot'}
-                    color={enabled_for_scan ? 'success' : 'text'}
-                    style={{ marginBottom: 4 }}
-                  />{' '}
-                  {enabled_for_scan ? 'Active' : 'Inactive'}&nbsp;
-                  <EuiIcon type={'iInCircle'} />
-                </span>
-              </EuiToolTip>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color={enabled_for_scan ? 'danger' : 'primary'}
-                onClick={toggleActiveState}
-              >
-                {enabled_for_scan ? 'Deactivate' : 'Activate'}
-              </EuiButton>
-            </EuiFlexItem>
+            {showActivateControls && (
+              <>
+                <EuiFlexItem grow={false}>
+                  <EuiToolTip
+                    content={
+                      'When Active, the indicators of compromise from this source are used to scan the log data as part of the threat intel scan.'
+                    }
+                  >
+                    <span>
+                      <EuiIcon
+                        type={'dot'}
+                        color={enabled_for_scan ? 'success' : 'text'}
+                        style={{ marginBottom: 4 }}
+                      />{' '}
+                      {enabled_for_scan ? 'Active' : 'Inactive'}&nbsp;
+                      <EuiIcon type={'iInCircle'} />
+                    </span>
+                  </EuiToolTip>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    color={enabled_for_scan ? 'danger' : 'primary'}
+                    onClick={toggleActiveState}
+                  >
+                    {enabled_for_scan ? 'Deactivate' : 'Activate'}
+                  </EuiButton>
+                </EuiFlexItem>
+              </>
+            )}
             {type === 'S3_CUSTOM' && (
               <EuiFlexItem grow={false}>
                 <EuiButton fill onClick={onRefresh}>

--- a/types/ThreatIntel.ts
+++ b/types/ThreatIntel.ts
@@ -52,12 +52,19 @@ export interface FileUploadSource {
   };
 }
 
+export interface URLDownloadSource {
+  url_download: {
+    url: string;
+  };
+}
+
 export interface ThreatIntelSourcePayloadBase {
   name: string;
   description?: string;
   format: 'STIX2';
   store_type: 'OS';
   enabled: boolean;
+  enabled_for_scan: boolean;
   ioc_types: ThreatIntelIocType[];
 }
 
@@ -78,9 +85,22 @@ export interface ThreatIntelIocUploadSourcePayload extends ThreatIntelSourcePayl
   source: FileUploadSource;
 }
 
+export interface ThreatIntelURLDownloadSourceInfo extends ThreatIntelSourcePayloadBase {
+  type: 'URL_DOWNLOAD';
+  schedule: {
+    interval: {
+      start_time: number;
+      period: number;
+      unit: string;
+    };
+  };
+  source: URLDownloadSource;
+}
+
 export type ThreatIntelSourcePayload =
   | ThreatIntelS3CustomSourcePayload
-  | ThreatIntelIocUploadSourcePayload;
+  | ThreatIntelIocUploadSourcePayload
+  | ThreatIntelURLDownloadSourceInfo;
 
 export interface LogSourceIocConfig {
   enabled: boolean;


### PR DESCRIPTION
### Description
In this PR we are adding support to display threat intel sources that use URL to download the IoC data. It also, integrates the Activate/Deactivate capability for threat intel sources. Deactivating a source will stop the refresh schedule and the source's use in threat intel scan.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).