### PR TITLE
[Create detector] Update data source selection label and help text

### DIFF
--- a/cypress/integration/1_detectors.spec.js
+++ b/cypress/integration/1_detectors.spec.js
@@ -36,7 +36,7 @@ const validateAlertPanel = (alertName) =>
     .eq(2)
     .within(() => cy.getElementByText('button', alertName));
 
-const dataSourceLabel = 'Select or input source indexes or index patterns';
+const dataSourceLabel = 'Select indexes/aliases';
 
 const getDataSourceField = () => cy.getFieldByLabel(dataSourceLabel);
 

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -290,6 +290,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                           },
                         ]
                       }
+                      compressed={false}
                       dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                       end="now"
                       isAutoRefreshOnly={false}
@@ -330,6 +331,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                             >
                               <EuiFormControlLayout
                                 className="euiSuperDatePicker"
+                                compressed={false}
                                 isDisabled={false}
                                 prepend={
                                   <EuiQuickSelectPopover
@@ -595,7 +597,9 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                         </button>
                                       </div>
                                     </EuiDatePickerRange>
-                                    <EuiFormControlLayoutIcons />
+                                    <EuiFormControlLayoutIcons
+                                      compressed={false}
+                                    />
                                   </div>
                                 </div>
                               </EuiFormControlLayout>
@@ -608,6 +612,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                               className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
                               <EuiSuperUpdateButton
+                                compressed={false}
                                 data-test-subj="superDatePickerApplyTimeButton"
                                 fill={false}
                                 isDisabled={false}
@@ -637,6 +642,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onFocus={[Function]}
+                                      size="m"
                                       textProps={
                                         Object {
                                           "className": "euiSuperUpdateButton__text",
@@ -657,6 +663,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                         onBlur={[Function]}
                                         onClick={[Function]}
                                         onFocus={[Function]}
+                                        size="m"
                                         textProps={
                                           Object {
                                             "className": "euiSuperUpdateButton__text",

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
@@ -12,6 +12,7 @@ import {
   EuiCallOut,
   EuiTextColor,
   EuiTitle,
+  EuiLink,
 } from '@elastic/eui';
 import { FormFieldHeader } from '../../../../../../components/FormFieldHeader/FormFieldHeader';
 import { IndexOption } from '../../../../../Detectors/models/interfaces';
@@ -155,11 +156,17 @@ export default class DetectorDataSource extends Component<
         </EuiTitle>
         <EuiSpacer size={'m'} />
         <EuiFormRow
-          label={
-            <FormFieldHeader headerTitle={'Select or input source indexes or index patterns'} />
-          }
+          label={<FormFieldHeader headerTitle={'Select indexes/aliases'} />}
           isInvalid={isInvalid}
           error={isInvalid && (errorMessage || 'Select an input source.')}
+          helpText={
+            <span>
+              <a href="https://opensearch.org/docs/latest/im-plugin/index-alias" target="_blank">
+                Aliases
+              </a>{' '}
+              are recommended for optimal functioning of detectors.
+            </span>
+          }
         >
           <EuiComboBox
             placeholder={'Select an input source for the detector.'}

--- a/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
@@ -718,7 +718,8 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
               >
                 Aliases
               </a>
-               are recommended for optimal functioning of detectors.
+               
+              are recommended for optimal functioning of detectors.
             </span>
           }
           isInvalid={false}
@@ -1112,7 +1113,8 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                     >
                       Aliases
                     </a>
-                     are recommended for optimal functioning of detectors.
+                     
+                    are recommended for optimal functioning of detectors.
                   </span>
                 </div>
               </EuiFormHelpText>

--- a/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
@@ -710,10 +710,21 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
           fullWidth={false}
           hasChildLabel={true}
           hasEmptyLabelSpace={false}
+          helpText={
+            <span>
+              <a
+                href="https://opensearch.org/docs/latest/im-plugin/index-alias"
+                target="_blank"
+              >
+                Aliases
+              </a>
+               are recommended for optimal functioning of detectors.
+            </span>
+          }
           isInvalid={false}
           label={
             <FormFieldHeader
-              headerTitle="Select or input source indexes or index patterns"
+              headerTitle="Select indexes/aliases"
             />
           }
           labelType="label"
@@ -739,7 +750,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                   htmlFor="some_html_id"
                 >
                   <FormFieldHeader
-                    headerTitle="Select or input source indexes or index patterns"
+                    headerTitle="Select indexes/aliases"
                   >
                     <EuiText
                       size="s"
@@ -748,7 +759,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                         className="euiText euiText--small"
                       >
                         <strong>
-                          Select or input source indexes or index patterns
+                          Select indexes/aliases
                         </strong>
                       </div>
                     </EuiText>
@@ -760,6 +771,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
               className="euiFormRow__fieldWrapper"
             >
               <EuiComboBox
+                aria-describedby="some_html_id-help-0"
                 async={false}
                 compressed={false}
                 data-test-subj="define-detector-select-data-source"
@@ -797,6 +809,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                 sortMatchesBy="none"
               >
                 <div
+                  aria-describedby="some_html_id-help-0"
                   aria-expanded={false}
                   aria-haspopup="listbox"
                   className="euiComboBox"
@@ -1083,6 +1096,26 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                   </EuiComboBoxInput>
                 </div>
               </EuiComboBox>
+              <EuiFormHelpText
+                className="euiFormRow__text"
+                id="some_html_id-help-0"
+                key="0"
+              >
+                <div
+                  className="euiFormHelpText euiFormRow__text"
+                  id="some_html_id-help-0"
+                >
+                  <span>
+                    <a
+                      href="https://opensearch.org/docs/latest/im-plugin/index-alias"
+                      target="_blank"
+                    >
+                      Aliases
+                    </a>
+                     are recommended for optimal functioning of detectors.
+                  </span>
+                </div>
+              </EuiFormHelpText>
             </div>
           </div>
         </EuiFormRow>


### PR DESCRIPTION
### Description
Update the label for data source selection and added help text to recommend usage of aliases.

#### Before
<img width="436" alt="image" src="https://github.com/user-attachments/assets/9df94438-886b-4025-8be7-571ab29b9561">


#### After
<img width="430" alt="image" src="https://github.com/user-attachments/assets/b5935a74-cd9e-4e6b-8885-9f475050ec1f">



### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).