### PR TITLE
Use smaller and compressed varients of buttons and form components

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.3.2",
+    "@types/vis": "^4.21.21",
     "cypress": "9.5.4",
     "cypress-real-events": "1.7.6",
     "cypress-recurse": "^1.27.0",
@@ -72,9 +73,8 @@
     "jest-cli": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1",
     "lint-staged": "^10.2.0",
-    "ts-loader": "^6.2.1",
-    "@types/vis": "^4.21.21",
-    "string.prototype.replaceall": "1.0.7"
+    "string.prototype.replaceall": "1.0.7",
+    "ts-loader": "^6.2.1"
   },
   "engines": {
     "yarn": "^1.21.1"

--- a/public/components/ContentPanel/ContentPanelActions.tsx
+++ b/public/components/ContentPanel/ContentPanelActions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ModalConsumer } from '../Modal';
 
 interface ContentPanelActionsProps {
@@ -22,22 +22,22 @@ const ContentPanelActions: React.SFC<ContentPanelActionsProps> = ({ actions }) =
   <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
     {actions.map(({ text, buttonProps = {}, flexItemProps = {}, modal = null }, index) => {
       let button = (
-        <EuiButton {...buttonProps} data-test-subj={`${text}Button`}>
+        <EuiSmallButton {...buttonProps} data-test-subj={`${text}Button`}>
           {text}
-        </EuiButton>
+        </EuiSmallButton>
       );
 
       if (modal) {
         button = (
           <ModalConsumer>
             {({ onShow }) => (
-              <EuiButton
+              <EuiSmallButton
                 {...buttonProps}
                 onClick={modal.onClickModal(onShow)}
                 data-test-subj={`${text}Button`}
               >
                 {text}
-              </EuiButton>
+              </EuiSmallButton>
             )}
           </ModalConsumer>
         );

--- a/public/components/ContentPanel/__snapshots__/ContentPanelActions.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanelActions.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<ContentPanelActions /> spec renders the component 1`] = `
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       data-test-subj="ContentPanelActionsButton"
       type="button"
     >

--- a/public/components/DeleteModal/DeleteModal.tsx
+++ b/public/components/DeleteModal/DeleteModal.tsx
@@ -6,7 +6,7 @@
 import React, { ChangeEvent, Component } from 'react';
 import {
   EuiConfirmModal,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
   EuiOverlayMask,
@@ -76,7 +76,7 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             <EuiSpacer size="s" />
             {!!confirmation && (
               <EuiCompressedFormRow helpText={`To confirm deletion, type "${DEFAULT_DELETION_TEXT}".`}>
-                <EuiFieldText
+                <EuiCompressedFieldText
                   value={confirmDeleteText}
                   placeholder={DEFAULT_DELETION_TEXT}
                   onChange={this.onChange}

--- a/public/components/DeleteModal/DeleteModal.tsx
+++ b/public/components/DeleteModal/DeleteModal.tsx
@@ -8,7 +8,7 @@ import {
   EuiConfirmModal,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiOverlayMask,
   EuiSpacer,
 } from '@elastic/eui';
@@ -75,14 +75,14 @@ export default class DeleteModal extends Component<DeleteModalProps, DeleteModal
             </p>
             <EuiSpacer size="s" />
             {!!confirmation && (
-              <EuiFormRow helpText={`To confirm deletion, type "${DEFAULT_DELETION_TEXT}".`}>
+              <EuiCompressedFormRow helpText={`To confirm deletion, type "${DEFAULT_DELETION_TEXT}".`}>
                 <EuiFieldText
                   value={confirmDeleteText}
                   placeholder={DEFAULT_DELETION_TEXT}
                   onChange={this.onChange}
                   data-test-subj={'deleteTextField'}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             )}
           </EuiForm>
         </EuiConfirmModal>

--- a/public/components/Notifications/NotificationForm.tsx
+++ b/public/components/Notifications/NotificationForm.tsx
@@ -6,7 +6,7 @@
 import {
   EuiAccordion,
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
   EuiFlexGroup,
@@ -84,7 +84,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
                   </EuiText>
                 }
               >
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder={'Select notification channel.'}
                   async={true}
                   isLoading={loadingNotifications}

--- a/public/components/Notifications/NotificationForm.tsx
+++ b/public/components/Notifications/NotificationForm.tsx
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiCompressedSwitch,
   EuiText,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { NOTIFICATIONS_HREF } from '../../utils/constants';
@@ -159,7 +159,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
                   }
                   fullWidth={true}
                 >
-                  <EuiTextArea
+                  <EuiCompressedTextArea
                     placeholder={'Enter the content of the notification message.'}
                     value={action?.message_template.source}
                     onChange={(e) => onMessageBodyChange(e.target.value)}

--- a/public/components/Notifications/NotificationForm.tsx
+++ b/public/components/Notifications/NotificationForm.tsx
@@ -8,7 +8,7 @@ import {
   EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -140,7 +140,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
                   }
                   fullWidth={true}
                 >
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     placeholder={'Enter a subject for the notification message.'}
                     value={action?.subject_template.source}
                     onChange={(e) => onMessageSubjectChange(e.target.value)}

--- a/public/components/Notifications/NotificationForm.tsx
+++ b/public/components/Notifications/NotificationForm.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiSpacer,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiText,
   EuiTextArea,
 } from '@elastic/eui';
@@ -64,7 +64,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
 
   return (
     <>
-      <EuiSwitch
+      <EuiCompressedSwitch
         label="Send notification"
         checked={shouldSendNotification}
         onChange={(e) => {

--- a/public/components/Notifications/NotificationForm.tsx
+++ b/public/components/Notifications/NotificationForm.tsx
@@ -11,7 +11,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiSwitch,
   EuiText,
@@ -77,7 +77,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
         <>
           <EuiFlexGroup alignItems={'flexEnd'}>
             <EuiFlexItem style={{ maxWidth: 400 }}>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={
                   <EuiText size="m">
                     <p>Notification channel</p>
@@ -97,7 +97,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
                   onFocus={refreshNotificationChannels}
                   isDisabled={!hasNotificationPlugin}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton
@@ -132,7 +132,7 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
           >
             <EuiFlexGroup direction={'column'} style={{ width: '75%' }}>
               <EuiFlexItem>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label={
                     <EuiText size={'s'}>
                       <p>Message subject</p>
@@ -147,11 +147,11 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
                     required={true}
                     fullWidth={true}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
 
               <EuiFlexItem>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label={
                     <EuiText size="s">
                       <p>Message body</p>
@@ -166,18 +166,18 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
                     required={true}
                     fullWidth={true}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
               {prepareMessage && (
                 <EuiFlexItem>
-                  <EuiFormRow>
+                  <EuiCompressedFormRow>
                     <EuiSmallButton
                       fullWidth={false}
                       onClick={() => prepareMessage(true /* updateMessage */)}
                     >
                       Generate message
                     </EuiSmallButton>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
               )}
             </EuiFlexGroup>

--- a/public/components/Notifications/NotificationForm.tsx
+++ b/public/components/Notifications/NotificationForm.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiAccordion,
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFieldText,
@@ -100,14 +100,14 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
               </EuiFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 href={NOTIFICATIONS_HREF}
                 iconType={'popout'}
                 target={'_blank'}
                 isDisabled={!hasNotificationPlugin}
               >
                 Manage channels
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
 
@@ -171,12 +171,12 @@ export const NotificationForm: React.FC<NotificationFormProps> = ({
               {prepareMessage && (
                 <EuiFlexItem>
                   <EuiFormRow>
-                    <EuiButton
+                    <EuiSmallButton
                       fullWidth={false}
                       onClick={() => prepareMessage(true /* updateMessage */)}
                     >
                       Generate message
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFormRow>
                 </EuiFlexItem>
               )}

--- a/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
+++ b/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
@@ -6,7 +6,7 @@
 import {
   EuiBasicTable,
   EuiBasicTableColumn,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -209,7 +209,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
             <EuiFlexItem grow={8}>
               <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
                 <EuiFlexItem grow={false}>
-                  <EuiButton
+                  <EuiSmallButton
                     disabled={acknowledged || alertItem.state !== ALERT_STATE.ACTIVE}
                     onClick={() => {
                       this.setState({ acknowledged: true });
@@ -218,7 +218,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
                     data-test-subj={'alert-details-flyout-acknowledge-button'}
                   >
                     Acknowledge
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiButtonIcon

--- a/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
+++ b/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
@@ -7,7 +7,7 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -111,7 +111,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
     const { rules } = this.state;
 
     const backButton = (
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         iconType="arrowLeft"
         aria-label="back"
         onClick={() => DataStore.findings.closeFlyout()}
@@ -221,7 +221,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
                   </EuiSmallButton>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonIcon
+                  <EuiSmallButtonIcon
                     aria-label="close"
                     iconType="cross"
                     iconSize="m"

--- a/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
+++ b/public/pages/Alerts/components/AlertFlyout/AlertFlyout.tsx
@@ -7,6 +7,7 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiSmallButton,
+  EuiButtonIcon,
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -111,7 +112,7 @@ export class AlertFlyout extends React.Component<AlertFlyoutProps, AlertFlyoutSt
     const { rules } = this.state;
 
     const backButton = (
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         iconType="arrowLeft"
         aria-label="back"
         onClick={() => DataStore.findings.closeFlyout()}

--- a/public/pages/Alerts/components/CorrelationAlertFlyout/CorrelationAlertFlyout.tsx
+++ b/public/pages/Alerts/components/CorrelationAlertFlyout/CorrelationAlertFlyout.tsx
@@ -7,7 +7,7 @@ import {
   EuiBadge,
     EuiBasicTable,
     EuiBasicTableColumn,
-    EuiButton,
+    EuiSmallButton,
     EuiButtonIcon,
     EuiFlexGroup,
     EuiFlexItem,
@@ -33,25 +33,25 @@ import {
   import { NotificationsStart } from 'opensearch-dashboards/public';
   import { DataStore } from '../../../../store/DataStore';
   import { CorrelationAlertTableItem, Finding, Query } from '../../../../../types';
-  
+
   export interface CorrelationAlertFlyoutProps {
     alertItem: CorrelationAlertTableItem;
     notifications: NotificationsStart;
     onClose: () => void;
     onAcknowledge: (selectedItems: CorrelationAlertTableItem[]) => void;
   }
-  
+
   export interface CorrelationAlertFlyoutState {
     acknowledged: boolean;
     findingItems: Finding[];
     loading: boolean;
     rules: { [key: string]: RuleSource };
   }
-  
+
   export class CorrelationAlertFlyout extends React.Component<CorrelationAlertFlyoutProps, CorrelationAlertFlyoutState> {
     constructor(props: CorrelationAlertFlyoutProps) {
       super(props);
-  
+
       this.state = {
         acknowledged: props.alertItem.state === ALERT_STATE.ACKNOWLEDGED,
         findingItems: [],
@@ -59,11 +59,11 @@ import {
         rules: {},
       };
     }
-  
+
     async componentDidMount() {
       this.getFindings();
     }
-  
+
     getFindings = async () => {
       this.setState({ loading: true });
       const { notifications } = this.props;
@@ -79,30 +79,30 @@ import {
       await this.getRules();
       this.setState({ loading: false });
     };
-  
+
     getRules = async () => {
       const { notifications } = this.props;
       try {
         const { findingItems } = this.state;
         const ruleIds: string[] = [];
-        
+
         // Extract ruleIds in order from findingItems
         findingItems.forEach((finding) => {
           finding.queries.forEach((query) => {
             ruleIds.push(query.id);
           });
         });
-    
+
         if (ruleIds.length > 0) {
           // Fetch rules based on ruleIds
           const rules = await DataStore.rules.getAllRules({ _id: ruleIds });
-    
+
           // Prepare allRules object with rules mapped by _id
           const allRules: { [id: string]: RuleSource } = {};
           rules.forEach((hit) => {
             allRules[hit._id] = hit._source;
           });
-    
+
           // Update state with allRules
           this.setState({ rules: allRules });
         }
@@ -110,8 +110,8 @@ import {
         // Handle errors if any
         errorNotificationToast(notifications, 'retrieve', 'rules', e);
       }
-    };    
-  
+    };
+
     createFindingTableColumns(): EuiBasicTableColumn<Finding>[] {
       const { rules } = this.state;
 
@@ -125,7 +125,7 @@ import {
           data-test-subj={'finding-details-flyout-back-button'}
         />
       );
-    
+
       return [
         {
           field: 'timestamp',
@@ -144,7 +144,7 @@ import {
               onClick={() => {
                 const ruleId = finding.queries[0]?.id; // Assuming you retrieve rule ID from finding
                 const rule: RuleSource | undefined = rules[ruleId];
-                
+
                 DataStore.findings.openFlyout(
                   {
                     ...finding,
@@ -185,13 +185,13 @@ import {
         },
       ];
     }
-    
-  
+
+
     render() {
       const { onClose, alertItem, onAcknowledge } = this.props;
       const { trigger_name, state, severity, start_time, end_time } = alertItem;
       const { acknowledged, findingItems, loading } = this.state;
-  
+
       return (
         <EuiFlyout
           onClose={onClose}
@@ -212,7 +212,7 @@ import {
               <EuiFlexItem grow={8}>
                 <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       disabled={acknowledged || alertItem.state !== ALERT_STATE.ACTIVE}
                       onClick={() => {
                         this.setState({ acknowledged: true });
@@ -221,7 +221,7 @@ import {
                       data-test-subj={'alert-details-flyout-acknowledge-button'}
                     >
                       Acknowledge
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiButtonIcon
@@ -256,9 +256,9 @@ import {
                 target: '_blank',
               },
             ])}
-  
+
             <EuiSpacer size={'xxl'} />
-  
+
             <ContentPanel title={`Findings (${findingItems.length})`}>
               <EuiBasicTable<Finding>
                 columns={this.createFindingTableColumns()}
@@ -271,4 +271,3 @@ import {
       );
     }
   }
-  

--- a/public/pages/Alerts/components/CorrelationAlertFlyout/CorrelationAlertFlyout.tsx
+++ b/public/pages/Alerts/components/CorrelationAlertFlyout/CorrelationAlertFlyout.tsx
@@ -8,7 +8,7 @@ import {
     EuiBasicTable,
     EuiBasicTableColumn,
     EuiSmallButton,
-    EuiButtonIcon,
+    EuiSmallButtonIcon,
     EuiFlexGroup,
     EuiFlexItem,
     EuiFlyout,
@@ -116,7 +116,7 @@ import {
       const { rules } = this.state;
 
       const backButton = (
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           iconType="arrowLeft"
           aria-label="back"
           onClick={() => DataStore.findings.closeFlyout()}
@@ -224,7 +224,7 @@ import {
                     </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
+                    <EuiSmallButtonIcon
                       aria-label="close"
                       iconType="cross"
                       iconSize="m"

--- a/public/pages/Alerts/components/CorrelationAlertFlyout/CorrelationAlertFlyout.tsx
+++ b/public/pages/Alerts/components/CorrelationAlertFlyout/CorrelationAlertFlyout.tsx
@@ -8,6 +8,7 @@ import {
     EuiBasicTable,
     EuiBasicTableColumn,
     EuiSmallButton,
+    EuiButtonIcon,
     EuiSmallButtonIcon,
     EuiFlexGroup,
     EuiFlexItem,
@@ -116,7 +117,7 @@ import {
       const { rules } = this.state;
 
       const backButton = (
-        <EuiSmallButtonIcon
+        <EuiButtonIcon
           iconType="arrowLeft"
           aria-label="back"
           onClick={() => DataStore.findings.closeFlyout()}

--- a/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
@@ -7,7 +7,7 @@ import {
   EuiBadge,
   EuiBasicTable,
   EuiBasicTableColumn,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -131,7 +131,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
             <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
               {showActionButton && (
                 <EuiFlexItem grow={false}>
-                  <EuiButton
+                  <EuiSmallButton
                     onClick={() => {
                       const nextState = alertState === 'ACTIVE' ? 'ACKNOWLEDGED' : 'COMPLETED';
                       onAlertStateChange([alertItem], nextState).then((success) => {
@@ -143,7 +143,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
                     data-test-subj={'alert-details-flyout-acknowledge-button'}
                   >
                     {alertState === 'ACTIVE' ? 'Acknowledge' : 'Complete'}
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
               )}
               <EuiFlexItem grow={false}>

--- a/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
@@ -8,7 +8,7 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -61,7 +61,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
 
   const createFindingTableColumns = (): EuiBasicTableColumn<ThreatIntelFinding>[] => {
     const backButton = (
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         iconType="arrowLeft"
         aria-label="back"
         onClick={() => DataStore.findings.closeFlyout()}
@@ -147,7 +147,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
                 </EuiFlexItem>
               )}
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label="close"
                   iconType="cross"
                   iconSize="m"

--- a/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
@@ -8,6 +8,7 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiSmallButton,
+  EuiButtonIcon,
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -61,7 +62,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
 
   const createFindingTableColumns = (): EuiBasicTableColumn<ThreatIntelFinding>[] => {
     const backButton = (
-      <EuiSmallButtonIcon
+      <EuiButtonIcon
         iconType="arrowLeft"
         aria-label="back"
         onClick={() => DataStore.findings.closeFlyout()}

--- a/public/pages/Alerts/components/ThreatIntelAlertsTable/ThreatIntelAlertsTable.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertsTable/ThreatIntelAlertsTable.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTableColumn,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiInMemoryTable,
   EuiTableSelectionType,
   EuiToolTip,
@@ -89,7 +89,7 @@ export const ThreatIntelAlertsTable: React.FC<ThreatIntelAlertsTableProps> = ({
 
             return alertItem.state === 'ACTIVE' || alertItem.state === 'ACKNOWLEDGED' ? (
               <EuiToolTip content={tooltipContent}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label={'Acknowledge'}
                   iconType={alertItem.state === 'ACTIVE' ? 'thumbsUp' : 'check'}
                   onClick={() =>
@@ -108,7 +108,7 @@ export const ThreatIntelAlertsTable: React.FC<ThreatIntelAlertsTableProps> = ({
         {
           render: (alertItem: ThreatIntelAlert) => (
             <EuiToolTip content={'View details'}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label={'View details'}
                 iconType={'expand'}
                 onClick={() => {

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -6,7 +6,7 @@
 import {
   EuiBasicTableColumn,
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiInMemoryTable,
@@ -395,7 +395,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
                     disableAcknowledge ? DISABLE_ACKNOWLEDGED_ALERT_HELP_TEXT : 'Acknowledge'
                   }
                 >
-                  <EuiButtonIcon
+                  <EuiSmallButtonIcon
                     aria-label={'Acknowledge'}
                     disabled={disableAcknowledge}
                     iconType={'check'}
@@ -408,7 +408,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           {
             render: (alertItem: AlertItem) => (
               <EuiToolTip content={'View details'}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label={'View details'}
                   iconType={'expand'}
                   onClick={() => this.setFlyout(alertItem)}
@@ -484,7 +484,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
                     disableAcknowledge ? DISABLE_ACKNOWLEDGED_ALERT_HELP_TEXT : 'Acknowledge'
                   }
                 >
-                  <EuiButtonIcon
+                  <EuiSmallButtonIcon
                     aria-label={'Acknowledge'}
                     disabled={disableAcknowledge}
                     iconType={'check'}
@@ -497,7 +497,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           {
             render: (alertItem: CorrelationAlertTableItem) => (
               <EuiToolTip content={'View details'}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label={'View details'}
                   iconType={'expand'}
                   onClick={() => this.setCorrelationFlyout(alertItem)}

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTableColumn,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -656,26 +656,26 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
   createAcknowledgeControl() {
     const { selectedDetectionRuleAlertItems } = this.state;
     return (
-      <EuiButton
+      <EuiSmallButton
         disabled={!selectedDetectionRuleAlertItems.length}
         onClick={() => this.onAcknowledge(selectedDetectionRuleAlertItems)}
         data-test-subj={'acknowledge-button'}
       >
         Acknowledge
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
   createAcknowledgeControlForCorrelations() {
     const { selectedCorrelationsAlertItems } = this.state;
     return (
-      <EuiButton
+      <EuiSmallButton
         disabled={!selectedCorrelationsAlertItems.length}
         onClick={() => this.onAcknowledgeCorrelationAlert(selectedCorrelationsAlertItems)}
         data-test-subj={'acknowledge-button'}
       >
         Acknowledge
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
@@ -692,7 +692,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
     return (
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             disabled={disableAcknowledge}
             onClick={() =>
               this.onThreatIntelAlertStateChange(selectedThreatIntelAlertItems, 'ACKNOWLEDGED')
@@ -700,10 +700,10 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
             data-test-subj={'acknowledge-button'}
           >
             Acknowledge
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             disabled={disableComplete}
             onClick={() =>
               this.onThreatIntelAlertStateChange(selectedThreatIntelAlertItems, 'COMPLETED')
@@ -711,7 +711,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
             data-test-subj={'complete-button'}
           >
             Complete
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -2058,6 +2058,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                               <FieldValueSelectionFilter
                                                 config={
                                                   Object {
+                                                    "compressed": undefined,
                                                     "field": "severity",
                                                     "multiSelect": "or",
                                                     "name": "Alert severity",
@@ -2187,6 +2188,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                               <FieldValueSelectionFilter
                                                 config={
                                                   Object {
+                                                    "compressed": undefined,
                                                     "field": "state",
                                                     "multiSelect": "or",
                                                     "name": "Status",

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -866,7 +866,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                               <div
                                 className="euiFlexItem euiFlexItem--flexGrowZero"
                               >
-                                <EuiSelect
+                                <EuiCompressedSelect
                                   id="alert-vis-groupBy"
                                   onChange={[Function]}
                                   options={
@@ -884,94 +884,114 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                   prepend="Group by"
                                   value="status"
                                 >
-                                  <EuiFormControlLayout
-                                    compressed={false}
-                                    fullWidth={false}
-                                    icon={
-                                      Object {
-                                        "side": "right",
-                                        "type": "arrowDown",
-                                      }
+                                  <EuiSelect
+                                    compressed={true}
+                                    id="alert-vis-groupBy"
+                                    onChange={[Function]}
+                                    options={
+                                      Array [
+                                        Object {
+                                          "text": "Alert status",
+                                          "value": "status",
+                                        },
+                                        Object {
+                                          "text": "Alert severity",
+                                          "value": "severity",
+                                        },
+                                      ]
                                     }
-                                    inputId="alert-vis-groupBy"
-                                    isLoading={false}
                                     prepend="Group by"
+                                    value="status"
                                   >
-                                    <div
-                                      className="euiFormControlLayout euiFormControlLayout--group"
+                                    <EuiFormControlLayout
+                                      compressed={true}
+                                      fullWidth={false}
+                                      icon={
+                                        Object {
+                                          "side": "right",
+                                          "type": "arrowDown",
+                                        }
+                                      }
+                                      inputId="alert-vis-groupBy"
+                                      isLoading={false}
+                                      prepend="Group by"
                                     >
-                                      <EuiFormLabel
-                                        className="euiFormControlLayout__prepend"
-                                        htmlFor="alert-vis-groupBy"
+                                      <div
+                                        className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group"
                                       >
-                                        <label
-                                          className="euiFormLabel euiFormControlLayout__prepend"
+                                        <EuiFormLabel
+                                          className="euiFormControlLayout__prepend"
                                           htmlFor="alert-vis-groupBy"
                                         >
-                                          Group by
-                                        </label>
-                                      </EuiFormLabel>
-                                      <div
-                                        className="euiFormControlLayout__childrenWrapper"
-                                      >
-                                        <EuiValidatableControl>
-                                          <select
-                                            className="euiSelect euiSelect--inGroup"
-                                            id="alert-vis-groupBy"
-                                            onChange={[Function]}
-                                            onMouseUp={[Function]}
-                                            value="status"
+                                          <label
+                                            className="euiFormLabel euiFormControlLayout__prepend"
+                                            htmlFor="alert-vis-groupBy"
                                           >
-                                            <option
-                                              key="0"
+                                            Group by
+                                          </label>
+                                        </EuiFormLabel>
+                                        <div
+                                          className="euiFormControlLayout__childrenWrapper"
+                                        >
+                                          <EuiValidatableControl>
+                                            <select
+                                              className="euiSelect euiSelect--compressed euiSelect--inGroup"
+                                              id="alert-vis-groupBy"
+                                              onChange={[Function]}
+                                              onMouseUp={[Function]}
                                               value="status"
                                             >
-                                              Alert status
-                                            </option>
-                                            <option
-                                              key="1"
-                                              value="severity"
-                                            >
-                                              Alert severity
-                                            </option>
-                                          </select>
-                                        </EuiValidatableControl>
-                                        <EuiFormControlLayoutIcons
-                                          compressed={false}
-                                          icon={
-                                            Object {
-                                              "side": "right",
-                                              "type": "arrowDown",
-                                            }
-                                          }
-                                          isLoading={false}
-                                        >
-                                          <div
-                                            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                          >
-                                            <EuiFormControlLayoutCustomIcon
-                                              size="m"
-                                              type="arrowDown"
-                                            >
-                                              <span
-                                                className="euiFormControlLayoutCustomIcon"
+                                              <option
+                                                key="0"
+                                                value="status"
                                               >
-                                                <EuiIcon
-                                                  aria-hidden="true"
-                                                  className="euiFormControlLayoutCustomIcon__icon"
-                                                  size="m"
-                                                  type="arrowDown"
+                                                Alert status
+                                              </option>
+                                              <option
+                                                key="1"
+                                                value="severity"
+                                              >
+                                                Alert severity
+                                              </option>
+                                            </select>
+                                          </EuiValidatableControl>
+                                          <EuiFormControlLayoutIcons
+                                            compressed={true}
+                                            icon={
+                                              Object {
+                                                "side": "right",
+                                                "type": "arrowDown",
+                                              }
+                                            }
+                                            isLoading={false}
+                                          >
+                                            <div
+                                              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                            >
+                                              <EuiFormControlLayoutCustomIcon
+                                                size="s"
+                                                type="arrowDown"
+                                              >
+                                                <span
+                                                  className="euiFormControlLayoutCustomIcon"
                                                 >
-                                                  EuiIconMock
-                                                </EuiIcon>
-                                              </span>
-                                            </EuiFormControlLayoutCustomIcon>
-                                          </div>
-                                        </EuiFormControlLayoutIcons>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiFormControlLayoutCustomIcon__icon"
+                                                    size="s"
+                                                    type="arrowDown"
+                                                  >
+                                                    EuiIconMock
+                                                  </EuiIcon>
+                                                </span>
+                                              </EuiFormControlLayoutCustomIcon>
+                                            </div>
+                                          </EuiFormControlLayoutIcons>
+                                        </div>
                                       </div>
-                                    </div>
-                                  </EuiFormControlLayout>
-                                </EuiSelect>
+                                    </EuiFormControlLayout>
+                                  </EuiSelect>
+                                </EuiCompressedSelect>
                               </div>
                             </EuiFlexItem>
                           </div>
@@ -1074,13 +1094,13 @@ exports[`<Alerts /> spec renders the component 1`] = `
             <ContentPanel
               actions={
                 Array [
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj="acknowledge-button"
                     disabled={true}
                     onClick={[Function]}
                   >
                     Acknowledge
-                  </EuiButton>,
+                  </EuiSmallButton>,
                 ]
               }
               title="Alerts"
@@ -1154,54 +1174,62 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                 <div
                                   className="euiFlexItem"
                                 >
-                                  <EuiButton
+                                  <EuiSmallButton
                                     data-test-subj="acknowledge-button"
                                     disabled={true}
                                     onClick={[Function]}
                                   >
-                                    <EuiButtonDisplay
-                                      baseClassName="euiButton"
+                                    <EuiButton
                                       data-test-subj="acknowledge-button"
                                       disabled={true}
-                                      element="button"
-                                      isDisabled={true}
                                       onClick={[Function]}
-                                      type="button"
+                                      size="s"
                                     >
-                                      <button
-                                        className="euiButton euiButton--primary euiButton-isDisabled"
+                                      <EuiButtonDisplay
+                                        baseClassName="euiButton"
                                         data-test-subj="acknowledge-button"
                                         disabled={true}
+                                        element="button"
+                                        isDisabled={true}
                                         onClick={[Function]}
-                                        style={
-                                          Object {
-                                            "minWidth": undefined,
-                                          }
-                                        }
+                                        size="s"
                                         type="button"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButton__content"
-                                          iconSide="left"
-                                          textProps={
+                                        <button
+                                          className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
+                                          data-test-subj="acknowledge-button"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          style={
                                             Object {
-                                              "className": "euiButton__text",
+                                              "minWidth": undefined,
                                             }
                                           }
+                                          type="button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButton__content"
+                                          <EuiButtonContent
+                                            className="euiButton__content"
+                                            iconSide="left"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButton__text",
+                                              }
+                                            }
                                           >
                                             <span
-                                              className="euiButton__text"
+                                              className="euiButtonContent euiButton__content"
                                             >
-                                              Acknowledge
+                                              <span
+                                                className="euiButton__text"
+                                              >
+                                                Acknowledge
+                                              </span>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonDisplay>
-                                  </EuiButton>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonDisplay>
+                                    </EuiButton>
+                                  </EuiSmallButton>
                                 </div>
                               </EuiFlexItem>
                             </div>

--- a/public/pages/Correlations/components/FilterGroup.tsx
+++ b/public/pages/Correlations/components/FilterGroup.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import {
-  EuiFilterButton,
+  EuiSmallFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
   EuiPopover,
@@ -161,7 +161,7 @@ export const FilterGroup: React.FC<LogTypeFilterGroupProps> = ({
   const numActiveFilters = items.filter((item) => !item.childOptionIds && item.checked === 'on')
     .length;
   const button = (
-    <EuiFilterButton
+    <EuiSmallFilterButton
       iconType="arrowDown"
       onClick={onButtonClick}
       isSelected={isPopoverOpen}
@@ -169,7 +169,7 @@ export const FilterGroup: React.FC<LogTypeFilterGroupProps> = ({
       numActiveFilters={numActiveFilters > 0 ? numActiveFilters : undefined}
     >
       {groupName}
-    </EuiFilterButton>
+    </EuiSmallFilterButton>
   );
 
   return (

--- a/public/pages/Correlations/components/FindingCard.tsx
+++ b/public/pages/Correlations/components/FindingCard.tsx
@@ -8,7 +8,7 @@ import {
   EuiPanel,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiSpacer,
   EuiBadge,
   EuiHorizontalRule,
@@ -74,7 +74,7 @@ export const FindingCard: React.FC<FindingCardProps> = ({
   );
   const openFindingFlyoutButton = (
     <EuiToolTip content={'View finding details'}>
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         aria-label={'View finding details'}
         data-test-subj={`view-details-icon`}
         iconType={'inspect'}
@@ -111,7 +111,7 @@ export const FindingCard: React.FC<FindingCardProps> = ({
           <EuiText size="s">
             Correlation score{' '}
             <EuiToolTip
-              content={`The score (0-1) is based on the proximity of relevant findings in the threat scenario defined by the 
+              content={`The score (0-1) is based on the proximity of relevant findings in the threat scenario defined by the
             correlation rule. The greater the score, the stronger the correlation.`}
             >
               <EuiIcon type={'iInCircle'} color="primary" />
@@ -126,7 +126,7 @@ export const FindingCard: React.FC<FindingCardProps> = ({
         <EuiFlexItem grow={false}>
           <div>
             {openFindingFlyoutButton}
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               iconType={'pin'}
               onClick={() => correlationData?.onInspect(id, logType)}
             />

--- a/public/pages/Correlations/containers/CorrelationRules.tsx
+++ b/public/pages/Correlations/containers/CorrelationRules.tsx
@@ -10,7 +10,7 @@ import {
   EuiSpacer,
   EuiTitle,
   EuiPanel,
-  EuiButton,
+  EuiSmallButton,
   EuiInMemoryTable,
   EuiEmptyPrompt,
 } from '@elastic/eui';
@@ -55,13 +55,13 @@ export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: Correla
 
   const createRuleAction = useMemo(
     () => (
-      <EuiButton
+      <EuiSmallButton
         href={`${PLUGIN_NAME}#${ROUTES.CORRELATION_RULE_CREATE}`}
         data-test-subj={'create_rule_button'}
         fill={true}
       >
         Create correlation rule
-      </EuiButton>
+      </EuiSmallButton>
     ),
     []
   );
@@ -145,13 +145,13 @@ export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: Correla
                   </p>
                 }
                 actions={[
-                  <EuiButton
+                  <EuiSmallButton
                     fill={true}
                     color="primary"
                     href={`#${ROUTES.CORRELATION_RULE_CREATE}`}
                   >
                     Create correlation rule
-                  </EuiButton>,
+                  </EuiSmallButton>,
                 ]}
               />
             )}

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -32,7 +32,7 @@ import {
   EuiFlyout,
   EuiFlyoutHeader,
   EuiFlyoutBody,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiText,
   EuiEmptyPrompt,
   EuiSmallButton,
@@ -496,7 +496,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
                   </EuiTitle>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonIcon
+                  <EuiSmallButtonIcon
                     aria-label="close"
                     iconType="cross"
                     display="empty"

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -28,7 +28,7 @@ import {
   EuiPanel,
   EuiSuperDatePicker,
   EuiSpacer,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlyout,
   EuiFlyoutHeader,
   EuiFlyoutBody,
@@ -587,7 +587,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
                   </EuiFilterGroup>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty onClick={this.resetFilters}>Reset filters</EuiButtonEmpty>
+                  <EuiSmallButtonEmpty onClick={this.resetFilters}>Reset filters</EuiSmallButtonEmpty>
                 </EuiFlexItem>
               </EuiFlexGroup>
               <EuiSpacer />

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -35,7 +35,7 @@ import {
   EuiButtonIcon,
   EuiText,
   EuiEmptyPrompt,
-  EuiButton,
+  EuiSmallButton,
   EuiBadge,
   EuiFilterGroup,
   EuiHorizontalRule,
@@ -456,9 +456,9 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
         }
         body={<p>There are no correlated findings in the system.</p>}
         actions={[
-          <EuiButton fill={true} color="primary" href={`#${ROUTES.CORRELATION_RULE_CREATE}`}>
+          <EuiSmallButton fill={true} color="primary" href={`#${ROUTES.CORRELATION_RULE_CREATE}`}>
             Create correlation rule
-          </EuiButton>,
+          </EuiSmallButton>,
         ]}
       />
     );

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -31,7 +31,7 @@ import {
   EuiCheckableCard,
   htmlIdGenerator,
   EuiComboBoxOptionOption,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiTextArea,
 } from '@elastic/eui';
 import { ruleTypes } from '../../Rules/utils/constants';
@@ -1082,7 +1082,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                     </EuiFlexGroup>
                     <EuiSpacer size={'l'} />
 
-                    <EuiSwitch
+                    <EuiCompressedSwitch
                       label="Send notification"
                       checked={showNotificationDetails}
                       onChange={(e) => {

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -32,7 +32,7 @@ import {
   htmlIdGenerator,
   EuiComboBoxOptionOption,
   EuiCompressedSwitch,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import { ruleTypes } from '../../Rules/utils/constants';
 import {
@@ -1207,7 +1207,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                 }
                                 fullWidth={true}
                               >
-                                <EuiTextArea
+                                <EuiCompressedTextArea
                                   placeholder={'Enter the content of the notification message.'}
                                   onChange={(e) => {
                                     const messsageBody = e.target.value || '';

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -17,7 +17,7 @@ import {
   EuiCompressedFormRow,
   EuiText,
   EuiComboBox,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSpacer,
   EuiTitle,
   EuiPanel,
@@ -27,7 +27,7 @@ import {
   EuiButtonGroup,
   EuiSelect,
   EuiSelectOption,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiCheckableCard,
   htmlIdGenerator,
   EuiComboBoxOptionOption,
@@ -676,7 +676,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         );
 
                         const fieldValueInput = (
-                          <EuiFieldText
+                          <EuiCompressedFieldText
                             placeholder="Enter field value"
                             data-test-subj={'rule_name_field'}
                             onChange={(e) => {
@@ -922,7 +922,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                     'Rule name must contain 5-50 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores.'
                   }
                 >
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     isInvalid={touched.name && !!errors.name}
                     placeholder="Enter rule name"
                     data-test-subj={'rule_name_field'}
@@ -953,7 +953,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                 >
                   <EuiFlexGroup gutterSize="none">
                     <EuiFlexItem>
-                      <EuiFieldNumber
+                      <EuiCompressedFieldNumber
                         isInvalid={!!errors.time_window}
                         min={1}
                         max={period.unit === 'HOURS' ? 24 : 1440}
@@ -1030,7 +1030,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             </EuiText>
                           }
                         >
-                          <EuiFieldText
+                          <EuiCompressedFieldText
                             placeholder="Trigger 1"
                             onChange={(e) => {
                               const triggerName = e.target.value || 'Trigger 1';
@@ -1182,7 +1182,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                 }
                                 fullWidth={true}
                               >
-                                <EuiFieldText
+                                <EuiCompressedFieldText
                                   placeholder={'Enter a subject for the notification message.'}
                                   onChange={(e) => {
                                     const subjectBody = e.target.value || '';

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -25,7 +25,7 @@ import {
   EuiSmallButtonIcon,
   EuiToolTip,
   EuiButtonGroup,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
   EuiCompressedFieldNumber,
   EuiCheckableCard,
@@ -971,7 +971,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       />
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <EuiSelect
+                      <EuiCompressedSelect
                         options={unitOptions}
                         onChange={(e) => {
                           const newUnit = e.target.value;

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -11,7 +11,7 @@ import { correlationRuleStateDefaultValue } from './CorrelationRuleFormModel';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
@@ -754,7 +754,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                           </>
                         );
                       })}
-                      <EuiButton
+                      <EuiSmallButton
                         style={{ width: 125 }}
                         onClick={() => {
                           props.setFieldValue(`queries[${queryIdx}].conditions`, [
@@ -765,7 +765,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         iconType={'plusInCircle'}
                       >
                         Add field
-                      </EuiButton>
+                      </EuiSmallButton>
                     </>
                   )}
 
@@ -813,7 +813,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
           );
         })}
         <EuiSpacer />
-        <EuiButton
+        <EuiSmallButton
           onClick={() => {
             props.setFieldValue('queries', [
               ...correlationQueries,
@@ -824,7 +824,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
           fullWidth={true}
         >
           Add query
-        </EuiButton>
+        </EuiSmallButton>
       </>
     );
   };
@@ -1012,9 +1012,9 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                 <EuiFormRow>
                   <EuiFlexGroup>
                     <EuiFlexItem grow={false}>
-                      <EuiButton onClick={() => setShowForm(!showForm)}>
+                      <EuiSmallButton onClick={() => setShowForm(!showForm)}>
                         Add Alert Trigger
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFormRow>
@@ -1142,14 +1142,14 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             </EuiFormRow>
                           </EuiFlexItem>
                           <EuiFlexItem grow={false}>
-                            <EuiButton
+                            <EuiSmallButton
                               href={NOTIFICATIONS_HREF}
                               iconType={'popout'}
                               target={'_blank'}
                               isDisabled={!hasNotificationPlugin}
                             >
                               Manage channels
-                            </EuiButton>
+                            </EuiSmallButton>
                           </EuiFlexItem>
                         </EuiFlexGroup>
 
@@ -1236,17 +1236,17 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                   <EuiSpacer size="xl" />
                   <EuiFlexGroup justifyContent="flexEnd">
                     <EuiFlexItem grow={false}>
-                      <EuiButton href={`#${ROUTES.CORRELATION_RULES}`}>Cancel</EuiButton>
+                      <EuiSmallButton href={`#${ROUTES.CORRELATION_RULES}`}>Cancel</EuiSmallButton>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
-                      <EuiButton
+                      <EuiSmallButton
                         onClick={() => {
                           props.handleSubmit();
                         }}
                         fill={true}
                       >
                         {action === 'Edit' ? 'Update' : 'Create '} correlation rule
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </>

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiText,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFieldText,
   EuiSpacer,
   EuiTitle,
@@ -565,7 +565,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         ?.index
                     }
                   >
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       isInvalid={isInvalidInputForQuery('index')}
                       placeholder="Select index or index pattern"
                       data-test-subj={'index_dropdown'}
@@ -599,7 +599,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         ?.logType
                     }
                   >
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       isInvalid={isInvalidInputForQuery('logType')}
                       placeholder="Select a log type"
                       data-test-subj={'rule_type_dropdown'}
@@ -648,7 +648,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       <EuiSpacer size="xs" />
                       {query.conditions.map((condition, conditionIdx) => {
                         const fieldNameInput = (
-                          <EuiComboBox
+                          <EuiCompressedComboBox
                             placeholder="Select a field"
                             data-test-subj={'field_dropdown'}
                             options={fieldOptions}
@@ -784,7 +784,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             ?.field
                         }
                       >
-                        <EuiComboBox
+                        <EuiCompressedComboBox
                           placeholder="Select a field"
                           data-test-subj={'field_dropdown'}
                           options={fieldOptions}
@@ -1050,7 +1050,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             </EuiText>
                           }
                         >
-                          <EuiComboBox
+                          <EuiCompressedComboBox
                             placeholder="Alert Severity"
                             options={ruleSeverityComboBoxOptions}
                             singleSelection={{ asPlainText: true }}
@@ -1102,7 +1102,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                 </EuiText>
                               }
                             >
-                              <EuiComboBox
+                              <EuiCompressedComboBox
                                 placeholder={'Select notification channel.'}
                                 async={true}
                                 isLoading={!!loadingNotifications}

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -14,7 +14,7 @@ import {
   EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiText,
   EuiComboBox,
   EuiFieldText,
@@ -557,7 +557,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                     <h3>Data source</h3>
                   </EuiTitle>
                   <EuiSpacer size="m" />
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={<EuiText size={'s'}>Select index</EuiText>}
                     isInvalid={isInvalidInputForQuery('index')}
                     error={
@@ -589,9 +589,9 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       }
                       isClearable={true}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                   <EuiSpacer size="m" />
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={<EuiText size={'s'}>Log type</EuiText>}
                     isInvalid={isInvalidInputForQuery('logType')}
                     error={
@@ -630,7 +630,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         props.handleChange(`queries[${queryIdx}].logType`)(e);
                       }}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                   {!dataFilterEnabled && !groupByEnabled && (
                     <>
                       <EuiSpacer />
@@ -709,17 +709,17 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         const firstFieldRow = (
                           <EuiFlexGroup alignItems="center">
                             <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
-                              <EuiFormRow label={<EuiText size={'s'}>Field</EuiText>}>
+                              <EuiCompressedFormRow label={<EuiText size={'s'}>Field</EuiText>}>
                                 {fieldNameInput}
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                             </EuiFlexItem>
                             <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
-                              <EuiFormRow label={<EuiText size={'s'}>Field value</EuiText>}>
+                              <EuiCompressedFormRow label={<EuiText size={'s'}>Field value</EuiText>}>
                                 {fieldValueInput}
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                             </EuiFlexItem>
                             <EuiFlexItem>
-                              <EuiFormRow label={<p style={{ visibility: 'hidden' }}>_</p>}>
+                              <EuiCompressedFormRow label={<p style={{ visibility: 'hidden' }}>_</p>}>
                                 <EuiSmallButtonIcon
                                   iconType={'trash'}
                                   color="danger"
@@ -732,7 +732,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                     );
                                   }}
                                 />
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         );
@@ -776,7 +776,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         <h3>Group by field</h3>
                       </EuiTitle>
                       <EuiSpacer size="s" />
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         label={<EuiText size={'s'}>Field</EuiText>}
                         isInvalid={isInvalidInputForQuery('field')}
                         error={
@@ -803,7 +803,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                           }}
                           isClearable={true}
                         />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </>
                   )}
                 </EuiAccordion>
@@ -910,7 +910,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                 title={'Correlation rule details'}
                 panelStyles={{ paddingLeft: 10, paddingRight: 10 }}
               >
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label={
                     <EuiText size={'s'}>
                       <strong>Name</strong>
@@ -932,9 +932,9 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                     onBlur={props.handleBlur('name')}
                     value={name}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 <EuiSpacer />
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label={
                     <>
                       <EuiText size={'s'}>
@@ -985,7 +985,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       />
                     </EuiFlexItem>
                   </EuiFlexGroup>
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </ContentPanel>
               <EuiSpacer size="l" />
               <ContentPanel
@@ -1009,7 +1009,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                   <p>Get an alert on the correlation between the findings.</p>
                 </EuiText>
                 <EuiSpacer size="m" />
-                <EuiFormRow>
+                <EuiCompressedFormRow>
                   <EuiFlexGroup>
                     <EuiFlexItem grow={false}>
                       <EuiSmallButton onClick={() => setShowForm(!showForm)}>
@@ -1017,13 +1017,13 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       </EuiSmallButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 {showForm && (
                   <>
                     <EuiSpacer size="m" />
                     <EuiFlexGroup alignItems="center">
                       <EuiFlexItem grow={false}>
-                        <EuiFormRow
+                        <EuiCompressedFormRow
                           label={
                             <EuiText size="s">
                               <p>Trigger Name</p>
@@ -1040,10 +1040,10 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             required={true}
                             data-test-subj="alert-condition-name"
                           />
-                        </EuiFormRow>
+                        </EuiCompressedFormRow>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiFormRow
+                        <EuiCompressedFormRow
                           label={
                             <EuiText size="s">
                               <p>Alert Severity</p>
@@ -1066,10 +1066,10 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             isClearable={true}
                             data-test-subj="alert-severity-combo-box"
                           />
-                        </EuiFormRow>
+                        </EuiCompressedFormRow>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiFormRow label={<p style={{ visibility: 'hidden' }}>_</p>}>
+                        <EuiCompressedFormRow label={<p style={{ visibility: 'hidden' }}>_</p>}>
                           <EuiSmallButtonIcon
                             aria-label="Delete Alert Trigger"
                             data-test-subj="delete-alert-trigger-icon"
@@ -1077,7 +1077,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             color="danger"
                             onClick={() => setShowForm(false)}
                           />
-                        </EuiFormRow>
+                        </EuiCompressedFormRow>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiSpacer size={'l'} />
@@ -1095,7 +1095,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       <>
                         <EuiFlexGroup alignItems={'flexEnd'}>
                           <EuiFlexItem style={{ maxWidth: 400 }}>
-                            <EuiFormRow
+                            <EuiCompressedFormRow
                               label={
                                 <EuiText size="m">
                                   <p>Notification channel</p>
@@ -1139,7 +1139,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                 singleSelection={{ asPlainText: true }}
                                 isDisabled={!hasNotificationPlugin}
                               />
-                            </EuiFormRow>
+                            </EuiCompressedFormRow>
                           </EuiFlexItem>
                           <EuiFlexItem grow={false}>
                             <EuiSmallButton
@@ -1174,7 +1174,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                         >
                           <EuiFlexGroup direction={'column'} style={{ width: '75%' }}>
                             <EuiFlexItem>
-                              <EuiFormRow
+                              <EuiCompressedFormRow
                                 label={
                                   <EuiText size={'s'}>
                                     <p>Message subject</p>
@@ -1195,11 +1195,11 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                   required={true}
                                   fullWidth={true}
                                 />
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                             </EuiFlexItem>
 
                             <EuiFlexItem>
-                              <EuiFormRow
+                              <EuiCompressedFormRow
                                 label={
                                   <EuiText size="s">
                                     <p>Message body</p>
@@ -1220,7 +1220,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                                   required={true}
                                   fullWidth={true}
                                 />
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiAccordion>

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -22,7 +22,7 @@ import {
   EuiTitle,
   EuiPanel,
   EuiAccordion,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiToolTip,
   EuiButtonGroup,
   EuiSelect,
@@ -538,7 +538,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                   extraAction={
                     correlationQueries.length > 2 ? (
                       <EuiToolTip title={'Delete query'}>
-                        <EuiButtonIcon
+                        <EuiSmallButtonIcon
                           iconType={'trash'}
                           color="danger"
                           onClick={() => {
@@ -720,7 +720,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                             </EuiFlexItem>
                             <EuiFlexItem>
                               <EuiFormRow label={<p style={{ visibility: 'hidden' }}>_</p>}>
-                                <EuiButtonIcon
+                                <EuiSmallButtonIcon
                                   iconType={'trash'}
                                   color="danger"
                                   onClick={() => {
@@ -1070,7 +1070,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiFormRow label={<p style={{ visibility: 'hidden' }}>_</p>}>
-                          <EuiButtonIcon
+                          <EuiSmallButtonIcon
                             aria-label="Delete Alert Trigger"
                             data-test-subj="delete-alert-trigger-icon"
                             iconType="trash"

--- a/public/pages/Correlations/utils/helpers.tsx
+++ b/public/pages/Correlations/utils/helpers.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiBasicTableColumn, EuiBadge, EuiToolTip, EuiButtonIcon, EuiLink } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiBadge, EuiToolTip, EuiSmallButtonIcon, EuiLink } from '@elastic/eui';
 import { CorrelationRule, CorrelationRuleQuery, CorrelationRuleTableItem } from '../../../../types';
 import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
 import { formatRuleType, getLogTypeFilterOptions } from '../../../utils/helpers';
@@ -55,7 +55,7 @@ export const getCorrelationRulesTableColumns = (
         {
           render: (ruleItem: CorrelationRule) => (
             <EuiToolTip content={'Delete'}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label={'Delete correlation rule'}
                 data-test-subj={`view-details-icon`}
                 iconType={'trash'}

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -11,7 +11,7 @@ import {
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFieldText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -339,7 +339,7 @@ export default class AlertConditionPanel extends Component<
 
     return (
       <div>
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={
             <EuiText size="s">
               <p>Trigger name</p>
@@ -357,7 +357,7 @@ export default class AlertConditionPanel extends Component<
             required={nameFieldTouched}
             data-test-subj={`alert-condition-name-${indexNum}`}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size={'l'} />
 
         <EuiTitle size="s">
@@ -397,7 +397,7 @@ export default class AlertConditionPanel extends Component<
                 </div>
               }
             >
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={
                   <EuiText size="s">
                     <p>Rule names</p>
@@ -411,10 +411,10 @@ export default class AlertConditionPanel extends Component<
                   selectedOptions={selectedNames}
                   data-test-subj={`alert-rulename-combo-box`}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer size={'m'} />
 
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={
                   <EuiText size="s">
                     <p>Rule Severities</p>
@@ -429,10 +429,10 @@ export default class AlertConditionPanel extends Component<
                   selectedOptions={createSelectedOptions(ruleSeverityLevels)}
                   data-test-subj={`alert-severity-combo-box`}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer size={'m'} />
 
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={
                   <EuiText size="s">
                     <p>Tags</p>
@@ -447,7 +447,7 @@ export default class AlertConditionPanel extends Component<
                   selectedOptions={createSelectedOptions(tags)}
                   data-test-subj={'alert-tags-combo-box'}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiAccordion>
 
             <EuiSpacer size="m" />
@@ -494,7 +494,7 @@ export default class AlertConditionPanel extends Component<
 
         <EuiSpacer size="s" />
 
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={
             <EuiText size="s">
               <p>Alert severity</p>
@@ -513,7 +513,7 @@ export default class AlertConditionPanel extends Component<
             isClearable={false}
             data-test-subj={'security-levels-combo-box'}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
         <EuiSpacer size={'l'} />
 

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -10,7 +10,7 @@ import {
   EuiCheckbox,
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
@@ -348,7 +348,7 @@ export default class AlertConditionPanel extends Component<
           isInvalid={nameFieldTouched && nameIsInvalid}
           error={getNameErrorMessage(name, nameIsInvalid, nameFieldTouched)}
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder={'Enter a name to describe the alert condition'}
             readOnly={false}
             value={name}

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -7,7 +7,7 @@ import React, { ChangeEvent, Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
   EuiAccordion,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
@@ -365,7 +365,7 @@ export default class AlertConditionPanel extends Component<
         </EuiTitle>
 
         {threatIntelEnabledInDetector ? (
-          <EuiCheckbox
+          <EuiCompressedCheckbox
             id="detection-type-rules"
             label="Detection rules"
             checked={detectionRulesTriggerEnabled}
@@ -456,7 +456,7 @@ export default class AlertConditionPanel extends Component<
 
         {threatIntelEnabledInDetector && (
           <>
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id="detection-type-threat-intel"
               label="Threat intelligence"
               checked={threatIntelTriggerEnabled}

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -8,7 +8,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import {
   EuiAccordion,
   EuiCompressedCheckbox,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
   EuiCompressedFormRow,
@@ -404,7 +404,7 @@ export default class AlertConditionPanel extends Component<
                   </EuiText>
                 }
               >
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder={'Any rules'}
                   options={namesOptions}
                   onChange={this.onRuleNamesChange}
@@ -421,7 +421,7 @@ export default class AlertConditionPanel extends Component<
                   </EuiText>
                 }
               >
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder={'Any severities'}
                   options={ruleSeverityOptions}
                   onChange={this.onRuleSeverityChange}
@@ -439,7 +439,7 @@ export default class AlertConditionPanel extends Component<
                   </EuiText>
                 }
               >
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder={'Any tags'}
                   options={tagsOptions}
                   onChange={this.onTagsChange}
@@ -501,7 +501,7 @@ export default class AlertConditionPanel extends Component<
             </EuiText>
           }
         >
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder={'Select applicable severity levels.'}
             async={true}
             options={Object.values(ALERT_SEVERITY_OPTIONS)}

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -31,13 +31,13 @@ Object {
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   data-test-subj="alert-condition-name-0"
                   id="some_html_id"
                   placeholder="Enter a name to describe the alert condition"
@@ -124,7 +124,7 @@ Object {
                 class="euiAccordion__padding--l"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -149,18 +149,18 @@ Object {
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      class="euiComboBox"
+                      class="euiComboBox euiComboBox--compressed"
                       data-test-subj="alert-rulename-combo-box"
                       role="combobox"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             tabindex="-1"
                           >
@@ -207,7 +207,7 @@ Object {
                   class="euiSpacer euiSpacer--m"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -232,18 +232,18 @@ Object {
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      class="euiComboBox"
+                      class="euiComboBox euiComboBox--compressed"
                       data-test-subj="alert-severity-combo-box"
                       role="combobox"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             tabindex="-1"
                           >
@@ -292,7 +292,7 @@ Object {
                           >
                             <button
                               aria-label="Clear input"
-                              class="euiFormControlLayoutClearButton"
+                              class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                               data-test-subj="comboBoxClearButton"
                               type="button"
                             >
@@ -316,7 +316,7 @@ Object {
                   class="euiSpacer euiSpacer--m"
                 />
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -341,18 +341,18 @@ Object {
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      class="euiComboBox"
+                      class="euiComboBox euiComboBox--compressed"
                       data-test-subj="alert-tags-combo-box"
                       role="combobox"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             tabindex="-1"
                           >
@@ -401,7 +401,7 @@ Object {
                           >
                             <button
                               aria-label="Clear input"
-                              class="euiFormControlLayoutClearButton"
+                              class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                               data-test-subj="comboBoxClearButton"
                               type="button"
                             >
@@ -435,7 +435,7 @@ Object {
           class="euiSpacer euiSpacer--s"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div
@@ -460,18 +460,18 @@ Object {
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="euiComboBox"
+              class="euiComboBox euiComboBox--compressed"
               data-test-subj="security-levels-combo-box"
               role="combobox"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                     data-test-subj="comboBoxInput"
                     tabindex="-1"
                   >
@@ -521,7 +521,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiSwitch euiSwitch--primary"
+          class="euiSwitch euiSwitch--primary euiSwitch--compressed"
         >
           <button
             aria-checked="true"
@@ -539,10 +539,7 @@ Object {
               />
               <span
                 class="euiSwitch__track"
-              >
-                EuiIconMock
-                EuiIconMock
-              </span>
+              />
             </span>
           </button>
           <span
@@ -563,7 +560,7 @@ Object {
             style="max-width: 400px;"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -588,17 +585,17 @@ Object {
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox euiComboBox-isDisabled"
+                  class="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -648,7 +645,7 @@ Object {
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
               disabled=""
               type="button"
             >
@@ -758,7 +755,7 @@ Object {
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormRow euiFormRow--fullWidth"
+                      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
@@ -781,13 +778,13 @@ Object {
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
-                              class="euiFieldText euiFieldText--fullWidth"
+                              class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                               id="some_html_id"
                               placeholder="Enter a subject for the notification message."
                               required=""
@@ -803,7 +800,7 @@ Object {
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormRow euiFormRow--fullWidth"
+                      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
@@ -826,11 +823,11 @@ Object {
                         class="euiFormRow__fieldWrapper"
                       >
                         <textarea
-                          class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth"
+                          class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth euiTextArea--compressed"
                           id="some_html_id"
                           placeholder="Enter the content of the notification message."
                           required=""
-                          rows="6"
+                          rows="3"
                         >
                           some_source
                         </textarea>
@@ -841,14 +838,14 @@ Object {
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
                         class="euiFormRow__fieldWrapper"
                       >
                         <button
-                          class="euiButton euiButton--primary"
+                          class="euiButton euiButton--primary euiButton--small"
                           id="some_html_id"
                           type="button"
                         >
@@ -879,7 +876,7 @@ Object {
   "container": <div>
     <div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -903,13 +900,13 @@ Object {
           class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
-                class="euiFieldText"
+                class="euiFieldText euiFieldText--compressed"
                 data-test-subj="alert-condition-name-0"
                 id="some_html_id"
                 placeholder="Enter a name to describe the alert condition"
@@ -996,7 +993,7 @@ Object {
               class="euiAccordion__padding--l"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -1021,18 +1018,18 @@ Object {
                   <div
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    class="euiComboBox"
+                    class="euiComboBox euiComboBox--compressed"
                     data-test-subj="alert-rulename-combo-box"
                     role="combobox"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <div
-                          class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                          class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                           data-test-subj="comboBoxInput"
                           tabindex="-1"
                         >
@@ -1079,7 +1076,7 @@ Object {
                 class="euiSpacer euiSpacer--m"
               />
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -1104,18 +1101,18 @@ Object {
                   <div
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    class="euiComboBox"
+                    class="euiComboBox euiComboBox--compressed"
                     data-test-subj="alert-severity-combo-box"
                     role="combobox"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <div
-                          class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                          class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                           data-test-subj="comboBoxInput"
                           tabindex="-1"
                         >
@@ -1164,7 +1161,7 @@ Object {
                         >
                           <button
                             aria-label="Clear input"
-                            class="euiFormControlLayoutClearButton"
+                            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                             data-test-subj="comboBoxClearButton"
                             type="button"
                           >
@@ -1188,7 +1185,7 @@ Object {
                 class="euiSpacer euiSpacer--m"
               />
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -1213,18 +1210,18 @@ Object {
                   <div
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    class="euiComboBox"
+                    class="euiComboBox euiComboBox--compressed"
                     data-test-subj="alert-tags-combo-box"
                     role="combobox"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <div
-                          class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                          class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                           data-test-subj="comboBoxInput"
                           tabindex="-1"
                         >
@@ -1273,7 +1270,7 @@ Object {
                         >
                           <button
                             aria-label="Clear input"
-                            class="euiFormControlLayoutClearButton"
+                            class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                             data-test-subj="comboBoxClearButton"
                             type="button"
                           >
@@ -1307,7 +1304,7 @@ Object {
         class="euiSpacer euiSpacer--s"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -1332,18 +1329,18 @@ Object {
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             data-test-subj="security-levels-combo-box"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -1393,7 +1390,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiSwitch euiSwitch--primary"
+        class="euiSwitch euiSwitch--primary euiSwitch--compressed"
       >
         <button
           aria-checked="true"
@@ -1411,10 +1408,7 @@ Object {
             />
             <span
               class="euiSwitch__track"
-            >
-              EuiIconMock
-              EuiIconMock
-            </span>
+            />
           </span>
         </button>
         <span
@@ -1435,7 +1429,7 @@ Object {
           style="max-width: 400px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -1460,17 +1454,17 @@ Object {
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox euiComboBox-isDisabled"
+                class="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -1520,7 +1514,7 @@ Object {
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <button
-            class="euiButton euiButton--primary euiButton-isDisabled"
+            class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
             disabled=""
             type="button"
           >
@@ -1630,7 +1624,7 @@ Object {
                   class="euiFlexItem"
                 >
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -1653,13 +1647,13 @@ Object {
                       class="euiFormRow__fieldWrapper"
                     >
                       <div
-                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <input
-                            class="euiFieldText euiFieldText--fullWidth"
+                            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
                             id="some_html_id"
                             placeholder="Enter a subject for the notification message."
                             required=""
@@ -1675,7 +1669,7 @@ Object {
                   class="euiFlexItem"
                 >
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -1698,11 +1692,11 @@ Object {
                       class="euiFormRow__fieldWrapper"
                     >
                       <textarea
-                        class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth"
+                        class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth euiTextArea--compressed"
                         id="some_html_id"
                         placeholder="Enter the content of the notification message."
                         required=""
-                        rows="6"
+                        rows="3"
                       >
                         some_source
                       </textarea>
@@ -1713,14 +1707,14 @@ Object {
                   class="euiFlexItem"
                 >
                   <div
-                    class="euiFormRow"
+                    class="euiFormRow euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
                       class="euiFormRow__fieldWrapper"
                     >
                       <button
-                        class="euiButton euiButton--primary"
+                        class="euiButton euiButton--primary euiButton--small"
                         id="some_html_id"
                         type="button"
                       >

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
   EuiAccordion,
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiPanel,
   EuiSpacer,
@@ -207,9 +207,9 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
                 paddingSize={'none'}
                 initialIsOpen={true}
                 extraAction={
-                  <EuiButton color="danger" onClick={() => this.onDelete(index)}>
+                  <EuiSmallButton color="danger" onClick={() => this.onDelete(index)}>
                     Remove
-                  </EuiButton>
+                  </EuiSmallButton>
                 }
               >
                 <EuiSpacer size={'m'} />
@@ -244,9 +244,9 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
 
         <EuiSpacer size={'m'} />
 
-        <EuiButton disabled={triggers.length >= MAX_ALERT_CONDITIONS} onClick={this.addCondition}>
+        <EuiSmallButton disabled={triggers.length >= MAX_ALERT_CONDITIONS} onClick={this.addCondition}>
           {triggers.length > 0 ? 'Add another alert trigger' : 'Add alert triggers'}
-        </EuiButton>
+        </EuiSmallButton>
       </>
     );
 

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldNameSelector.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldNameSelector.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow } from '@elastic/eui';
+import { EuiComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow } from '@elastic/eui';
 
 interface SIEMFieldNameProps {
   fieldNameOptions: string[];
@@ -57,7 +57,7 @@ export default class FieldNameSelector extends Component<SIEMFieldNameProps, SIE
     }));
 
     return (
-      <EuiFormRow style={{ width: '100%' }}>
+      <EuiCompressedFormRow style={{ width: '100%' }}>
         <EuiComboBox
           data-test-subj={'detector-field-mappings-select'}
           placeholder="Select a mapping field"
@@ -66,7 +66,7 @@ export default class FieldNameSelector extends Component<SIEMFieldNameProps, SIE
           selectedOptions={selectedOptions}
           onChange={this.onMappingChange}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   }
 }

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldNameSelector.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/FieldNameSelector.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiComboBoxOptionOption, EuiCompressedFormRow } from '@elastic/eui';
 
 interface SIEMFieldNameProps {
   fieldNameOptions: string[];
@@ -58,7 +58,7 @@ export default class FieldNameSelector extends Component<SIEMFieldNameProps, SIE
 
     return (
       <EuiCompressedFormRow style={{ width: '100%' }}>
-        <EuiComboBox
+        <EuiCompressedComboBox
           data-test-subj={'detector-field-mappings-select'}
           placeholder="Select a mapping field"
           singleSelection={{ asPlainText: true }}

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/SIEMFieldName.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/SIEMFieldName.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiCompressedFormRow, EuiSelect } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCompressedSelect } from '@elastic/eui';
 import { ChangeEvent } from 'react';
 
 interface SIEMFieldNameProps {
@@ -45,7 +45,7 @@ export default class SIEMFieldNameSelector extends Component<
         isInvalid={isInvalid}
         error={isInvalid ? 'Alias already used' : undefined}
       >
-        <EuiSelect
+        <EuiCompressedSelect
           required={true}
           hasNoInitialSelection
           options={this.props.siemFieldNameOptions.map((option) => ({

--- a/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/SIEMFieldName.tsx
+++ b/public/pages/CreateDetector/components/ConfigureFieldMapping/components/RequiredFieldMapping/SIEMFieldName.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiSelect } from '@elastic/eui';
 import { ChangeEvent } from 'react';
 
 interface SIEMFieldNameProps {
@@ -40,7 +40,7 @@ export default class SIEMFieldNameSelector extends Component<
   render() {
     const { isInvalid } = this.props;
     return (
-      <EuiFormRow
+      <EuiCompressedFormRow
         style={{ width: '100%' }}
         isInvalid={isInvalid}
         error={isInvalid ? 'Alias already used' : undefined}
@@ -55,7 +55,7 @@ export default class SIEMFieldNameSelector extends Component<
           value={this.state.selectedOption}
           onChange={this.onChange}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   }
 }

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules.tsx
@@ -9,7 +9,7 @@ import {
   CriteriaWithPagination,
   EuiText,
   EuiEmptyPrompt,
-  EuiButton,
+  EuiSmallButton,
   EuiIcon,
   EuiLoadingSpinner,
 } from '@elastic/eui';
@@ -119,9 +119,9 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
           </div>
         }
         extraAction={
-          <EuiButton href={`#${ROUTES.RULES}`} target="_blank">
+          <EuiSmallButton href={`#${ROUTES.RULES}`} target="_blank">
             Manage <EuiIcon type={'popout'} />
-          </EuiButton>
+          </EuiSmallButton>
         }
         id={'detectorRulesAccordion'}
         initialIsOpen={false}
@@ -153,10 +153,10 @@ export const DetectionRules: React.FC<DetectionRulesProps> = ({
             actions={
               detectorType
                 ? [
-                    <EuiButton href={`#${ROUTES.RULES}`} target="_blank">
+                    <EuiSmallButton href={`#${ROUTES.RULES}`} target="_blank">
                       Manage&nbsp;
                       <EuiIcon type={'popout'} />
-                    </EuiButton>,
+                    </EuiSmallButton>,
                   ]
                 : undefined
             }

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/utils/constants.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/utils/constants.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiLink, EuiSwitch } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiLink, EuiCompressedSwitch } from '@elastic/eui';
 import { capitalizeFirstLetter } from '../../../../../../../utils/helpers';
 import React, { ReactNode } from 'react';
 import { RuleItem } from '../types/interfaces';
@@ -69,7 +69,7 @@ export const getRulesColumns = (
   if (onActivationToggle) {
     columns.unshift({
       name: onAllRulesToggled ? (
-        <EuiSwitch
+        <EuiCompressedSwitch
           checked={allEnabled}
           onChange={(event: ActiveToggleOnChangeEvent) => {
             onAllRulesToggled(!allEnabled);
@@ -80,7 +80,7 @@ export const getRulesColumns = (
       ) : undefined,
       render: (item: RuleItem) => {
         return (
-          <EuiSwitch
+          <EuiCompressedSwitch
             checked={item.active}
             onChange={(event: ActiveToggleOnChangeEvent) =>
               onActivationToggle(item, event.target.checked)

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import {
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiCallOut,
   EuiTextColor,
@@ -154,7 +154,7 @@ export default class DetectorDataSource extends Component<
           <h3>Data source</h3>
         </EuiTitle>
         <EuiSpacer size={'m'} />
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={<FormFieldHeader headerTitle={'Select indexes/aliases'} />}
           isInvalid={isInvalid}
           error={isInvalid && (errorMessage || 'Select an input source.')}
@@ -186,7 +186,7 @@ export default class DetectorDataSource extends Component<
               return option.index ? `${option.label} (${option.index})` : option.label;
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         {differentLogTypesDetected ? (
           <>
             <EuiSpacer size={'m'} />

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDataSource/DetectorDataSource.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFormRow,
   EuiSpacer,
@@ -171,7 +171,7 @@ export default class DetectorDataSource extends Component<
             </span>
           }
         >
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder={'Select an input source for the detector.'}
             isLoading={loading}
             options={indexOptions}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDetails/DetectorBasicDetailsForm.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDetails/DetectorBasicDetailsForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiFormRow, EuiFieldText, EuiSpacer, EuiTextArea, EuiTitle } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiFieldText, EuiSpacer, EuiTextArea, EuiTitle } from '@elastic/eui';
 import { FormFieldHeader } from '../../../../../../components/FormFieldHeader/FormFieldHeader';
 import {
   getDescriptionErrorMessage,
@@ -78,7 +78,7 @@ export default class DetectorBasicDetailsForm extends Component<
           <h3>Detector details</h3>
         </EuiTitle>
         <EuiSpacer size={'m'} />
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={<FormFieldHeader headerTitle={'Name'} />}
           isInvalid={nameFieldTouched && nameIsInvalid}
           error={getNameErrorMessage(detectorName, nameIsInvalid, nameFieldTouched)}
@@ -92,10 +92,10 @@ export default class DetectorBasicDetailsForm extends Component<
             required={nameFieldTouched}
             data-test-subj={'define-detector-detector-name'}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size={'m'} />
 
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={<FormFieldHeader headerTitle={'Description'} optionalField={true} />}
           isInvalid={descriptionFieldTouched && descriptionIsInvalid}
           error={getDescriptionErrorMessage(
@@ -112,7 +112,7 @@ export default class DetectorBasicDetailsForm extends Component<
             onChange={this.onDescriptionChange}
             data-test-subj={'define-detector-detector-description'}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   }

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorDetails/DetectorBasicDetailsForm.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorDetails/DetectorBasicDetailsForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiCompressedFormRow, EuiFieldText, EuiSpacer, EuiTextArea, EuiTitle } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCompressedFieldText, EuiSpacer, EuiTextArea, EuiTitle } from '@elastic/eui';
 import { FormFieldHeader } from '../../../../../../components/FormFieldHeader/FormFieldHeader';
 import {
   getDescriptionErrorMessage,
@@ -83,7 +83,7 @@ export default class DetectorBasicDetailsForm extends Component<
           isInvalid={nameFieldTouched && nameIsInvalid}
           error={getNameErrorMessage(detectorName, nameIsInvalid, nameFieldTouched)}
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder={'Enter a name for the detector.'}
             readOnly={false}
             value={detectorName}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Daily.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Daily.tsx
@@ -9,7 +9,7 @@ import {
   EuiDatePicker,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import React from 'react';
 import moment, { Moment } from 'moment';
@@ -60,7 +60,7 @@ export class Daily extends React.Component<DailyProps, DailyState> {
     return (
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={<FormFieldHeader headerTitle={'Around'} />}
             isInvalid={!!invalidTimeMessage}
             error={invalidTimeMessage}
@@ -75,10 +75,10 @@ export class Daily extends React.Component<DailyProps, DailyState> {
               dateFormat="hh:mm A"
               timeIntervals={60}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiFormRow isInvalid={!!invalidTimeZoneMessage} error={invalidTimeZoneMessage}>
+          <EuiCompressedFormRow isInvalid={!!invalidTimeZoneMessage} error={invalidTimeZoneMessage}>
             <EuiComboBox
               placeholder="Select a timezone"
               options={timezones}
@@ -87,7 +87,7 @@ export class Daily extends React.Component<DailyProps, DailyState> {
               selectedOptions={selectedTimeZone ? [{ label: selectedTimeZone }] : undefined}
               onChange={this.onTimeZoneSelect}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Daily.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Daily.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiDatePicker,
   EuiFlexGroup,
@@ -79,7 +79,7 @@ export class Daily extends React.Component<DailyProps, DailyState> {
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiCompressedFormRow isInvalid={!!invalidTimeZoneMessage} error={invalidTimeZoneMessage}>
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select a timezone"
               options={timezones}
               renderOption={({ label: tz }) => `${tz} (${moment.tz(tz).format('Z')})`}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -64,7 +64,7 @@ export class Interval extends React.Component<IntervalProps, IntervalState> {
       >
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               min={1}
               icon={'clock'}
               value={period.interval}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval.tsx
@@ -8,7 +8,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
 } from '@elastic/eui';
 import React from 'react';
@@ -76,7 +76,7 @@ export class Interval extends React.Component<IntervalProps, IntervalState> {
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiSelect
+            <EuiCompressedSelect
               options={this.props.scheduleUnitOptions ?? Object.values(defaultIntervalUnitOptions)}
               onChange={this.onUnitChange}
               value={period.unit}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval.tsx
@@ -7,7 +7,7 @@ import {
   EuiFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiSelectOption,
 } from '@elastic/eui';
@@ -57,7 +57,7 @@ export class Interval extends React.Component<IntervalProps, IntervalState> {
     const { isIntervalValid } = this.state;
     const { period } = this.props.schedule;
     return (
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={this.props.label}
         isInvalid={!isIntervalValid}
         error={'Enter schedule interval.'}
@@ -85,7 +85,7 @@ export class Interval extends React.Component<IntervalProps, IntervalState> {
             />
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   }
 }

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiCompressedFormRow, EuiSpacer, EuiComboBox, EuiTitle, EuiText } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiSpacer, EuiCompressedComboBox, EuiTitle, EuiText } from '@elastic/eui';
 import { FormFieldHeader } from '../../../../../../components/FormFieldHeader/FormFieldHeader';
 import { CreateDetectorRulesState, DetectionRules } from '../DetectionRules/DetectionRules';
 import { RuleItem } from '../DetectionRules/types/interfaces';
@@ -94,7 +94,7 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
           isInvalid={this.isInvalid()}
           error={this.getErrorMessage()}
         >
-          <EuiComboBox
+          <EuiCompressedComboBox
             isInvalid={this.isInvalid()}
             placeholder="Select log type"
             data-test-subj={'log_type_dropdown'}

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Component } from 'react';
-import { EuiFormRow, EuiSpacer, EuiComboBox, EuiTitle, EuiText } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiSpacer, EuiComboBox, EuiTitle, EuiText } from '@elastic/eui';
 import { FormFieldHeader } from '../../../../../../components/FormFieldHeader/FormFieldHeader';
 import { CreateDetectorRulesState, DetectionRules } from '../DetectionRules/DetectionRules';
 import { RuleItem } from '../DetectionRules/types/interfaces';
@@ -83,7 +83,7 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
           </p>
         </EuiText>
         <EuiSpacer />
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={
             <div>
               <FormFieldHeader headerTitle={'Log type'} />
@@ -107,9 +107,9 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
               detectorType ? [{ value: detectorType, label: getLogTypeLabel(detectorType) }] : []
             }
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
-        <EuiFormRow fullWidth={true}>
+        <EuiCompressedFormRow fullWidth={true}>
           <DetectionRules
             detectorType={detectorType}
             rulesState={this.props.rulesState}
@@ -118,11 +118,11 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
             onRuleToggle={this.props.onRuleToggle}
             onAllRulesToggle={this.props.onAllRulesToggle}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
-        <EuiFormRow fullWidth={true}>
+        <EuiCompressedFormRow fullWidth={true}>
           <ConfigureFieldMapping {...this.props.configureFieldMappingProps} />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   }

--- a/public/pages/CreateDetector/components/DefineDetector/components/ThreatIntelligence/ThreatIntelligence.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/ThreatIntelligence/ThreatIntelligence.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiCheckbox, EuiText, EuiTitle, htmlIdGenerator } from '@elastic/eui';
+import { EuiCompressedCheckbox, EuiText, EuiTitle, htmlIdGenerator } from '@elastic/eui';
 
 export interface ThreatIntelligenceProps {
   threatIntelChecked: boolean;
@@ -27,7 +27,7 @@ export const ThreatIntelligence: React.FC<ThreatIntelligenceProps> = ({
           types only.
         </p>
       </EuiText>
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={htmlIdGenerator()()}
         label="Enable threat intelligence-based detection"
         checked={threatIntelChecked}

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -400,34 +400,34 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
 
           {currentStep > DetectorCreationStep.DEFINE_DETECTOR && (
             <EuiFlexItem grow={false}>
-              <EuiButton disabled={creatingDetector} onClick={this.onPreviousClick}>
+              <EuiSmallButton disabled={creatingDetector} onClick={this.onPreviousClick}>
                 Back
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
 
           {currentStep < DetectorCreationStep.CONFIGURE_ALERTS && (
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 fill={true}
                 onClick={this.onNextClick}
                 disabled={!stepDataValid[currentStep]}
               >
                 Next
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
 
           {currentStep === DetectorCreationStep.CONFIGURE_ALERTS && (
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 disabled={creatingDetector || !stepDataValid[currentStep]}
                 isLoading={creatingDetector}
                 fill={true}
                 onClick={this.onCreateClick}
               >
                 Create detector
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -395,7 +395,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
 
         <EuiFlexGroup alignItems={'center'} justifyContent={'flexEnd'}>
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty href={`${PLUGIN_NAME}#${ROUTES.DETECTORS}`}>Cancel</EuiButtonEmpty>
+            <EuiSmallButtonEmpty href={`${PLUGIN_NAME}#${ROUTES.DETECTORS}`}>Cancel</EuiSmallButtonEmpty>
           </EuiFlexItem>
 
           {currentStep > DetectorCreationStep.DEFINE_DETECTOR && (

--- a/public/pages/Detectors/components/AlertTriggerView/__snapshots__/AlertTriggerView.test.tsx.snap
+++ b/public/pages/Detectors/components/AlertTriggerView/__snapshots__/AlertTriggerView.test.tsx.snap
@@ -55,7 +55,7 @@ Object {
                   class="euiSpacer euiSpacer--s"
                 />
                 <div
-                  class="euiFormRow euiFormRow--fullWidth"
+                  class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -97,7 +97,7 @@ Object {
                   class="euiSpacer euiSpacer--s"
                 />
                 <div
-                  class="euiFormRow euiFormRow--fullWidth"
+                  class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -132,7 +132,7 @@ Object {
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormRow euiFormRow--fullWidth"
+                      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
@@ -162,7 +162,7 @@ Object {
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormRow euiFormRow--fullWidth"
+                      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
@@ -201,7 +201,7 @@ Object {
                   class="euiSpacer euiSpacer--m"
                 />
                 <div
-                  class="euiFormRow euiFormRow--fullWidth"
+                  class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -233,7 +233,7 @@ Object {
                   class="euiSpacer euiSpacer--l"
                 />
                 <div
-                  class="euiFormRow euiFormRow--fullWidth"
+                  class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -323,7 +323,7 @@ Object {
                 class="euiSpacer euiSpacer--s"
               />
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -365,7 +365,7 @@ Object {
                 class="euiSpacer euiSpacer--s"
               />
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -400,7 +400,7 @@ Object {
                   class="euiFlexItem"
                 >
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -430,7 +430,7 @@ Object {
                   class="euiFlexItem"
                 >
                   <div
-                    class="euiFormRow euiFormRow--fullWidth"
+                    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                     id="some_html_id-row"
                   >
                     <div
@@ -469,7 +469,7 @@ Object {
                 class="euiSpacer euiSpacer--m"
               />
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -501,7 +501,7 @@ Object {
                 class="euiSpacer euiSpacer--l"
               />
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div

--- a/public/pages/Detectors/components/DetectorBasicDetailsView/DetectorBasicDetailsView.tsx
+++ b/public/pages/Detectors/components/DetectorBasicDetailsView/DetectorBasicDetailsView.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiSpacer, EuiLink, EuiIcon, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiSpacer, EuiLink, EuiIcon, EuiText } from '@elastic/eui';
 import React from 'react';
 import { ContentPanel } from '../../../../components/ContentPanel';
 import { createTextDetailsGroup, parseSchedule } from '../../../../utils/helpers';
@@ -51,9 +51,9 @@ export const DetectorBasicDetailsView: React.FC<DetectorBasicDetailsViewProps> =
       actions={
         isEditable
           ? [
-              <EuiButton onClick={onEditClicked} data-test-subj={'edit-detector-basic-details'}>
+              <EuiSmallButton onClick={onEditClicked} data-test-subj={'edit-detector-basic-details'}>
                 Edit
-              </EuiButton>,
+              </EuiSmallButton>,
             ]
           : null
       }

--- a/public/pages/Detectors/components/DetectorBasicDetailsView/__snapshots__/DetectorBasicDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorBasicDetailsView/__snapshots__/DetectorBasicDetailsView.test.tsx.snap
@@ -32,7 +32,7 @@ Object {
                 class="euiFlexItem"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="edit-detector-basic-details"
                   type="button"
                 >
@@ -66,7 +66,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -96,7 +96,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -126,7 +126,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -163,7 +163,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -197,7 +197,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -227,7 +227,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -264,7 +264,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -294,7 +294,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -324,7 +324,7 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -355,7 +355,7 @@ Object {
             class="euiSpacer euiSpacer--l"
           />
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -415,7 +415,7 @@ Object {
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="edit-detector-basic-details"
                 type="button"
               >
@@ -449,7 +449,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -479,7 +479,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -509,7 +509,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -546,7 +546,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -580,7 +580,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -610,7 +610,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -647,7 +647,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -677,7 +677,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -707,7 +707,7 @@ Object {
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -738,7 +738,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           id="some_html_id-row"
         >
           <div

--- a/public/pages/Detectors/components/DetectorRulesView/DetectorRulesView.tsx
+++ b/public/pages/Detectors/components/DetectorRulesView/DetectorRulesView.tsx
@@ -5,7 +5,7 @@
 
 import { ContentPanel } from '../../../../components/ContentPanel';
 import React, { useContext, useEffect, useState } from 'react';
-import { EuiAccordion, EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiAccordion, EuiSmallButton, EuiSpacer, EuiText } from '@elastic/eui';
 import { RuleItem } from '../../../CreateDetector/components/DefineDetector/components/DetectionRules/types/interfaces';
 import { SecurityAnalyticsContext } from '../../../../services';
 import { RuleInfo } from '../../../../../server/models/interfaces';
@@ -52,12 +52,12 @@ export const DetectorRulesView: React.FC<DetectorRulesViewProps> = (props) => {
   const [loading, setLoading] = useState(false);
   const actions = props.isEditable
     ? [
-        <EuiButton
+        <EuiSmallButton
           onClick={() => props.onEditClicked(enabledRuleItems, allRuleItems)}
           data-test-subj={'edit-detector-rules'}
         >
           Edit
-        </EuiButton>,
+        </EuiSmallButton>,
       ]
     : null;
   const saContext = useContext(SecurityAnalyticsContext);

--- a/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
@@ -819,6 +819,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                 <FieldValueSelectionFilter
                                   config={
                                     Object {
+                                      "compressed": undefined,
                                       "field": "category",
                                       "multiSelect": "or",
                                       "name": "Log type",
@@ -948,6 +949,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                 <FieldValueSelectionFilter
                                   config={
                                     Object {
+                                      "compressed": undefined,
                                       "field": "level",
                                       "multiSelect": "or",
                                       "name": "Rule severity",
@@ -1123,6 +1125,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                 <FieldValueSelectionFilter
                                   config={
                                     Object {
+                                      "compressed": undefined,
                                       "field": "source",
                                       "multiSelect": "or",
                                       "name": "Source",

--- a/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
@@ -201,12 +201,12 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
   <ContentPanel
     actions={
       Array [
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="edit-detector-rules"
           onClick={[Function]}
         >
           Edit
-        </EuiButton>,
+        </EuiSmallButton>,
       ]
     }
     title="Active rules (2)"
@@ -280,53 +280,60 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                       <div
                         className="euiFlexItem"
                       >
-                        <EuiButton
+                        <EuiSmallButton
                           data-test-subj="edit-detector-rules"
                           onClick={[Function]}
                         >
-                          <EuiButtonDisplay
-                            baseClassName="euiButton"
+                          <EuiButton
                             data-test-subj="edit-detector-rules"
-                            disabled={false}
-                            element="button"
-                            isDisabled={false}
                             onClick={[Function]}
-                            type="button"
+                            size="s"
                           >
-                            <button
-                              className="euiButton euiButton--primary"
+                            <EuiButtonDisplay
+                              baseClassName="euiButton"
                               data-test-subj="edit-detector-rules"
                               disabled={false}
+                              element="button"
+                              isDisabled={false}
                               onClick={[Function]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
+                              size="s"
                               type="button"
                             >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="left"
-                                textProps={
+                              <button
+                                className="euiButton euiButton--primary euiButton--small"
+                                data-test-subj="edit-detector-rules"
+                                disabled={false}
+                                onClick={[Function]}
+                                style={
                                   Object {
-                                    "className": "euiButton__text",
+                                    "minWidth": undefined,
                                   }
                                 }
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButton__content"
+                                <EuiButtonContent
+                                  className="euiButton__content"
+                                  iconSide="left"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButton__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButton__text"
+                                    className="euiButtonContent euiButton__content"
                                   >
-                                    Edit
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Edit
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonDisplay>
-                        </EuiButton>
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonDisplay>
+                          </EuiButton>
+                        </EuiSmallButton>
                       </div>
                     </EuiFlexItem>
                   </div>

--- a/public/pages/Detectors/components/FieldMappingsView/FieldMappingsView.tsx
+++ b/public/pages/Detectors/components/FieldMappingsView/FieldMappingsView.tsx
@@ -5,7 +5,7 @@
 
 import { ContentPanel } from '../../../../components/ContentPanel';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { EuiBasicTableColumn, EuiButton, EuiInMemoryTable } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton, EuiInMemoryTable } from '@elastic/eui';
 import { FieldMappingsTableItem } from '../../../CreateDetector/models/interfaces';
 import { SecurityAnalyticsContext } from '../../../../services';
 import { FieldMapping } from '../../../../../models/interfaces';
@@ -45,9 +45,9 @@ export const FieldMappingsView: React.FC<FieldMappingsViewProps> = ({
     () =>
       isEditable
         ? [
-            <EuiButton onClick={editFieldMappings} data-test-subj={'edit-detector-field-mappings'}>
+            <EuiSmallButton onClick={editFieldMappings} data-test-subj={'edit-detector-field-mappings'}>
               Edit
-            </EuiButton>,
+            </EuiSmallButton>,
           ]
         : null,
     []

--- a/public/pages/Detectors/components/FieldMappingsView/__snapshots__/FieldMappingsView.test.tsx.snap
+++ b/public/pages/Detectors/components/FieldMappingsView/__snapshots__/FieldMappingsView.test.tsx.snap
@@ -32,7 +32,7 @@ Object {
                 class="euiFlexItem"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="edit-detector-field-mappings"
                   type="button"
                 >
@@ -237,7 +237,7 @@ Object {
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="edit-detector-field-mappings"
                 type="button"
               >

--- a/public/pages/Detectors/components/UpdateAlertConditions/UpdateAlertConditions.tsx
+++ b/public/pages/Detectors/components/UpdateAlertConditions/UpdateAlertConditions.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import {
   DetectorHit,
   RuleSource,
@@ -199,19 +199,19 @@ export default class UpdateAlertConditions extends Component<
 
         <EuiFlexGroup justifyContent={'flexEnd'}>
           <EuiFlexItem grow={false}>
-            <EuiButton disabled={submitting} onClick={this.onCancel}>
+            <EuiSmallButton disabled={submitting} onClick={this.onCancel}>
               Cancel
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               disabled={isSaveDisabled}
               fill={true}
               isLoading={submitting}
               onClick={this.onSave}
             >
               Save changes
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/Detectors/components/UpdateAlertConditions/__snapshots__/UpdateAlertConditions.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateAlertConditions/__snapshots__/UpdateAlertConditions.test.tsx.snap
@@ -1027,51 +1027,58 @@ exports[`<UpdateAlertConditions /> spec renders the component 1`] = `
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <EuiButton
+            <EuiSmallButton
               disabled={false}
               onClick={[Function]}
             >
-              <EuiButtonDisplay
-                baseClassName="euiButton"
+              <EuiButton
                 disabled={false}
-                element="button"
-                isDisabled={false}
                 onClick={[Function]}
-                type="button"
+                size="s"
               >
-                <button
-                  className="euiButton euiButton--primary"
+                <EuiButtonDisplay
+                  baseClassName="euiButton"
                   disabled={false}
+                  element="button"
+                  isDisabled={false}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "minWidth": undefined,
-                    }
-                  }
+                  size="s"
                   type="button"
                 >
-                  <EuiButtonContent
-                    className="euiButton__content"
-                    iconSide="left"
-                    textProps={
+                  <button
+                    className="euiButton euiButton--primary euiButton--small"
+                    disabled={false}
+                    onClick={[Function]}
+                    style={
                       Object {
-                        "className": "euiButton__text",
+                        "minWidth": undefined,
                       }
                     }
+                    type="button"
                   >
-                    <span
-                      className="euiButtonContent euiButton__content"
+                    <EuiButtonContent
+                      className="euiButton__content"
+                      iconSide="left"
+                      textProps={
+                        Object {
+                          "className": "euiButton__text",
+                        }
+                      }
                     >
                       <span
-                        className="euiButton__text"
+                        className="euiButtonContent euiButton__content"
                       >
-                        Cancel
+                        <span
+                          className="euiButton__text"
+                        >
+                          Cancel
+                        </span>
                       </span>
-                    </span>
-                  </EuiButtonContent>
-                </button>
-              </EuiButtonDisplay>
-            </EuiButton>
+                    </EuiButtonContent>
+                  </button>
+                </EuiButtonDisplay>
+              </EuiButton>
+            </EuiSmallButton>
           </div>
         </EuiFlexItem>
         <EuiFlexItem
@@ -1080,56 +1087,65 @@ exports[`<UpdateAlertConditions /> spec renders the component 1`] = `
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <EuiButton
+            <EuiSmallButton
               disabled={false}
               fill={true}
               isLoading={false}
               onClick={[Function]}
             >
-              <EuiButtonDisplay
-                baseClassName="euiButton"
+              <EuiButton
                 disabled={false}
-                element="button"
                 fill={true}
-                isDisabled={false}
                 isLoading={false}
                 onClick={[Function]}
-                type="button"
+                size="s"
               >
-                <button
-                  className="euiButton euiButton--primary euiButton--fill"
+                <EuiButtonDisplay
+                  baseClassName="euiButton"
                   disabled={false}
+                  element="button"
+                  fill={true}
+                  isDisabled={false}
+                  isLoading={false}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "minWidth": undefined,
-                    }
-                  }
+                  size="s"
                   type="button"
                 >
-                  <EuiButtonContent
-                    className="euiButton__content"
-                    iconSide="left"
-                    isLoading={false}
-                    textProps={
+                  <button
+                    className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                    disabled={false}
+                    onClick={[Function]}
+                    style={
                       Object {
-                        "className": "euiButton__text",
+                        "minWidth": undefined,
                       }
                     }
+                    type="button"
                   >
-                    <span
-                      className="euiButtonContent euiButton__content"
+                    <EuiButtonContent
+                      className="euiButton__content"
+                      iconSide="left"
+                      isLoading={false}
+                      textProps={
+                        Object {
+                          "className": "euiButton__text",
+                        }
+                      }
                     >
                       <span
-                        className="euiButton__text"
+                        className="euiButtonContent euiButton__content"
                       >
-                        Save changes
+                        <span
+                          className="euiButton__text"
+                        >
+                          Save changes
+                        </span>
                       </span>
-                    </span>
-                  </EuiButtonContent>
-                </button>
-              </EuiButtonDisplay>
-            </EuiButton>
+                    </EuiButtonContent>
+                  </button>
+                </EuiButtonDisplay>
+              </EuiButton>
+            </EuiSmallButton>
           </div>
         </EuiFlexItem>
       </div>

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -321,12 +321,12 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
 
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={onCancel} disabled={loading}>
+          <EuiSmallButton onClick={onCancel} disabled={loading}>
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             onClick={onSave}
             fill={true}
             disabled={loading || submitting}
@@ -334,7 +334,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
             data-test-subj={'save-basic-details-edits'}
           >
             Save changes
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
@@ -461,9 +461,9 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             className="euiSpacer euiSpacer--m"
           />
         </EuiSpacer>
-        <EuiFormRow
+        <EuiCompressedFormRow
           describedByIds={Array []}
-          display="row"
+          display="rowCompressed"
           fullWidth={false}
           hasChildLabel={true}
           hasEmptyLabelSpace={false}
@@ -476,7 +476,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
           labelType="label"
         >
           <div
-            className="euiFormRow"
+            className="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -516,7 +516,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             <div
               className="euiFormRow__fieldWrapper"
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="define-detector-detector-name"
                 id="some_html_id"
                 onBlur={[Function]}
@@ -527,40 +527,56 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                 required={true}
                 value="detector_name"
               >
-                <EuiFormControlLayout
-                  fullWidth={false}
-                  inputId="some_html_id"
+                <EuiFieldText
+                  compressed={true}
+                  data-test-subj="define-detector-detector-name"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Enter a name for the detector."
                   readOnly={false}
+                  required={true}
+                  value="detector_name"
                 >
-                  <div
-                    className="euiFormControlLayout"
+                  <EuiFormControlLayout
+                    compressed={true}
+                    fullWidth={false}
+                    inputId="some_html_id"
+                    readOnly={false}
                   >
                     <div
-                      className="euiFormControlLayout__childrenWrapper"
+                      className="euiFormControlLayout euiFormControlLayout--compressed"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldText"
-                          data-test-subj="define-detector-detector-name"
-                          id="some_html_id"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder="Enter a name for the detector."
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="detector_name"
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <EuiValidatableControl>
+                          <input
+                            className="euiFieldText euiFieldText--compressed"
+                            data-test-subj="define-detector-detector-name"
+                            id="some_html_id"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder="Enter a name for the detector."
+                            readOnly={false}
+                            required={true}
+                            type="text"
+                            value="detector_name"
+                          />
+                        </EuiValidatableControl>
+                        <EuiFormControlLayoutIcons
+                          compressed={true}
                         />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons />
+                      </div>
                     </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldText>
+                  </EuiFormControlLayout>
+                </EuiFieldText>
+              </EuiCompressedFieldText>
             </div>
           </div>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer
           size="m"
         >
@@ -568,9 +584,9 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             className="euiSpacer euiSpacer--m"
           />
         </EuiSpacer>
-        <EuiFormRow
+        <EuiCompressedFormRow
           describedByIds={Array []}
-          display="row"
+          display="rowCompressed"
           fullWidth={false}
           hasChildLabel={true}
           hasEmptyLabelSpace={false}
@@ -584,7 +600,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
           labelType="label"
         >
           <div
-            className="euiFormRow"
+            className="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -654,7 +670,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
               </EuiTextArea>
             </div>
           </div>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </DetectorBasicDetailsForm>
       <EuiSpacer
         size="l"
@@ -710,9 +726,9 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             className="euiSpacer euiSpacer--m"
           />
         </EuiSpacer>
-        <EuiFormRow
+        <EuiCompressedFormRow
           describedByIds={Array []}
-          display="row"
+          display="rowCompressed"
           error={false}
           fullWidth={false}
           hasChildLabel={true}
@@ -745,7 +761,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
           labelType="label"
         >
           <div
-            className="euiFormRow"
+            className="euiFormRow euiFormRow--compressed"
             id="some_html_id-row"
           >
             <div
@@ -785,10 +801,10 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             <div
               className="euiFormRow__fieldWrapper"
             >
-              <EuiComboBox
+              <EuiCompressedComboBox
                 aria-describedby="some_html_id-help-0"
                 async={false}
-                compressed={false}
+                compressed={true}
                 data-test-subj="define-detector-select-data-source"
                 fullWidth={false}
                 id="some_html_id"
@@ -827,14 +843,14 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                   aria-describedby="some_html_id-help-0"
                   aria-expanded={false}
                   aria-haspopup="listbox"
-                  className="euiComboBox"
+                  className="euiComboBox euiComboBox--compressed"
                   data-test-subj="define-detector-select-data-source"
                   onKeyDown={[Function]}
                   role="combobox"
                 >
                   <EuiComboBoxInput
                     autoSizeInputRef={[Function]}
-                    compressed={false}
+                    compressed={true}
                     fullWidth={false}
                     hasSelectedOptions={true}
                     id="some_html_id"
@@ -871,7 +887,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                           "onClick": [Function],
                         }
                       }
-                      compressed={false}
+                      compressed={true}
                       fullWidth={false}
                       icon={
                         Object {
@@ -887,13 +903,13 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                       isLoading={false}
                     >
                       <div
-                        className="euiFormControlLayout"
+                        className="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           className="euiFormControlLayout__childrenWrapper"
                         >
                           <div
-                            className="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                            className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                             data-test-subj="comboBoxInput"
                             onClick={[Function]}
                             tabIndex={-1}
@@ -1036,7 +1052,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                                 "onClick": [Function],
                               }
                             }
-                            compressed={false}
+                            compressed={true}
                             icon={
                               Object {
                                 "aria-label": "Open list of options",
@@ -1056,7 +1072,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                               <EuiFormControlLayoutClearButton
                                 data-test-subj="comboBoxClearButton"
                                 onClick={[Function]}
-                                size="m"
+                                size="s"
                               >
                                 <EuiI18n
                                   default="Clear input"
@@ -1064,7 +1080,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                                 >
                                   <button
                                     aria-label="Clear input"
-                                    className="euiFormControlLayoutClearButton"
+                                    className="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                     data-test-subj="comboBoxClearButton"
                                     onClick={[Function]}
                                     type="button"
@@ -1083,7 +1099,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                                 data-test-subj="comboBoxToggleListButton"
                                 iconRef={[Function]}
                                 onClick={[Function]}
-                                size="m"
+                                size="s"
                                 type="arrowDown"
                               >
                                 <button
@@ -1096,7 +1112,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                                   <EuiIcon
                                     aria-hidden="true"
                                     className="euiFormControlLayoutCustomIcon__icon"
-                                    size="m"
+                                    size="s"
                                     type="arrowDown"
                                   >
                                     EuiIconMock
@@ -1110,7 +1126,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                     </EuiFormControlLayout>
                   </EuiComboBoxInput>
                 </div>
-              </EuiComboBox>
+              </EuiCompressedComboBox>
               <EuiFormHelpText
                 className="euiFormRow__text"
                 id="some_html_id-help-0"
@@ -1141,7 +1157,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
               </EuiFormHelpText>
             </div>
           </div>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </DetectorDataSource>
       <EuiSpacer
         size="l"
@@ -1171,9 +1187,9 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             </p>
           </div>
         </EuiText>
-        <EuiCheckbox
+        <EuiCompressedCheckbox
           checked={false}
-          compressed={false}
+          compressed={true}
           disabled={false}
           id="some_html_id"
           indeterminate={false}
@@ -1181,7 +1197,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
           onChange={[Function]}
         >
           <div
-            className="euiCheckbox"
+            className="euiCheckbox euiCheckbox--compressed"
           >
             <input
               checked={false}
@@ -1201,7 +1217,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
               Enable threat intelligence-based detection
             </label>
           </div>
-        </EuiCheckbox>
+        </EuiCompressedCheckbox>
       </ThreatIntelligence>
       <EuiSpacer
         size="l"
@@ -1427,9 +1443,9 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             }
           }
         >
-          <EuiFormRow
+          <EuiCompressedFormRow
             describedByIds={Array []}
-            display="row"
+            display="rowCompressed"
             error="Enter schedule interval."
             fullWidth={false}
             hasChildLabel={true}
@@ -1443,7 +1459,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
             labelType="label"
           >
             <div
-              className="euiFormRow"
+              className="euiFormRow euiFormRow--compressed"
               id="some_html_id-row"
             >
               <div
@@ -1498,7 +1514,7 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                       <div
                         className="euiFlexItem"
                       >
-                        <EuiFieldNumber
+                        <EuiCompressedFieldNumber
                           data-test-subj="detector-schedule-number-select"
                           icon="clock"
                           isInvalid={false}
@@ -1507,69 +1523,80 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                           required={true}
                           value={1}
                         >
-                          <EuiFormControlLayout
-                            compressed={false}
-                            fullWidth={false}
+                          <EuiFieldNumber
+                            compressed={true}
+                            data-test-subj="detector-schedule-number-select"
                             icon="clock"
-                            isLoading={false}
+                            isInvalid={false}
+                            min={1}
+                            onChange={[Function]}
+                            required={true}
+                            value={1}
                           >
-                            <div
-                              className="euiFormControlLayout"
+                            <EuiFormControlLayout
+                              compressed={true}
+                              fullWidth={false}
+                              icon="clock"
+                              isLoading={false}
                             >
                               <div
-                                className="euiFormControlLayout__childrenWrapper"
+                                className="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <EuiValidatableControl
-                                  isInvalid={false}
+                                <div
+                                  className="euiFormControlLayout__childrenWrapper"
                                 >
-                                  <input
-                                    className="euiFieldNumber euiFieldNumber--withIcon"
-                                    data-test-subj="detector-schedule-number-select"
-                                    min={1}
-                                    onChange={[Function]}
-                                    required={true}
-                                    type="number"
-                                    value={1}
-                                  />
-                                </EuiValidatableControl>
-                                <EuiFormControlLayoutIcons
-                                  compressed={false}
-                                  icon="clock"
-                                  isLoading={false}
-                                >
-                                  <div
-                                    className="euiFormControlLayoutIcons"
+                                  <EuiValidatableControl
+                                    isInvalid={false}
                                   >
-                                    <EuiFormControlLayoutCustomIcon
-                                      size="m"
-                                      type="clock"
+                                    <input
+                                      className="euiFieldNumber euiFieldNumber--withIcon euiFieldNumber--compressed"
+                                      data-test-subj="detector-schedule-number-select"
+                                      min={1}
+                                      onChange={[Function]}
+                                      required={true}
+                                      type="number"
+                                      value={1}
+                                    />
+                                  </EuiValidatableControl>
+                                  <EuiFormControlLayoutIcons
+                                    compressed={true}
+                                    icon="clock"
+                                    isLoading={false}
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons"
                                     >
-                                      <span
-                                        className="euiFormControlLayoutCustomIcon"
+                                      <EuiFormControlLayoutCustomIcon
+                                        size="s"
+                                        type="clock"
                                       >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiFormControlLayoutCustomIcon__icon"
-                                          size="m"
-                                          type="clock"
+                                        <span
+                                          className="euiFormControlLayoutCustomIcon"
                                         >
-                                          EuiIconMock
-                                        </EuiIcon>
-                                      </span>
-                                    </EuiFormControlLayoutCustomIcon>
-                                  </div>
-                                </EuiFormControlLayoutIcons>
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            size="s"
+                                            type="clock"
+                                          >
+                                            EuiIconMock
+                                          </EuiIcon>
+                                        </span>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
+                                </div>
                               </div>
-                            </div>
-                          </EuiFormControlLayout>
-                        </EuiFieldNumber>
+                            </EuiFormControlLayout>
+                          </EuiFieldNumber>
+                        </EuiCompressedFieldNumber>
                       </div>
                     </EuiFlexItem>
                     <EuiFlexItem>
                       <div
                         className="euiFlexItem"
                       >
-                        <EuiSelect
+                        <EuiCompressedSelect
                           data-test-subj="detector-schedule-unit-select"
                           onChange={[Function]}
                           options={
@@ -1590,94 +1617,117 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
                           }
                           value="MINUTES"
                         >
-                          <EuiFormControlLayout
-                            compressed={false}
-                            fullWidth={false}
-                            icon={
-                              Object {
-                                "side": "right",
-                                "type": "arrowDown",
-                              }
+                          <EuiSelect
+                            compressed={true}
+                            data-test-subj="detector-schedule-unit-select"
+                            onChange={[Function]}
+                            options={
+                              Array [
+                                Object {
+                                  "text": "Minutes",
+                                  "value": "MINUTES",
+                                },
+                                Object {
+                                  "text": "Hours",
+                                  "value": "HOURS",
+                                },
+                                Object {
+                                  "text": "Days",
+                                  "value": "DAYS",
+                                },
+                              ]
                             }
-                            isLoading={false}
+                            value="MINUTES"
                           >
-                            <div
-                              className="euiFormControlLayout"
+                            <EuiFormControlLayout
+                              compressed={true}
+                              fullWidth={false}
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
                             >
                               <div
-                                className="euiFormControlLayout__childrenWrapper"
+                                className="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <EuiValidatableControl>
-                                  <select
-                                    className="euiSelect"
-                                    data-test-subj="detector-schedule-unit-select"
-                                    onChange={[Function]}
-                                    onMouseUp={[Function]}
-                                    value="MINUTES"
-                                  >
-                                    <option
-                                      key="0"
+                                <div
+                                  className="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <EuiValidatableControl>
+                                    <select
+                                      className="euiSelect euiSelect--compressed"
+                                      data-test-subj="detector-schedule-unit-select"
+                                      onChange={[Function]}
+                                      onMouseUp={[Function]}
                                       value="MINUTES"
                                     >
-                                      Minutes
-                                    </option>
-                                    <option
-                                      key="1"
-                                      value="HOURS"
-                                    >
-                                      Hours
-                                    </option>
-                                    <option
-                                      key="2"
-                                      value="DAYS"
-                                    >
-                                      Days
-                                    </option>
-                                  </select>
-                                </EuiValidatableControl>
-                                <EuiFormControlLayoutIcons
-                                  compressed={false}
-                                  icon={
-                                    Object {
-                                      "side": "right",
-                                      "type": "arrowDown",
-                                    }
-                                  }
-                                  isLoading={false}
-                                >
-                                  <div
-                                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                  >
-                                    <EuiFormControlLayoutCustomIcon
-                                      size="m"
-                                      type="arrowDown"
-                                    >
-                                      <span
-                                        className="euiFormControlLayoutCustomIcon"
+                                      <option
+                                        key="0"
+                                        value="MINUTES"
                                       >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiFormControlLayoutCustomIcon__icon"
-                                          size="m"
-                                          type="arrowDown"
+                                        Minutes
+                                      </option>
+                                      <option
+                                        key="1"
+                                        value="HOURS"
+                                      >
+                                        Hours
+                                      </option>
+                                      <option
+                                        key="2"
+                                        value="DAYS"
+                                      >
+                                        Days
+                                      </option>
+                                    </select>
+                                  </EuiValidatableControl>
+                                  <EuiFormControlLayoutIcons
+                                    compressed={true}
+                                    icon={
+                                      Object {
+                                        "side": "right",
+                                        "type": "arrowDown",
+                                      }
+                                    }
+                                    isLoading={false}
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                    >
+                                      <EuiFormControlLayoutCustomIcon
+                                        size="s"
+                                        type="arrowDown"
+                                      >
+                                        <span
+                                          className="euiFormControlLayoutCustomIcon"
                                         >
-                                          EuiIconMock
-                                        </EuiIcon>
-                                      </span>
-                                    </EuiFormControlLayoutCustomIcon>
-                                  </div>
-                                </EuiFormControlLayoutIcons>
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            size="s"
+                                            type="arrowDown"
+                                          >
+                                            EuiIconMock
+                                          </EuiIcon>
+                                        </span>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
+                                </div>
                               </div>
-                            </div>
-                          </EuiFormControlLayout>
-                        </EuiSelect>
+                            </EuiFormControlLayout>
+                          </EuiSelect>
+                        </EuiCompressedSelect>
                       </div>
                     </EuiFlexItem>
                   </div>
                 </EuiFlexGroup>
               </div>
             </div>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </Interval>
       </DetectorSchedule>
       <EuiSpacer
@@ -1706,51 +1756,58 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
         <div
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <EuiButton
+          <EuiSmallButton
             disabled={false}
             onClick={[Function]}
           >
-            <EuiButtonDisplay
-              baseClassName="euiButton"
+            <EuiButton
               disabled={false}
-              element="button"
-              isDisabled={false}
               onClick={[Function]}
-              type="button"
+              size="s"
             >
-              <button
-                className="euiButton euiButton--primary"
+              <EuiButtonDisplay
+                baseClassName="euiButton"
                 disabled={false}
+                element="button"
+                isDisabled={false}
                 onClick={[Function]}
-                style={
-                  Object {
-                    "minWidth": undefined,
-                  }
-                }
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  iconSide="left"
-                  textProps={
+                <button
+                  className="euiButton euiButton--primary euiButton--small"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
                     Object {
-                      "className": "euiButton__text",
+                      "minWidth": undefined,
                     }
                   }
+                  type="button"
                 >
-                  <span
-                    className="euiButtonContent euiButton__content"
+                  <EuiButtonContent
+                    className="euiButton__content"
+                    iconSide="left"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButtonContent euiButton__content"
                     >
-                      Cancel
+                      <span
+                        className="euiButton__text"
+                      >
+                        Cancel
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonDisplay>
-          </EuiButton>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
+            </EuiButton>
+          </EuiSmallButton>
         </div>
       </EuiFlexItem>
       <EuiFlexItem
@@ -1759,59 +1816,69 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
         <div
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="save-basic-details-edits"
             disabled={false}
             fill={true}
             isLoading={false}
             onClick={[Function]}
           >
-            <EuiButtonDisplay
-              baseClassName="euiButton"
+            <EuiButton
               data-test-subj="save-basic-details-edits"
               disabled={false}
-              element="button"
               fill={true}
-              isDisabled={false}
               isLoading={false}
               onClick={[Function]}
-              type="button"
+              size="s"
             >
-              <button
-                className="euiButton euiButton--primary euiButton--fill"
+              <EuiButtonDisplay
+                baseClassName="euiButton"
                 data-test-subj="save-basic-details-edits"
                 disabled={false}
+                element="button"
+                fill={true}
+                isDisabled={false}
+                isLoading={false}
                 onClick={[Function]}
-                style={
-                  Object {
-                    "minWidth": undefined,
-                  }
-                }
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  iconSide="left"
-                  isLoading={false}
-                  textProps={
+                <button
+                  className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                  data-test-subj="save-basic-details-edits"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
                     Object {
-                      "className": "euiButton__text",
+                      "minWidth": undefined,
                     }
                   }
+                  type="button"
                 >
-                  <span
-                    className="euiButtonContent euiButton__content"
+                  <EuiButtonContent
+                    className="euiButton__content"
+                    iconSide="left"
+                    isLoading={false}
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButtonContent euiButton__content"
                     >
-                      Save changes
+                      <span
+                        className="euiButton__text"
+                      >
+                        Save changes
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonDisplay>
-          </EuiButton>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
+            </EuiButton>
+          </EuiSmallButton>
         </div>
       </EuiFlexItem>
     </div>

--- a/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
+++ b/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiText } from '@elastic/eui';
 import { FieldMapping } from '../../../../../models/interfaces';
 import FieldMappingService from '../../../../services/FieldMappingService';
 import { DetectorHit, SearchDetectorsResponse } from '../../../../../server/models/interfaces';
@@ -201,19 +201,19 @@ export default class UpdateFieldMappings extends Component<
 
         <EuiFlexGroup justifyContent={'flexEnd'}>
           <EuiFlexItem grow={false}>
-            <EuiButton disabled={submitting} onClick={this.onCancel}>
+            <EuiSmallButton disabled={submitting} onClick={this.onCancel}>
               Cancel
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               disabled={submitting}
               fill={true}
               isLoading={submitting}
               onClick={this.onSave}
             >
               Save changes
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </div>

--- a/public/pages/Detectors/components/UpdateFieldMappings/__snapshots__/UpdateFieldMappings.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateFieldMappings/__snapshots__/UpdateFieldMappings.test.tsx.snap
@@ -32,7 +32,7 @@ Object {
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               type="button"
             >
               <span
@@ -50,7 +50,7 @@ Object {
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <button
-              class="euiButton euiButton--primary euiButton--fill"
+              class="euiButton euiButton--primary euiButton--small euiButton--fill"
               type="button"
             >
               <span
@@ -96,7 +96,7 @@ Object {
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             type="button"
           >
             <span
@@ -114,7 +114,7 @@ Object {
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <button
-            class="euiButton euiButton--primary euiButton--fill"
+            class="euiButton euiButton--primary euiButton--small euiButton--fill"
             type="button"
           >
             <span

--- a/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
+++ b/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import {
   DetectorHit,
   SearchDetectorsResponse,
@@ -319,13 +319,13 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
 
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButton disabled={submitting} onClick={onCancel}>
+            <EuiSmallButton disabled={submitting} onClick={onCancel}>
               Cancel
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               disabled={loading}
               fill={true}
               isLoading={submitting}
@@ -333,7 +333,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
               data-test-subj={'save-detector-rules-edits'}
             >
               Save changes
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </ContentPanel>

--- a/public/pages/Detectors/components/UpdateRules/__snapshots__/UpdateDetectorRules.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateRules/__snapshots__/UpdateDetectorRules.test.tsx.snap
@@ -186,10 +186,9 @@ Object {
                             >
                               <span
                                 class="euiTableCellContent__text"
-                                title="EuiIconMockEuiIconMock"
                               >
                                 <div
-                                  class="euiSwitch euiSwitch--primary"
+                                  class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                                 >
                                   <button
                                     aria-checked="true"
@@ -207,10 +206,7 @@ Object {
                                       />
                                       <span
                                         class="euiSwitch__track"
-                                      >
-                                        EuiIconMock
-                                        EuiIconMock
-                                      </span>
+                                      />
                                     </span>
                                   </button>
                                 </div>
@@ -346,7 +342,7 @@ Object {
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   type="button"
                 >
                   <span
@@ -364,7 +360,7 @@ Object {
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary euiButton--fill"
+                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
                   data-test-subj="save-detector-rules-edits"
                   type="button"
                 >
@@ -567,10 +563,9 @@ Object {
                           >
                             <span
                               class="euiTableCellContent__text"
-                              title="EuiIconMockEuiIconMock"
                             >
                               <div
-                                class="euiSwitch euiSwitch--primary"
+                                class="euiSwitch euiSwitch--primary euiSwitch--compressed"
                               >
                                 <button
                                   aria-checked="true"
@@ -588,10 +583,7 @@ Object {
                                     />
                                     <span
                                       class="euiSwitch__track"
-                                    >
-                                      EuiIconMock
-                                      EuiIconMock
-                                    </span>
+                                    />
                                   </span>
                                 </button>
                               </div>
@@ -727,7 +719,7 @@ Object {
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 type="button"
               >
                 <span
@@ -745,7 +737,7 @@ Object {
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 data-test-subj="save-detector-rules-edits"
                 type="button"
               >

--- a/public/pages/Detectors/containers/AlertTriggersView/AlertTriggersView.tsx
+++ b/public/pages/Detectors/containers/AlertTriggersView/AlertTriggersView.tsx
@@ -5,7 +5,7 @@
 
 import { ContentPanel } from '../../../../components/ContentPanel';
 import React, { useMemo, useEffect, useState, useContext } from 'react';
-import { EuiButton, EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { EuiSmallButton, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { AlertTriggerView } from '../../components/AlertTriggerView/AlertTriggerView';
 import { SecurityAnalyticsContext } from '../../../../services';
 import { ServerResponse } from '../../../../../server/models/types';
@@ -32,7 +32,7 @@ export const AlertTriggersView: React.FC<AlertTriggersViewProps> = ({
   const [channels, setChannels] = useState<FeatureChannelList[]>([]);
   const [rules, setRules] = useState<{ [key: string]: RuleInfo }>({});
   const actions = useMemo(
-    () => (isEditable ? [<EuiButton onClick={editAlertTriggers}>Edit</EuiButton>] : null),
+    () => (isEditable ? [<EuiSmallButton onClick={editAlertTriggers}>Edit</EuiSmallButton>] : null),
     []
   );
 

--- a/public/pages/Detectors/containers/AlertTriggersView/__snapshots__/AlertTriggersView.test.tsx.snap
+++ b/public/pages/Detectors/containers/AlertTriggersView/__snapshots__/AlertTriggersView.test.tsx.snap
@@ -199,11 +199,11 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
   <ContentPanel
     actions={
       Array [
-        <EuiButton
+        <EuiSmallButton
           onClick={[MockFunction]}
         >
           Edit
-        </EuiButton>,
+        </EuiSmallButton>,
       ]
     }
     title="Alert triggers (2)"
@@ -277,50 +277,56 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                       <div
                         className="euiFlexItem"
                       >
-                        <EuiButton
+                        <EuiSmallButton
                           onClick={[MockFunction]}
                         >
-                          <EuiButtonDisplay
-                            baseClassName="euiButton"
-                            disabled={false}
-                            element="button"
-                            isDisabled={false}
+                          <EuiButton
                             onClick={[MockFunction]}
-                            type="button"
+                            size="s"
                           >
-                            <button
-                              className="euiButton euiButton--primary"
+                            <EuiButtonDisplay
+                              baseClassName="euiButton"
                               disabled={false}
+                              element="button"
+                              isDisabled={false}
                               onClick={[MockFunction]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
+                              size="s"
                               type="button"
                             >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="left"
-                                textProps={
+                              <button
+                                className="euiButton euiButton--primary euiButton--small"
+                                disabled={false}
+                                onClick={[MockFunction]}
+                                style={
                                   Object {
-                                    "className": "euiButton__text",
+                                    "minWidth": undefined,
                                   }
                                 }
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButton__content"
+                                <EuiButtonContent
+                                  className="euiButton__content"
+                                  iconSide="left"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButton__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButton__text"
+                                    className="euiButtonContent euiButton__content"
                                   >
-                                    Edit
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Edit
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonDisplay>
-                        </EuiButton>
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonDisplay>
+                          </EuiButton>
+                        </EuiSmallButton>
                       </div>
                     </EuiFlexItem>
                   </div>
@@ -679,9 +685,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--s"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -689,7 +695,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -730,7 +736,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -763,9 +769,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--s"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -773,7 +779,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -814,7 +820,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -835,9 +841,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 <div
                                   className="euiFlexItem"
                                 >
-                                  <EuiFormRow
+                                  <EuiCompressedFormRow
                                     describedByIds={Array []}
-                                    display="row"
+                                    display="rowCompressed"
                                     fullWidth={true}
                                     hasChildLabel={true}
                                     hasEmptyLabelSpace={false}
@@ -845,7 +851,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                     labelType="label"
                                   >
                                     <div
-                                      className="euiFormRow euiFormRow--fullWidth"
+                                      className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                                       id="some_html_id-row"
                                     >
                                       <div
@@ -886,7 +892,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                         </EuiText>
                                       </div>
                                     </div>
-                                  </EuiFormRow>
+                                  </EuiCompressedFormRow>
                                 </div>
                               </EuiFlexItem>
                               <EuiFlexItem
@@ -896,9 +902,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 <div
                                   className="euiFlexItem"
                                 >
-                                  <EuiFormRow
+                                  <EuiCompressedFormRow
                                     describedByIds={Array []}
-                                    display="row"
+                                    display="rowCompressed"
                                     fullWidth={true}
                                     hasChildLabel={true}
                                     hasEmptyLabelSpace={false}
@@ -906,7 +912,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                     labelType="label"
                                   >
                                     <div
-                                      className="euiFormRow euiFormRow--fullWidth"
+                                      className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                                       id="some_html_id-row"
                                     >
                                       <div
@@ -947,7 +953,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                         </EuiText>
                                       </div>
                                     </div>
-                                  </EuiFormRow>
+                                  </EuiCompressedFormRow>
                                 </div>
                               </EuiFlexItem>
                             </div>
@@ -975,9 +981,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--m"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -985,7 +991,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -1026,7 +1032,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -1041,9 +1047,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -1051,7 +1057,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -1098,7 +1104,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -1450,9 +1456,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--s"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -1460,7 +1466,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -1501,7 +1507,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -1534,9 +1540,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--s"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -1544,7 +1550,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -1585,7 +1591,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -1606,9 +1612,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 <div
                                   className="euiFlexItem"
                                 >
-                                  <EuiFormRow
+                                  <EuiCompressedFormRow
                                     describedByIds={Array []}
-                                    display="row"
+                                    display="rowCompressed"
                                     fullWidth={true}
                                     hasChildLabel={true}
                                     hasEmptyLabelSpace={false}
@@ -1616,7 +1622,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                     labelType="label"
                                   >
                                     <div
-                                      className="euiFormRow euiFormRow--fullWidth"
+                                      className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                                       id="some_html_id-row"
                                     >
                                       <div
@@ -1657,7 +1663,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                         </EuiText>
                                       </div>
                                     </div>
-                                  </EuiFormRow>
+                                  </EuiCompressedFormRow>
                                 </div>
                               </EuiFlexItem>
                               <EuiFlexItem
@@ -1667,9 +1673,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 <div
                                   className="euiFlexItem"
                                 >
-                                  <EuiFormRow
+                                  <EuiCompressedFormRow
                                     describedByIds={Array []}
-                                    display="row"
+                                    display="rowCompressed"
                                     fullWidth={true}
                                     hasChildLabel={true}
                                     hasEmptyLabelSpace={false}
@@ -1677,7 +1683,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                     labelType="label"
                                   >
                                     <div
-                                      className="euiFormRow euiFormRow--fullWidth"
+                                      className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                                       id="some_html_id-row"
                                     >
                                       <div
@@ -1718,7 +1724,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                         </EuiText>
                                       </div>
                                     </div>
-                                  </EuiFormRow>
+                                  </EuiCompressedFormRow>
                                 </div>
                               </EuiFlexItem>
                             </div>
@@ -1746,9 +1752,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--m"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -1756,7 +1762,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -1797,7 +1803,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >
@@ -1812,9 +1818,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                               className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             describedByIds={Array []}
-                            display="row"
+                            display="rowCompressed"
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
@@ -1822,7 +1828,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                             labelType="label"
                           >
                             <div
-                              className="euiFormRow euiFormRow--fullWidth"
+                              className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                               id="some_html_id-row"
                             >
                               <div
@@ -1869,7 +1875,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                                 </EuiText>
                               </div>
                             </div>
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                           <EuiSpacer
                             size="l"
                           >

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFlexGroup,
@@ -349,7 +349,7 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
       <EuiPopover
         id={'detectorsActionsPopover'}
         button={
-          <EuiButton
+          <EuiSmallButton
             isLoading={loading}
             iconType={'arrowDown'}
             iconSide={'right'}
@@ -357,7 +357,7 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
             data-test-subj={'detectorsActionsButton'}
           >
             Actions
-          </EuiButton>
+          </EuiSmallButton>
         }
         isOpen={isActionsMenuOpen}
         closePopover={this.closeActionsPopover}

--- a/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
@@ -255,7 +255,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
           "renderComponent": <EuiPopover
             anchorPosition="downLeft"
             button={
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj="detectorsActionsButton"
                 iconSide="right"
                 iconType="arrowDown"
@@ -263,7 +263,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                 onClick={[Function]}
               >
                 Actions
-              </EuiButton>
+              </EuiSmallButton>
             }
             closePopover={[Function]}
             data-test-subj="detectorsActionsPopover"
@@ -428,7 +428,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <EuiPopover
                       anchorPosition="downLeft"
                       button={
-                        <EuiButton
+                        <EuiSmallButton
                           data-test-subj="detectorsActionsButton"
                           iconSide="right"
                           iconType="arrowDown"
@@ -436,7 +436,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           onClick={[Function]}
                         >
                           Actions
-                        </EuiButton>
+                        </EuiSmallButton>
                       }
                       closePopover={[Function]}
                       data-test-subj="detectorsActionsPopover"
@@ -455,69 +455,79 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         <div
                           className="euiPopover__anchor"
                         >
-                          <EuiButton
+                          <EuiSmallButton
                             data-test-subj="detectorsActionsButton"
                             iconSide="right"
                             iconType="arrowDown"
                             isLoading={false}
                             onClick={[Function]}
                           >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
+                            <EuiButton
                               data-test-subj="detectorsActionsButton"
-                              disabled={false}
-                              element="button"
                               iconSide="right"
                               iconType="arrowDown"
-                              isDisabled={false}
                               isLoading={false}
                               onClick={[Function]}
-                              type="button"
+                              size="s"
                             >
-                              <button
-                                className="euiButton euiButton--primary"
+                              <EuiButtonDisplay
+                                baseClassName="euiButton"
                                 data-test-subj="detectorsActionsButton"
                                 disabled={false}
+                                element="button"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                isDisabled={false}
+                                isLoading={false}
                                 onClick={[Function]}
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                  }
-                                }
+                                size="s"
                                 type="button"
                               >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  isLoading={false}
-                                  textProps={
+                                <button
+                                  className="euiButton euiButton--primary euiButton--small"
+                                  data-test-subj="detectorsActionsButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  style={
                                     Object {
-                                      "className": "euiButton__text",
+                                      "minWidth": undefined,
                                     }
                                   }
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="right"
+                                    iconType="arrowDown"
+                                    isLoading={false}
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
                                   >
-                                    <EuiIcon
-                                      className="euiButtonContent__icon"
-                                      color="inherit"
-                                      size="m"
-                                      type="arrowDown"
-                                    >
-                                      EuiIconMock
-                                    </EuiIcon>
                                     <span
-                                      className="euiButton__text"
+                                      className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                                     >
-                                      Actions
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        EuiIconMock
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Actions
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonDisplay>
-                          </EuiButton>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </EuiSmallButton>
                         </div>
                       </div>
                     </EuiPopover>
@@ -1465,12 +1475,12 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
       <ContentPanel
         actions={
           Array [
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="edit-detector-basic-details"
               onClick={[Function]}
             >
               Edit
-            </EuiButton>,
+            </EuiSmallButton>,
           ]
         }
         title="Detector details"
@@ -1544,53 +1554,60 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           <div
                             className="euiFlexItem"
                           >
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="edit-detector-basic-details"
                               onClick={[Function]}
                             >
-                              <EuiButtonDisplay
-                                baseClassName="euiButton"
+                              <EuiButton
                                 data-test-subj="edit-detector-basic-details"
-                                disabled={false}
-                                element="button"
-                                isDisabled={false}
                                 onClick={[Function]}
-                                type="button"
+                                size="s"
                               >
-                                <button
-                                  className="euiButton euiButton--primary"
+                                <EuiButtonDisplay
+                                  baseClassName="euiButton"
                                   data-test-subj="edit-detector-basic-details"
                                   disabled={false}
+                                  element="button"
+                                  isDisabled={false}
                                   onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                  size="s"
                                   type="button"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
+                                  <button
+                                    className="euiButton euiButton--primary euiButton--small"
+                                    data-test-subj="edit-detector-basic-details"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    style={
                                       Object {
-                                        "className": "euiButton__text",
+                                        "minWidth": undefined,
                                       }
                                     }
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButton__text"
+                                        className="euiButtonContent euiButton__content"
                                       >
-                                        Edit
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Edit
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonDisplay>
-                            </EuiButton>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonDisplay>
+                              </EuiButton>
+                            </EuiSmallButton>
                           </div>
                         </EuiFlexItem>
                       </div>
@@ -1633,9 +1650,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -1643,7 +1660,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -1684,7 +1701,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -1694,9 +1711,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -1704,7 +1721,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -1745,7 +1762,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -1755,9 +1772,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -1765,7 +1782,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -1806,7 +1823,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                 </div>
@@ -1831,9 +1848,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -1841,7 +1858,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -1890,7 +1907,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -1900,9 +1917,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -1910,7 +1927,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -1951,7 +1968,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -1961,9 +1978,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -1971,7 +1988,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -2012,7 +2029,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                 </div>
@@ -2037,9 +2054,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -2047,7 +2064,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -2088,7 +2105,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -2098,9 +2115,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -2108,7 +2125,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -2149,7 +2166,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -2159,9 +2176,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={true}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -2169,7 +2186,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow euiFormRow--fullWidth"
+                          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -2210,7 +2227,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             </EuiText>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                 </div>
@@ -2222,9 +2239,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                   className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 describedByIds={Array []}
-                display="row"
+                display="rowCompressed"
                 fullWidth={true}
                 hasChildLabel={true}
                 hasEmptyLabelSpace={false}
@@ -2232,7 +2249,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                 labelType="label"
               >
                 <div
-                  className="euiFormRow euiFormRow--fullWidth"
+                  className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -2273,7 +2290,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     </EuiText>
                   </div>
                 </div>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer
                 size="l"
               >
@@ -2729,12 +2746,12 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
       <ContentPanel
         actions={
           Array [
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="edit-detector-rules"
               onClick={[Function]}
             >
               Edit
-            </EuiButton>,
+            </EuiSmallButton>,
           ]
         }
         title="Active rules (2)"
@@ -2808,53 +2825,60 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           <div
                             className="euiFlexItem"
                           >
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="edit-detector-rules"
                               onClick={[Function]}
                             >
-                              <EuiButtonDisplay
-                                baseClassName="euiButton"
+                              <EuiButton
                                 data-test-subj="edit-detector-rules"
-                                disabled={false}
-                                element="button"
-                                isDisabled={false}
                                 onClick={[Function]}
-                                type="button"
+                                size="s"
                               >
-                                <button
-                                  className="euiButton euiButton--primary"
+                                <EuiButtonDisplay
+                                  baseClassName="euiButton"
                                   data-test-subj="edit-detector-rules"
                                   disabled={false}
+                                  element="button"
+                                  isDisabled={false}
                                   onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                  size="s"
                                   type="button"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
+                                  <button
+                                    className="euiButton euiButton--primary euiButton--small"
+                                    data-test-subj="edit-detector-rules"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    style={
                                       Object {
-                                        "className": "euiButton__text",
+                                        "minWidth": undefined,
                                       }
                                     }
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButton__text"
+                                        className="euiButtonContent euiButton__content"
                                       >
-                                        Edit
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Edit
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonDisplay>
-                            </EuiButton>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonDisplay>
+                              </EuiButton>
+                            </EuiSmallButton>
                           </div>
                         </EuiFlexItem>
                       </div>
@@ -3340,6 +3364,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                     <FieldValueSelectionFilter
                                       config={
                                         Object {
+                                          "compressed": undefined,
                                           "field": "category",
                                           "multiSelect": "or",
                                           "name": "Log type",
@@ -3469,6 +3494,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                     <FieldValueSelectionFilter
                                       config={
                                         Object {
+                                          "compressed": undefined,
                                           "field": "level",
                                           "multiSelect": "or",
                                           "name": "Rule severity",
@@ -3644,6 +3670,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                     <FieldValueSelectionFilter
                                       config={
                                         Object {
+                                          "compressed": undefined,
                                           "field": "source",
                                           "multiSelect": "or",
                                           "name": "Source",

--- a/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
@@ -2068,6 +2068,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
+                                        "compressed": undefined,
                                         "field": "category",
                                         "multiSelect": "or",
                                         "name": "Log type",
@@ -2197,6 +2198,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
+                                        "compressed": undefined,
                                         "field": "level",
                                         "multiSelect": "or",
                                         "name": "Rule severity",
@@ -2372,6 +2374,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
+                                        "compressed": undefined,
                                         "field": "source",
                                         "multiSelect": "or",
                                         "name": "Source",

--- a/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
@@ -404,12 +404,12 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
     <ContentPanel
       actions={
         Array [
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="edit-detector-basic-details"
             onClick={[MockFunction]}
           >
             Edit
-          </EuiButton>,
+          </EuiSmallButton>,
         ]
       }
       title="Detector details"
@@ -483,53 +483,60 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                         <div
                           className="euiFlexItem"
                         >
-                          <EuiButton
+                          <EuiSmallButton
                             data-test-subj="edit-detector-basic-details"
                             onClick={[MockFunction]}
                           >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
+                            <EuiButton
                               data-test-subj="edit-detector-basic-details"
-                              disabled={false}
-                              element="button"
-                              isDisabled={false}
                               onClick={[MockFunction]}
-                              type="button"
+                              size="s"
                             >
-                              <button
-                                className="euiButton euiButton--primary"
+                              <EuiButtonDisplay
+                                baseClassName="euiButton"
                                 data-test-subj="edit-detector-basic-details"
                                 disabled={false}
+                                element="button"
+                                isDisabled={false}
                                 onClick={[MockFunction]}
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                  }
-                                }
+                                size="s"
                                 type="button"
                               >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="left"
-                                  textProps={
+                                <button
+                                  className="euiButton euiButton--primary euiButton--small"
+                                  data-test-subj="edit-detector-basic-details"
+                                  disabled={false}
+                                  onClick={[MockFunction]}
+                                  style={
                                     Object {
-                                      "className": "euiButton__text",
+                                      "minWidth": undefined,
                                     }
                                   }
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButton__content"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButton__text"
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      Edit
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Edit
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonDisplay>
-                          </EuiButton>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </EuiSmallButton>
                         </div>
                       </EuiFlexItem>
                     </div>
@@ -572,9 +579,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -582,7 +589,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -623,7 +630,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -633,9 +640,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -643,7 +650,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -684,7 +691,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -694,9 +701,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -704,7 +711,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -745,7 +752,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
               </div>
@@ -770,9 +777,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -780,7 +787,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -829,7 +836,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -839,9 +846,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -849,7 +856,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -890,7 +897,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -900,9 +907,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -910,7 +917,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -951,7 +958,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
               </div>
@@ -976,9 +983,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -986,7 +993,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -1027,7 +1034,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -1037,9 +1044,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -1047,7 +1054,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -1088,7 +1095,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -1098,9 +1105,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <div
                     className="euiFlexItem"
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -1108,7 +1115,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow euiFormRow--fullWidth"
+                        className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -1149,7 +1156,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           </EuiText>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
               </div>
@@ -1161,9 +1168,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                 className="euiSpacer euiSpacer--l"
               />
             </EuiSpacer>
-            <EuiFormRow
+            <EuiCompressedFormRow
               describedByIds={Array []}
-              display="row"
+              display="rowCompressed"
               fullWidth={true}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
@@ -1171,7 +1178,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
               labelType="label"
             >
               <div
-                className="euiFormRow euiFormRow--fullWidth"
+                className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -1212,7 +1219,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   </EuiText>
                 </div>
               </div>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer
               size="l"
             >
@@ -1443,12 +1450,12 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
     <ContentPanel
       actions={
         Array [
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="edit-detector-rules"
             onClick={[Function]}
           >
             Edit
-          </EuiButton>,
+          </EuiSmallButton>,
         ]
       }
       title="Active rules (2)"
@@ -1522,53 +1529,60 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                         <div
                           className="euiFlexItem"
                         >
-                          <EuiButton
+                          <EuiSmallButton
                             data-test-subj="edit-detector-rules"
                             onClick={[Function]}
                           >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
+                            <EuiButton
                               data-test-subj="edit-detector-rules"
-                              disabled={false}
-                              element="button"
-                              isDisabled={false}
                               onClick={[Function]}
-                              type="button"
+                              size="s"
                             >
-                              <button
-                                className="euiButton euiButton--primary"
+                              <EuiButtonDisplay
+                                baseClassName="euiButton"
                                 data-test-subj="edit-detector-rules"
                                 disabled={false}
+                                element="button"
+                                isDisabled={false}
                                 onClick={[Function]}
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                  }
-                                }
+                                size="s"
                                 type="button"
                               >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="left"
-                                  textProps={
+                                <button
+                                  className="euiButton euiButton--primary euiButton--small"
+                                  data-test-subj="edit-detector-rules"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  style={
                                     Object {
-                                      "className": "euiButton__text",
+                                      "minWidth": undefined,
                                     }
                                   }
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButton__content"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButton__text"
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      Edit
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Edit
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonDisplay>
-                          </EuiButton>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </EuiSmallButton>
                         </div>
                       </EuiFlexItem>
                     </div>

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
   EuiBasicTableColumn,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiEmptyPrompt,
@@ -231,17 +231,17 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
     } = this.state;
 
     const actions = [
-      <EuiButton
+      <EuiSmallButton
         iconType={'refresh'}
         onClick={this.getDetectors}
         data-test-subj={'detectorsRefreshButton'}
       >
         Refresh
-      </EuiButton>,
+      </EuiSmallButton>,
       <EuiPopover
         id={'detectorsActionsPopover'}
         button={
-          <EuiButton
+          <EuiSmallButton
             isLoading={loadingDetectors}
             iconType={'arrowDown'}
             iconSide={'right'}
@@ -250,7 +250,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
             data-test-subj={'detectorsActionsButton'}
           >
             Actions
-          </EuiButton>
+          </EuiSmallButton>
         }
         isOpen={isPopoverOpen}
         closePopover={this.closeActionsPopover}
@@ -260,13 +260,13 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
       >
         <EuiContextMenuPanel items={this.getActionItems(loadingDetectors, selectedItems)} />
       </EuiPopover>,
-      <EuiButton
+      <EuiSmallButton
         href={`${PLUGIN_NAME}#${ROUTES.DETECTORS_CREATE}`}
         fill={true}
         data-test-subj={'detectorsCreateButton'}
       >
         Create detector
-      </EuiButton>,
+      </EuiSmallButton>,
     ];
 
     const columns: EuiBasicTableColumn<DetectorHit>[] = [

--- a/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
@@ -41,19 +41,19 @@ exports[`<Detectors /> spec renders the component 1`] = `
         appRightControls={
           Array [
             Object {
-              "renderComponent": <EuiButton
+              "renderComponent": <EuiSmallButton
                 data-test-subj="detectorsRefreshButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 Refresh
-              </EuiButton>,
+              </EuiSmallButton>,
             },
             Object {
               "renderComponent": <EuiPopover
                 anchorPosition="downLeft"
                 button={
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj="detectorsActionsButton"
                     disabled={true}
                     iconSide="right"
@@ -62,7 +62,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                     onClick={[Function]}
                   >
                     Actions
-                  </EuiButton>
+                  </EuiSmallButton>
                 }
                 closePopover={[Function]}
                 data-test-subj="detectorsActionsPopover"
@@ -91,13 +91,13 @@ exports[`<Detectors /> spec renders the component 1`] = `
               </EuiPopover>,
             },
             Object {
-              "renderComponent": <EuiButton
+              "renderComponent": <EuiSmallButton
                 data-test-subj="detectorsCreateButton"
                 fill={true}
                 href="opensearch_security_analytics_dashboards#/create-detector"
               >
                 Create detector
-              </EuiButton>,
+              </EuiSmallButton>,
             },
           ]
         }
@@ -142,64 +142,72 @@ exports[`<Detectors /> spec renders the component 1`] = `
                           <div
                             className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="detectorsRefreshButton"
                               iconType="refresh"
                               onClick={[Function]}
                             >
-                              <EuiButtonDisplay
-                                baseClassName="euiButton"
+                              <EuiButton
                                 data-test-subj="detectorsRefreshButton"
-                                disabled={false}
-                                element="button"
                                 iconType="refresh"
-                                isDisabled={false}
                                 onClick={[Function]}
-                                type="button"
+                                size="s"
                               >
-                                <button
-                                  className="euiButton euiButton--primary"
+                                <EuiButtonDisplay
+                                  baseClassName="euiButton"
                                   data-test-subj="detectorsRefreshButton"
                                   disabled={false}
+                                  element="button"
+                                  iconType="refresh"
+                                  isDisabled={false}
                                   onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                  size="s"
                                   type="button"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    iconType="refresh"
-                                    textProps={
+                                  <button
+                                    className="euiButton euiButton--primary euiButton--small"
+                                    data-test-subj="detectorsRefreshButton"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    style={
                                       Object {
-                                        "className": "euiButton__text",
+                                        "minWidth": undefined,
                                       }
                                     }
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      iconType="refresh"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text",
+                                        }
+                                      }
                                     >
-                                      <EuiIcon
-                                        className="euiButtonContent__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="refresh"
-                                      >
-                                        EuiIconMock
-                                      </EuiIcon>
                                       <span
-                                        className="euiButton__text"
+                                        className="euiButtonContent euiButton__content"
                                       >
-                                        Refresh
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="refresh"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Refresh
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonDisplay>
-                            </EuiButton>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonDisplay>
+                              </EuiButton>
+                            </EuiSmallButton>
                           </div>
                         </EuiFlexItem>
                         <EuiFlexItem
@@ -212,7 +220,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                             <EuiPopover
                               anchorPosition="downLeft"
                               button={
-                                <EuiButton
+                                <EuiSmallButton
                                   data-test-subj="detectorsActionsButton"
                                   disabled={true}
                                   iconSide="right"
@@ -221,7 +229,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   onClick={[Function]}
                                 >
                                   Actions
-                                </EuiButton>
+                                </EuiSmallButton>
                               }
                               closePopover={[Function]}
                               data-test-subj="detectorsActionsPopover"
@@ -240,7 +248,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                 <div
                                   className="euiPopover__anchor"
                                 >
-                                  <EuiButton
+                                  <EuiSmallButton
                                     data-test-subj="detectorsActionsButton"
                                     disabled={true}
                                     iconSide="right"
@@ -248,62 +256,73 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                     isLoading={false}
                                     onClick={[Function]}
                                   >
-                                    <EuiButtonDisplay
-                                      baseClassName="euiButton"
+                                    <EuiButton
                                       data-test-subj="detectorsActionsButton"
                                       disabled={true}
-                                      element="button"
                                       iconSide="right"
                                       iconType="arrowDown"
-                                      isDisabled={true}
                                       isLoading={false}
                                       onClick={[Function]}
-                                      type="button"
+                                      size="s"
                                     >
-                                      <button
-                                        className="euiButton euiButton--primary euiButton-isDisabled"
+                                      <EuiButtonDisplay
+                                        baseClassName="euiButton"
                                         data-test-subj="detectorsActionsButton"
                                         disabled={true}
+                                        element="button"
+                                        iconSide="right"
+                                        iconType="arrowDown"
+                                        isDisabled={true}
+                                        isLoading={false}
                                         onClick={[Function]}
-                                        style={
-                                          Object {
-                                            "minWidth": undefined,
-                                          }
-                                        }
+                                        size="s"
                                         type="button"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButton__content"
-                                          iconSide="right"
-                                          iconType="arrowDown"
-                                          isLoading={false}
-                                          textProps={
+                                        <button
+                                          className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
+                                          data-test-subj="detectorsActionsButton"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          style={
                                             Object {
-                                              "className": "euiButton__text",
+                                              "minWidth": undefined,
                                             }
                                           }
+                                          type="button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                                          <EuiButtonContent
+                                            className="euiButton__content"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isLoading={false}
+                                            textProps={
+                                              Object {
+                                                "className": "euiButton__text",
+                                              }
+                                            }
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="m"
-                                              type="arrowDown"
-                                            >
-                                              EuiIconMock
-                                            </EuiIcon>
                                             <span
-                                              className="euiButton__text"
+                                              className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                                             >
-                                              Actions
+                                              <EuiIcon
+                                                className="euiButtonContent__icon"
+                                                color="inherit"
+                                                size="m"
+                                                type="arrowDown"
+                                              >
+                                                EuiIconMock
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButton__text"
+                                              >
+                                                Actions
+                                              </span>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonDisplay>
-                                  </EuiButton>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonDisplay>
+                                    </EuiButton>
+                                  </EuiSmallButton>
                                 </div>
                               </div>
                             </EuiPopover>
@@ -316,54 +335,62 @@ exports[`<Detectors /> spec renders the component 1`] = `
                           <div
                             className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="detectorsCreateButton"
                               fill={true}
                               href="opensearch_security_analytics_dashboards#/create-detector"
                             >
-                              <EuiButtonDisplay
-                                baseClassName="euiButton"
+                              <EuiButton
                                 data-test-subj="detectorsCreateButton"
-                                element="a"
                                 fill={true}
                                 href="opensearch_security_analytics_dashboards#/create-detector"
-                                isDisabled={false}
-                                rel="noreferrer"
+                                size="s"
                               >
-                                <a
-                                  className="euiButton euiButton--primary euiButton--fill"
+                                <EuiButtonDisplay
+                                  baseClassName="euiButton"
                                   data-test-subj="detectorsCreateButton"
-                                  disabled={false}
+                                  element="a"
+                                  fill={true}
                                   href="opensearch_security_analytics_dashboards#/create-detector"
+                                  isDisabled={false}
                                   rel="noreferrer"
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                  size="s"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
+                                  <a
+                                    className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                                    data-test-subj="detectorsCreateButton"
+                                    disabled={false}
+                                    href="opensearch_security_analytics_dashboards#/create-detector"
+                                    rel="noreferrer"
+                                    style={
                                       Object {
-                                        "className": "euiButton__text",
+                                        "minWidth": undefined,
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButton__text"
+                                        className="euiButtonContent euiButton__content"
                                       >
-                                        Create detector
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Create detector
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </a>
-                              </EuiButtonDisplay>
-                            </EuiButton>
+                                    </EuiButtonContent>
+                                  </a>
+                                </EuiButtonDisplay>
+                              </EuiButton>
+                            </EuiSmallButton>
                           </div>
                         </EuiFlexItem>
                       </div>
@@ -901,6 +928,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
+                                        "compressed": undefined,
                                         "field": "status",
                                         "multiSelect": "or",
                                         "name": "Status",
@@ -1035,6 +1063,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
+                                        "compressed": undefined,
                                         "field": "logType",
                                         "multiSelect": "or",
                                         "name": "Log type",

--- a/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
+++ b/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
@@ -8,7 +8,7 @@ import { CorrelationFinding, FindingItemType } from '../../../../../types';
 import { ruleTypes } from '../../../Rules/utils/constants';
 import { DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -232,12 +232,12 @@ export const CorrelationsTable: React.FC<CorrelationsTableProps> = ({
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => goToCorrelationsPage()}
             disabled={correlatedFindings.length === 0}
           >
             View correlations graph
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexGroup>

--- a/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
+++ b/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.tsx
@@ -9,7 +9,7 @@ import { ruleTypes } from '../../../Rules/utils/constants';
 import { DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
@@ -98,7 +98,7 @@ export const CorrelationsTable: React.FC<CorrelationsTableProps> = ({
   const actions = [
     {
       render: (item: CorrelationFinding) => (
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           onClick={() => toggleCorrelationDetails(item)}
           aria-label={itemIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
           iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
@@ -127,7 +127,7 @@ export const CorrelationsTable: React.FC<CorrelationsTableProps> = ({
       render: (item: CorrelationFinding) => (
         <EuiPopover
           button={
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               onClick={() => copyFindingIdToClipboard(item.id)}
               aria-label="Copy"
               iconType="copy"

--- a/public/pages/Findings/components/CreateAlertFlyout.tsx
+++ b/public/pages/Findings/components/CreateAlertFlyout.tsx
@@ -12,7 +12,7 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -146,10 +146,10 @@ export default class CreateAlertFlyout extends Component<
         </EuiFlyoutHeader>
 
         <EuiFlyoutBody>
-          <EuiFormRow label={'Detector'}>
+          <EuiCompressedFormRow label={'Detector'}>
             {/*//TODO: Refactor EuiText to EuiLink once detector edit page is available, and hyperlink to that page.*/}
             <EuiText>{name || DEFAULT_EMPTY_DATA}</EuiText>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer size={'m'} />
           <AlertConditionPanel

--- a/public/pages/Findings/components/CreateAlertFlyout.tsx
+++ b/public/pages/Findings/components/CreateAlertFlyout.tsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -166,20 +166,20 @@ export default class CreateAlertFlyout extends Component<
 
           <EuiFlexGroup justifyContent={'flexEnd'}>
             <EuiFlexItem grow={false}>
-              <EuiButton disabled={submitting} onClick={() => closeFlyout()}>
+              <EuiSmallButton disabled={submitting} onClick={() => closeFlyout()}>
                 Cancel
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 disabled={submitting || !isTriggerDataValid}
                 fill={true}
                 isLoading={submitting}
                 onClick={this.onCreate}
               >
                 Create alert trigger
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlyoutBody>

--- a/public/pages/Findings/components/CreateIndexPatternForm.tsx
+++ b/public/pages/Findings/components/CreateIndexPatternForm.tsx
@@ -8,7 +8,7 @@ import { Formik, Form, FormikErrors } from 'formik';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiSmallButton,
   EuiSpacer,
@@ -134,7 +134,7 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
             an index pattern to continue.
           </EuiText>
           <EuiSpacer />
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={
               <EuiText size={'s'}>
                 <strong>Specify index pattern name</strong>
@@ -156,9 +156,9 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
               onBlur={props.handleBlur('name')}
               value={props.values.name}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={
               <EuiText size={'s'}>
                 <strong>Time filed</strong>
@@ -183,7 +183,7 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
                   : []
               }
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer />
 

--- a/public/pages/Findings/components/CreateIndexPatternForm.tsx
+++ b/public/pages/Findings/components/CreateIndexPatternForm.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexItem,
   EuiFormRow,
   EuiFieldText,
-  EuiButton,
+  EuiSmallButton,
   EuiSpacer,
   EuiComboBox,
   EuiText,
@@ -83,14 +83,14 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
       <EuiSpacer />
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             onClick={() => {
               created(createdIndex?.id || '');
             }}
           >
             View surrounding documents
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>
@@ -189,17 +189,17 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
 
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={() => close()}>Cancel</EuiButton>
+              <EuiSmallButton onClick={() => close()}>Cancel</EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj={'index_pattern_form_submit_button'}
                 isLoading={props.isSubmitting}
                 fill
                 onClick={() => props.handleSubmit()}
               >
                 Create index pattern
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </Form>

--- a/public/pages/Findings/components/CreateIndexPatternForm.tsx
+++ b/public/pages/Findings/components/CreateIndexPatternForm.tsx
@@ -12,7 +12,7 @@ import {
   EuiCompressedFieldText,
   EuiSmallButton,
   EuiSpacer,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiText,
   EuiCallOut,
 } from '@elastic/eui';
@@ -167,7 +167,7 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
             isInvalid={props.touched.timeField && !!props.errors?.timeField}
             error={props.errors.timeField}
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               isInvalid={props.touched.timeField && !!props.errors.timeField}
               placeholder="Select a time field"
               data-test-subj={'index_pattern_time_field_dropdown'}

--- a/public/pages/Findings/components/CreateIndexPatternForm.tsx
+++ b/public/pages/Findings/components/CreateIndexPatternForm.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSmallButton,
   EuiSpacer,
   EuiComboBox,
@@ -143,7 +143,7 @@ export const CreateIndexPatternForm: React.FC<CreateIndexPatternFormProps> = ({
             isInvalid={props.touched.name && !!props.errors?.name}
             error={props.errors.name}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               isInvalid={props.touched.name && !!props.errors.name}
               placeholder="Enter index pattern name"
               data-test-subj={'index_pattern_name_field'}

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -8,7 +8,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiBadgeGroup,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -412,7 +412,7 @@ export default class FindingDetailsFlyout extends Component<
       {
         render: ({ id }: FindingDocumentItem) => (
           <EuiToolTip content="View surrounding documents">
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               disabled={loadingIndexPatternId}
               iconType={'inspect'}
               data-test-subj={'finding-details-flyout-view-surrounding-documents'}
@@ -433,7 +433,7 @@ export default class FindingDetailsFlyout extends Component<
       {
         name: '',
         render: (item: FindingDocumentItem) => (
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             onClick={() => this.toggleDocumentDetails(item)}
             aria-label={docIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
             iconType={docIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
@@ -656,7 +656,7 @@ export default class FindingDetailsFlyout extends Component<
               </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label="close"
                 iconType="cross"
                 display="empty"

--- a/public/pages/Findings/components/FindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/FindingDetailsFlyout.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiHorizontalRule,
   EuiLink,
   EuiModal,
@@ -270,47 +270,47 @@ export default class FindingDetailsFlyout extends Component<
             <EuiPanel color="subdued">
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiFormRow label={'Rule name'}>
+                  <EuiCompressedFormRow label={'Rule name'}>
                     <EuiLink
                       onClick={() => this.showRuleDetails(fullRule, rule.id)}
                       data-test-subj={`finding-details-flyout-${fullRule.title}-details`}
                     >
                       {fullRule.title || DEFAULT_EMPTY_DATA}
                     </EuiLink>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
 
                 <EuiFlexItem>
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={'Rule severity'}
                     data-test-subj={'finding-details-flyout-rule-severity'}
                   >
                     <EuiText>{severity || DEFAULT_EMPTY_DATA}</EuiText>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
 
                 <EuiFlexItem>
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={'Log type'}
                     data-test-subj={'finding-details-flyout-rule-category'}
                   >
                     <EuiText>{getLogTypeLabel(fullRule.category) || DEFAULT_EMPTY_DATA}</EuiText>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
               </EuiFlexGroup>
 
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={'Description'}
                 data-test-subj={'finding-details-flyout-rule-description'}
               >
                 <EuiText>{fullRule.description || DEFAULT_EMPTY_DATA}</EuiText>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
 
               <EuiSpacer size={'m'} />
 
-              <EuiFormRow label={'Tags'} data-test-subj={'finding-details-flyout-rule-tags'}>
+              <EuiCompressedFormRow label={'Tags'} data-test-subj={'finding-details-flyout-rule-tags'}>
                 <EuiText>{this.renderTags(rule.tags) || DEFAULT_EMPTY_DATA}</EuiText>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiPanel>
           </EuiAccordion>
           {rules.length > 1 && <EuiHorizontalRule margin={'xs'} />}
@@ -345,7 +345,7 @@ export default class FindingDetailsFlyout extends Component<
     }
 
     return (
-      <EuiFormRow fullWidth={true} style={{ width: '100%' }}>
+      <EuiCompressedFormRow fullWidth={true} style={{ width: '100%' }}>
         <EuiCodeBlock
           language="json"
           isCopyable
@@ -353,7 +353,7 @@ export default class FindingDetailsFlyout extends Component<
         >
           {formattedDocument}
         </EuiCodeBlock>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 
@@ -459,9 +459,9 @@ export default class FindingDetailsFlyout extends Component<
           <h3>Documents ({relatedDocuments.length})</h3>
         </EuiTitle>
         <EuiSpacer />
-        <EuiFormRow label={'Index'} data-test-subj={`finding-details-flyout-rule-document-index`}>
+        <EuiCompressedFormRow label={'Index'} data-test-subj={`finding-details-flyout-rule-document-index`}>
           <EuiText size="s">{index || DEFAULT_EMPTY_DATA}</EuiText>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
         <EuiInMemoryTable
           columns={documentsColumns}
@@ -670,29 +670,29 @@ export default class FindingDetailsFlyout extends Component<
         <EuiFlyoutBody>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiFormRow label={'Finding ID'}>
+              <EuiCompressedFormRow label={'Finding ID'}>
                 <EuiText data-test-subj={'finding-details-flyout-finding-id'}>
                   {id || DEFAULT_EMPTY_DATA}
                 </EuiText>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
 
             <EuiFlexItem>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={'Finding time'}
                 data-test-subj={'finding-details-flyout-timestamp'}
               >
                 <EuiText>{renderTime(timestamp) || DEFAULT_EMPTY_DATA}</EuiText>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
 
             <EuiFlexItem>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label={'Detection type'}
                 data-test-subj={'finding-details-flyout-detection-type'}
               >
                 <EuiText>{detectionType}</EuiText>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
 

--- a/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
@@ -8,7 +8,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import moment from 'moment';
 import {
   EuiBasicTableColumn,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiInMemoryTable,
   EuiLink,
   EuiToolTip,
@@ -228,7 +228,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
           {
             render: (finding) => (
               <EuiToolTip content={'View details'}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label={'View details'}
                   data-test-subj={`view-details-icon`}
                   iconType={'inspect'}
@@ -242,7 +242,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
           {
             render: (finding) => (
               <EuiToolTip content={'Create alert'}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label={'Create alert'}
                   iconType={'bell'}
                   onClick={() => this.renderCreateAlertFlyout(finding)}

--- a/public/pages/Findings/components/FindingsTable/ThreatIntelFindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/ThreatIntelFindingsTable.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiButtonIcon, EuiInMemoryTable, EuiToolTip } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButtonIcon, EuiInMemoryTable, EuiToolTip } from '@elastic/eui';
 import { ThreatIntelFinding } from '../../../../../types';
 import React from 'react';
 import { renderTime } from '../../../../utils/helpers';
@@ -46,7 +46,7 @@ export const ThreatIntelFindingsTable: React.FC<ThreatIntelFindingsTableProps> =
         {
           render: (finding) => (
             <EuiToolTip content={'View details'}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label={'View details'}
                 data-test-subj={`view-details-icon`}
                 iconType={'inspect'}

--- a/public/pages/Findings/components/ThreatIntelFindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/ThreatIntelFindingDetailsFlyout.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiInMemoryTable,
   EuiLoadingSpinner,
   EuiSpacer,
@@ -62,7 +62,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
         DataStore.documents.getDocument(item.index, item.id).then((doc) => {
           formattedDocument = doc ? JSON.stringify(JSON.parse(doc), null, 2) : '';
           onDocUpdate(
-            <EuiFormRow fullWidth={true} style={{ width: '100%' }}>
+            <EuiCompressedFormRow fullWidth={true} style={{ width: '100%' }}>
               {!formattedDocument ? (
                 <EuiEmptyPrompt body={<p>Document not found</p>} />
               ) : (
@@ -74,7 +74,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
                   {formattedDocument}
                 </EuiCodeBlock>
               )}
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           );
           this.setState({
             docIdToDocument: {
@@ -85,7 +85,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
         });
       } else {
         return (
-          <EuiFormRow fullWidth={true} style={{ width: '100%' }}>
+          <EuiCompressedFormRow fullWidth={true} style={{ width: '100%' }}>
             <EuiCodeBlock
               language="json"
               isCopyable
@@ -93,7 +93,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
             >
               {formattedDocument}
             </EuiCodeBlock>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         );
       }
     } catch {
@@ -101,7 +101,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
     }
 
     return (
-      <EuiFormRow fullWidth={true} style={{ width: '100%' }}>
+      <EuiCompressedFormRow fullWidth={true} style={{ width: '100%' }}>
         <EuiCodeBlock
           language="json"
           isCopyable
@@ -109,7 +109,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
         >
           <EuiLoadingSpinner />
         </EuiCodeBlock>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 

--- a/public/pages/Findings/components/ThreatIntelFindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/ThreatIntelFindingDetailsFlyout.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {
   EuiAccordion,
   EuiBasicTableColumn,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCodeBlock,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -156,7 +156,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
       {
         name: '',
         render: (item: ThreatIntelFindingDocumentItem) => (
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             onClick={() => this.toggleDocumentDetails(item)}
             aria-label={docIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
             iconType={docIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
@@ -223,7 +223,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
               </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label="close"
                 iconType="cross"
                 display="empty"

--- a/public/pages/LogTypes/components/DeleteLogTypeModal.tsx
+++ b/public/pages/LogTypes/components/DeleteLogTypeModal.tsx
@@ -7,7 +7,7 @@ import {
   EuiSmallButton,
   EuiCallOut,
   EuiConfirmModal,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
   EuiLoadingSpinner,
@@ -102,7 +102,7 @@ export const DeleteLogTypeModal: React.FC<DeleteLogTypeModalProps> = ({
               Type <b>{logTypeName}</b> to confirm
             </p>
             <EuiCompressedFormRow>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 value={confirmDeleteText}
                 onChange={(e) => setConfirmDeleteText(e.target.value)}
               />

--- a/public/pages/LogTypes/components/DeleteLogTypeModal.tsx
+++ b/public/pages/LogTypes/components/DeleteLogTypeModal.tsx
@@ -9,7 +9,7 @@ import {
   EuiConfirmModal,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLoadingSpinner,
   EuiModal,
   EuiModalBody,
@@ -101,12 +101,12 @@ export const DeleteLogTypeModal: React.FC<DeleteLogTypeModalProps> = ({
             <p style={{ marginBottom: '0.3rem' }}>
               Type <b>{logTypeName}</b> to confirm
             </p>
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiFieldText
                 value={confirmDeleteText}
                 onChange={(e) => setConfirmDeleteText(e.target.value)}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiConfirmModal>
       )}

--- a/public/pages/LogTypes/components/DeleteLogTypeModal.tsx
+++ b/public/pages/LogTypes/components/DeleteLogTypeModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiConfirmModal,
   EuiFieldText,
@@ -79,9 +79,9 @@ export const DeleteLogTypeModal: React.FC<DeleteLogTypeModalProps> = ({
             </p>
           </EuiModalBody>
           <EuiModalFooter>
-            <EuiButton onClick={closeModal} fill>
+            <EuiSmallButton onClick={closeModal} fill>
               Close
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       ) : (

--- a/public/pages/LogTypes/components/LogTypeDetails.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetails.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiDescriptionList } from '@elastic/eui';
+import { EuiSmallButton, EuiDescriptionList } from '@elastic/eui';
 import { ContentPanel } from '../../../components/ContentPanel';
 import React from 'react';
 import { LogTypeItem } from '../../../../types';
@@ -44,7 +44,7 @@ export const LogTypeDetails: React.FC<LogTypeDetailsProps> = ({
       actions={
         !isEditMode &&
         logTypeDetails.source.toLocaleLowerCase() !== 'standard' && [
-          <EuiButton onClick={() => setIsEditMode(true)}>Edit</EuiButton>,
+          <EuiSmallButton onClick={() => setIsEditMode(true)}>Edit</EuiSmallButton>,
         ]
       }
     >

--- a/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
@@ -8,7 +8,7 @@ import {
   EuiButton,
   EuiDescriptionList,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSpacer,
   EuiTextArea,
   EuiBottomBar,
@@ -56,7 +56,7 @@ export const LogTypeDetailsTab: React.FC<LogTypeDetailsTabProps> = ({
             description: (
               <>
                 <EuiCompressedFormRow label="Name">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     value={logTypeDetails?.name}
                     onChange={(e) =>
                       setLogTypeDetails({

--- a/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+  EuiSmallButton,
   EuiButton,
   EuiDescriptionList,
   EuiFormRow,
@@ -45,7 +46,7 @@ export const LogTypeDetailsTab: React.FC<LogTypeDetailsTabProps> = ({
   return (
     <ContentPanel
       title="Details"
-      actions={!isEditMode && [<EuiButton onClick={() => setIsEditMode(true)}>Edit</EuiButton>]}
+      actions={!isEditMode && [<EuiSmallButton onClick={() => setIsEditMode(true)}>Edit</EuiSmallButton>]}
     >
       <EuiDescriptionList
         type="column"

--- a/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
@@ -7,7 +7,7 @@ import {
   EuiSmallButton,
   EuiButton,
   EuiDescriptionList,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiSpacer,
   EuiTextArea,
@@ -55,7 +55,7 @@ export const LogTypeDetailsTab: React.FC<LogTypeDetailsTabProps> = ({
             title: 'Log type',
             description: (
               <>
-                <EuiFormRow label="Name">
+                <EuiCompressedFormRow label="Name">
                   <EuiFieldText
                     value={logTypeDetails?.name}
                     onChange={(e) =>
@@ -67,9 +67,9 @@ export const LogTypeDetailsTab: React.FC<LogTypeDetailsTabProps> = ({
                     placeholder="Enter name for log type"
                     disabled={!isEditMode || !!logTypeDetails.detectionRulesCount}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 <EuiSpacer />
-                <EuiFormRow label="Description">
+                <EuiCompressedFormRow label="Description">
                   <EuiTextArea
                     value={logTypeDetails?.description}
                     onChange={(e) =>
@@ -81,7 +81,7 @@ export const LogTypeDetailsTab: React.FC<LogTypeDetailsTabProps> = ({
                     placeholder="Description of the log type"
                     disabled={!isEditMode}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 {isEditMode ? (
                   <EuiBottomBar>
                     <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">

--- a/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetailsTab.tsx
@@ -10,7 +10,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiSpacer,
-  EuiTextArea,
+  EuiCompressedTextArea,
   EuiBottomBar,
   EuiFlexGroup,
   EuiFlexItem,
@@ -70,7 +70,7 @@ export const LogTypeDetailsTab: React.FC<LogTypeDetailsTabProps> = ({
                 </EuiCompressedFormRow>
                 <EuiSpacer />
                 <EuiCompressedFormRow label="Description">
-                  <EuiTextArea
+                  <EuiCompressedTextArea
                     value={logTypeDetails?.description}
                     onChange={(e) =>
                       setLogTypeDetails({

--- a/public/pages/LogTypes/components/LogTypeDetectionRules.tsx
+++ b/public/pages/LogTypes/components/LogTypeDetectionRules.tsx
@@ -7,7 +7,7 @@ import React, { useState, useCallback } from 'react';
 import { RulesTable } from '../../Rules/components/RulesTable/RulesTable';
 import { RuleTableItem } from '../../Rules/utils/helpers';
 import { ContentPanel } from '../../../components/ContentPanel';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
 import { RuleViewerFlyout } from '../../Rules/components/RuleViewerFlyout/RuleViewerFlyout';
 
 export interface LogTypeDetectionRulesProps {
@@ -32,7 +32,7 @@ export const LogTypeDetectionRules: React.FC<LogTypeDetectionRulesProps> = ({
       <ContentPanel
         title="Detection rules"
         hideHeaderBorder={true}
-        actions={[<EuiButton onClick={refreshRules}>Refresh</EuiButton>]}
+        actions={[<EuiSmallButton onClick={refreshRules}>Refresh</EuiSmallButton>]}
       >
         {rules.length === 0 ? (
           <EuiFlexGroup justifyContent="center" alignItems="center" direction="column">
@@ -42,14 +42,14 @@ export const LogTypeDetectionRules: React.FC<LogTypeDetectionRulesProps> = ({
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 fill
                 href={`opensearch_security_analytics_dashboards#/create-rule`}
                 target="_blank"
               >
                 Create detection rule&nbsp;
                 <EuiIcon type={'popout'} />
-              </EuiButton>
+              </EuiSmallButton>
               <EuiSpacer size="xl" />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/LogTypes/components/LogTypeForm.tsx
+++ b/public/pages/LogTypes/components/LogTypeForm.tsx
@@ -10,7 +10,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiSuperSelect,
   EuiTextArea,
@@ -70,7 +70,7 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
 
   return (
     <>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Name"
         helpText={
           isEditMode &&
@@ -92,9 +92,9 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
           readOnly={!isEditMode}
           disabled={isEditMode && !!logTypeDetails.detectionRulesCount}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={
           <>
             {'Description - '}
@@ -115,9 +115,9 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
           placeholder="Description of the log type"
           readOnly={!isEditMode}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
-      <EuiFormRow label="Category" isInvalid={!!categoryError} error={categoryError}>
+      <EuiCompressedFormRow label="Category" isInvalid={!!categoryError} error={categoryError}>
         <EuiSuperSelect
           options={getLogTypeCategoryOptions().map((option) => ({
             ...option,
@@ -136,7 +136,7 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
           hasDividers
           itemLayoutAlign="top"
         ></EuiSuperSelect>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       {isEditMode ? (
         <EuiBottomBar>
           <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">

--- a/public/pages/LogTypes/components/LogTypeForm.tsx
+++ b/public/pages/LogTypes/components/LogTypeForm.tsx
@@ -7,7 +7,7 @@ import {
   EuiBottomBar,
   EuiButton,
   EuiButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -79,7 +79,7 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
         isInvalid={!!nameError}
         error={nameError}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           value={logTypeDetails?.name}
           onChange={(e) => {
             const newLogType = {

--- a/public/pages/LogTypes/components/LogTypeForm.tsx
+++ b/public/pages/LogTypes/components/LogTypeForm.tsx
@@ -13,7 +13,7 @@ import {
   EuiCompressedFormRow,
   EuiSpacer,
   EuiCompressedSuperSelect,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import { LogTypeItem } from '../../../../types';
 import React from 'react';
@@ -102,7 +102,7 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
           </>
         }
       >
-        <EuiTextArea
+        <EuiCompressedTextArea
           value={logTypeDetails?.description}
           onChange={(e) => {
             const newLogType = {

--- a/public/pages/LogTypes/components/LogTypeForm.tsx
+++ b/public/pages/LogTypes/components/LogTypeForm.tsx
@@ -12,7 +12,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiSpacer,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiTextArea,
 } from '@elastic/eui';
 import { LogTypeItem } from '../../../../types';
@@ -118,7 +118,7 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
       </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiCompressedFormRow label="Category" isInvalid={!!categoryError} error={categoryError}>
-        <EuiSuperSelect
+        <EuiCompressedSuperSelect
           options={getLogTypeCategoryOptions().map((option) => ({
             ...option,
             disabled: !isEditMode || (isEditMode && !!logTypeDetails.detectionRulesCount),
@@ -135,7 +135,7 @@ export const LogTypeForm: React.FC<LogTypeFormProps> = ({
           }}
           hasDividers
           itemLayoutAlign="top"
-        ></EuiSuperSelect>
+        ></EuiCompressedSuperSelect>
       </EuiCompressedFormRow>
       {isEditMode ? (
         <EuiBottomBar>

--- a/public/pages/LogTypes/containers/LogType.tsx
+++ b/public/pages/LogTypes/containers/LogType.tsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react';
 import { RouteComponentProps, useParams } from 'react-router-dom';
 import { LogTypeItem } from '../../../../types';
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiDescriptionList,
   EuiFlexGroup,
   EuiFlexItem,
@@ -143,7 +143,7 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
 
   const deleteAction = (
     <EuiToolTip content="Delete" position="bottom">
-      <EuiButtonIcon iconType={'trash'} color="danger" onClick={() => setShowDeleteModal(true)} />
+      <EuiSmallButtonIcon iconType={'trash'} color="danger" onClick={() => setShowDeleteModal(true)} />
     </EuiToolTip>
   );
 

--- a/public/pages/LogTypes/containers/LogTypes.tsx
+++ b/public/pages/LogTypes/containers/LogTypes.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiInMemoryTable,
@@ -69,9 +69,9 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, data
   };
 
   const createLogTypeAction = (
-    <EuiButton fill={true} onClick={() => history.push(ROUTES.LOG_TYPES_CREATE)}>
+    <EuiSmallButton fill={true} onClick={() => history.push(ROUTES.LOG_TYPES_CREATE)}>
       Create log type
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   return (

--- a/public/pages/LogTypes/utils/helpers.tsx
+++ b/public/pages/LogTypes/utils/helpers.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiButtonIcon, EuiLink, EuiToolTip } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiLink, EuiToolTip } from '@elastic/eui';
 import { LogType } from '../../../../types';
 import { capitalize, startCase } from 'lodash';
 import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
@@ -46,7 +46,7 @@ export const getLogTypesTableColumns = (
         render: (item: LogType) => {
           return (
             <EuiToolTip content="Delete">
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label={'Delete log type'}
                 iconType={'trash'}
                 color="danger"

--- a/public/pages/Main/components/Callout.tsx
+++ b/public/pages/Main/components/Callout.tsx
@@ -9,7 +9,7 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiLoadingSpinner,
 } from '@elastic/eui';
 
@@ -78,7 +78,7 @@ export const CallOut = ({
         <EuiFlexItem grow={false}>{title}</EuiFlexItem>
         {closable && (
           <EuiFlexItem className={'mainCalloutCloseButton'}>
-            <EuiButtonIcon onClick={() => closeCallout()} iconType="cross" aria-label="Close" />
+            <EuiSmallButtonIcon onClick={() => closeCallout()} iconType="cross" aria-label="Close" />
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/public/pages/Overview/components/GettingStarted/GetStartedStep.tsx
+++ b/public/pages/Overview/components/GettingStarted/GetStartedStep.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { MouseEventHandler } from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import { EuiButtonPropsForButton } from '@elastic/eui/src/components/button/button';
 
 interface GetStartedStepButton {
@@ -28,9 +28,9 @@ export const GetStartedStep: React.FC<GetStartedStepProps> = ({ buttons, title }
       <EuiFlexGroup gutterSize="s">
         {buttons.map((btn: GetStartedStepButton, index: number) => (
           <EuiFlexItem grow={false} key={index}>
-            <EuiButton {...btn.opts} onClick={btn.onClick}>
+            <EuiSmallButton {...btn.opts} onClick={btn.onClick}>
               {btn.text}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         ))}
       </EuiFlexGroup>

--- a/public/pages/Overview/components/Widgets/DetectorsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/DetectorsWidget.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiButton, EuiEmptyPrompt, EuiLink } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton, EuiEmptyPrompt, EuiLink } from '@elastic/eui';
 import { ROUTES } from '../../../../utils/constants';
 import React, { useCallback } from 'react';
 import { TableWidget } from './TableWidget';
@@ -81,17 +81,17 @@ export const DetectorsWidget: React.FC<DetectorsWidgetProps> = ({
           </p>
         }
         actions={[
-          <EuiButton fill={false} href={`#${ROUTES.DETECTORS_CREATE}`}>
+          <EuiSmallButton fill={false} href={`#${ROUTES.DETECTORS_CREATE}`}>
             Create detector
-          </EuiButton>,
+          </EuiSmallButton>,
         ]}
       />
     ) : undefined;
 
   const actions = React.useMemo(
     () => [
-      <EuiButton href={`#${ROUTES.DETECTORS}`}>View all detectors</EuiButton>,
-      <EuiButton href={`#${ROUTES.DETECTORS_CREATE}`}>Create detector</EuiButton>,
+      <EuiSmallButton href={`#${ROUTES.DETECTORS}`}>View all detectors</EuiSmallButton>,
+      <EuiSmallButton href={`#${ROUTES.DETECTORS_CREATE}`}>Create detector</EuiSmallButton>,
     ],
     []
   );

--- a/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton, EuiEmptyPrompt } from '@elastic/eui';
 import { DEFAULT_EMPTY_DATA, ROUTES, SortDirection } from '../../../../utils/constants';
 import React, { useEffect, useState } from 'react';
 import { TableWidget } from './TableWidget';
@@ -71,7 +71,7 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
   }, [items]);
 
   const actions = React.useMemo(
-    () => [<EuiButton href={`#${ROUTES.ALERTS}`}>View Alerts</EuiButton>],
+    () => [<EuiSmallButton href={`#${ROUTES.ALERTS}`}>View Alerts</EuiSmallButton>],
     []
   );
 

--- a/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton, EuiEmptyPrompt } from '@elastic/eui';
 import { ROUTES, SortDirection } from '../../../../utils/constants';
 import React, { useEffect, useState } from 'react';
 import { TableWidget } from './TableWidget';
@@ -76,7 +76,7 @@ export const RecentFindingsWidget: React.FC<RecentFindingsWidgetProps> = ({
   }, [items]);
 
   const actions = React.useMemo(
-    () => [<EuiButton href={`#${ROUTES.FINDINGS}`}>View all findings</EuiButton>],
+    () => [<EuiSmallButton href={`#${ROUTES.FINDINGS}`}>View all findings</EuiSmallButton>],
     []
   );
 

--- a/public/pages/Overview/components/Widgets/Summary.tsx
+++ b/public/pages/Overview/components/Widgets/Summary.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -173,13 +173,13 @@ export const Summary: React.FC<SummaryProps> = ({
                     Adjust the time range to see more results or create a <br />
                     detector to generate findings.
                   </p>
-                  <EuiButton
+                  <EuiSmallButton
                     href={`${PLUGIN_NAME}#${ROUTES.DETECTORS_CREATE}`}
                     fill={true}
                     data-test-subj={'detectorsCreateButton'}
                   >
                     Create a detector
-                  </EuiButton>
+                  </EuiSmallButton>
                 </>
               }
             />

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -12,7 +12,7 @@ import {
   EuiSuperDatePicker,
   EuiTitle,
   EuiSpacer,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import {
@@ -204,13 +204,13 @@ export const Overview: React.FC<OverviewProps> = (props) => {
   );
 
   const createDetectorAction = (
-    <EuiButton
+    <EuiSmallButton
       href={`${PLUGIN_NAME}#${ROUTES.DETECTORS_CREATE}`}
       fill={true}
       data-test-subj={'detectorsCreateButton'}
     >
       Create detector
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const gettingStartedBadgeControl = (

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
@@ -181,9 +181,9 @@ export const Overview: React.FC<OverviewProps> = (props) => {
   };
 
   const button = (
-    <EuiButtonEmpty iconType="cheer" onClick={onButtonClick}>
+    <EuiSmallButtonEmpty iconType="cheer" onClick={onButtonClick}>
       Getting started
-    </EuiButtonEmpty>
+    </EuiSmallButtonEmpty>
   );
 
   const datePicker = (

--- a/public/pages/Rules/components/RuleContentViewer/RuleContentViewer.tsx
+++ b/public/pages/Rules/components/RuleContentViewer/RuleContentViewer.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormLabel,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiModalBody,
   EuiSpacer,
@@ -205,17 +205,17 @@ export const RuleContentViewer: React.FC<RuleContentViewerProps> = ({
 
           <EuiSpacer />
 
-          <EuiFormRow label="Detection" fullWidth>
+          <EuiCompressedFormRow label="Detection" fullWidth>
             <EuiCodeBlock language="yaml" data-test-subj={'rule_flyout_rule_detection'}>
               {ruleData.detection}
             </EuiCodeBlock>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
       {selectedEditorType === 'yaml' && (
-        <EuiFormRow label="Rule" fullWidth>
+        <EuiCompressedFormRow label="Rule" fullWidth>
           <RuleContentYamlViewer rule={ruleData} />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </EuiModalBody>
   );

--- a/public/pages/Rules/components/RuleContentViewer/__snapshots__/RuleContentViewer.test.tsx.snap
+++ b/public/pages/Rules/components/RuleContentViewer/__snapshots__/RuleContentViewer.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`<RuleContentViewer /> spec renders the component 1`] = `
       class="euiSpacer euiSpacer--l"
     />
     <div
-      class="euiFormRow euiFormRow--fullWidth"
+      class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -8,7 +8,7 @@ import { dump, load } from 'js-yaml';
 import {
   EuiAccordion,
   EuiToolTip,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiTitle,
   EuiText,
   EuiSpacer,
@@ -525,7 +525,7 @@ export class DetectionVisualEditor extends React.Component<
                   <EuiFlexItem grow={false} className={'detection-visual-editor-delete-selection'}>
                     {selections.length > 1 && (
                       <EuiToolTip title={'Delete selection'}>
-                        <EuiButtonIcon
+                        <EuiSmallButtonIcon
                           aria-label={'Delete selection'}
                           iconType={'trash'}
                           color="danger"
@@ -567,7 +567,7 @@ export class DetectionVisualEditor extends React.Component<
                         extraAction={
                           selection.data.length > 1 ? (
                             <EuiToolTip title={'Delete map'}>
-                              <EuiButtonIcon
+                              <EuiSmallButtonIcon
                                 aria-label={'Delete map'}
                                 iconType={'trash'}
                                 color="danger"

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiComboBox,
   EuiPanel,
   EuiRadioGroup,
@@ -506,7 +506,7 @@ export class DetectionVisualEditor extends React.Component<
                       isInvalid={errors.touched.name && !!errors.fields.name}
                       error={errors.fields.name}
                     >
-                      <EuiFieldText
+                      <EuiCompressedFieldText
                         className={'detection-visual-editor-name euiTitle--small'}
                         isInvalid={errors.touched.name && !!errors.fields.name}
                         placeholder="Enter selection name"
@@ -590,7 +590,7 @@ export class DetectionVisualEditor extends React.Component<
                               error={errors.fields[fieldName]}
                               label={<EuiText size={'s'}>Key</EuiText>}
                             >
-                              <EuiFieldText
+                              <EuiCompressedFieldText
                                 isInvalid={errors.touched[fieldName] && !!errors.fields[fieldName]}
                                 placeholder="Enter key name"
                                 data-test-subj={'selection_field_key_name'}
@@ -720,7 +720,7 @@ export class DetectionVisualEditor extends React.Component<
                             isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
                             error={errors.fields[valueId]}
                           >
-                            <EuiFieldText
+                            <EuiCompressedFieldText
                               isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
                               placeholder="Value"
                               data-test-subj={'selection_field_value'}

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -20,7 +20,7 @@ import {
   EuiPanel,
   EuiRadioGroup,
   EuiTextArea,
-  EuiButton,
+  EuiSmallButton,
   EuiModal,
   EuiModalHeader,
   EuiModalHeaderTitle,
@@ -648,7 +648,7 @@ export class DetectionVisualEditor extends React.Component<
                           <>
                             <EuiFlexGroup>
                               <EuiFlexItem grow={false}>
-                                <EuiButton
+                                <EuiSmallButton
                                   iconType="download"
                                   onClick={() => {
                                     this.setState({
@@ -660,7 +660,7 @@ export class DetectionVisualEditor extends React.Component<
                                   }}
                                 >
                                   Upload file
-                                </EuiButton>
+                                </EuiSmallButton>
                                 <EuiSpacer size={'s'} />
                               </EuiFlexItem>
 
@@ -747,7 +747,7 @@ export class DetectionVisualEditor extends React.Component<
 
                 <EuiSpacer size={'m'} />
 
-                <EuiButton
+                <EuiSmallButton
                   style={{ width: '70%' }}
                   iconType="plusInCircle"
                   disabled={!selection.data.at(-1)?.field}
@@ -760,7 +760,7 @@ export class DetectionVisualEditor extends React.Component<
                   }}
                 >
                   Add map
-                </EuiButton>
+                </EuiSmallButton>
               </EuiPanel>
 
               {selections.length > 1 && selections.length !== selectionIdx ? (
@@ -772,7 +772,7 @@ export class DetectionVisualEditor extends React.Component<
 
         <EuiSpacer size={'m'} />
 
-        <EuiButton
+        <EuiSmallButton
           fullWidth
           iconType={'plusInCircle'}
           onClick={() => {
@@ -792,7 +792,7 @@ export class DetectionVisualEditor extends React.Component<
           }}
         >
           Add selection
-        </EuiButton>
+        </EuiSmallButton>
 
         <EuiSpacer />
 
@@ -878,9 +878,9 @@ export class DetectionVisualEditor extends React.Component<
             </EuiModalBody>
 
             <EuiModalFooter>
-              <EuiButton fill={true} onClick={this.closeFileUploadModal}>
+              <EuiSmallButton fill={true} onClick={this.closeFileUploadModal}>
                 Close
-              </EuiButton>
+              </EuiSmallButton>
             </EuiModalFooter>
           </EuiModal>
         )}

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -27,7 +27,7 @@ import {
   EuiModalBody,
   EuiModalFooter,
   EuiFilePicker,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiCodeEditor,
 } from '@elastic/eui';
@@ -668,7 +668,7 @@ export class DetectionVisualEditor extends React.Component<
                                 grow={true}
                                 className={'detection-visual-editor-textarea-clear-btn'}
                               >
-                                <EuiButtonEmpty
+                                <EuiSmallButtonEmpty
                                   isDisabled={!datum.values[0]}
                                   color={datum.values[0] ? 'primary' : 'ghost'}
                                   iconType={'cross'}
@@ -679,7 +679,7 @@ export class DetectionVisualEditor extends React.Component<
                                   }}
                                 >
                                   Clear list
-                                </EuiButtonEmpty>
+                                </EuiSmallButtonEmpty>
                                 <EuiSpacer size={'s'} />
                               </EuiFlexItem>
                             </EuiFlexGroup>
@@ -808,12 +808,12 @@ export class DetectionVisualEditor extends React.Component<
               <EuiText size="xs">
                 Define how each selection should be included in the final query. For more options
                 use{' '}
-                <EuiButtonEmpty
+                <EuiSmallButtonEmpty
                   className={'empty-text-button'}
                   onClick={() => this.props.goToYamlEditor('yaml')}
                 >
                   <EuiText size="s">YAML editor</EuiText>
-                </EuiButtonEmpty>
+                </EuiSmallButtonEmpty>
                 .
               </EuiText>
             </>

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiCompressedFieldText,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiPanel,
   EuiCompressedRadioGroup,
   EuiTextArea,
@@ -610,7 +610,7 @@ export class DetectionVisualEditor extends React.Component<
                           </EuiFlexItem>
                           <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
                             <EuiCompressedFormRow label={<EuiText size={'s'}>Modifier</EuiText>}>
-                              <EuiComboBox
+                              <EuiCompressedComboBox
                                 data-test-subj={'modifier_dropdown'}
                                 options={detectionModifierOptions}
                                 singleSelection={{ asPlainText: true }}

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -14,7 +14,7 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiComboBox,
   EuiPanel,
@@ -502,7 +502,7 @@ export class DetectionVisualEditor extends React.Component<
               >
                 <EuiFlexGroup alignItems="center">
                   <EuiFlexItem grow={true}>
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       isInvalid={errors.touched.name && !!errors.fields.name}
                       error={errors.fields.name}
                     >
@@ -517,7 +517,7 @@ export class DetectionVisualEditor extends React.Component<
                         onBlur={(e) => this.updateSelection(selectionIdx, { name: e.target.value })}
                         value={selection.name}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                     <EuiText size="s">
                       <p>Define the search identifier in your data the rule will be applied to.</p>
                     </EuiText>
@@ -585,7 +585,7 @@ export class DetectionVisualEditor extends React.Component<
                       >
                         <EuiFlexGroup>
                           <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
-                            <EuiFormRow
+                            <EuiCompressedFormRow
                               isInvalid={errors.touched[fieldName] && !!errors.fields[fieldName]}
                               error={errors.fields[fieldName]}
                               label={<EuiText size={'s'}>Key</EuiText>}
@@ -606,10 +606,10 @@ export class DetectionVisualEditor extends React.Component<
                                 }
                                 value={datum.field}
                               />
-                            </EuiFormRow>
+                            </EuiCompressedFormRow>
                           </EuiFlexItem>
                           <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
-                            <EuiFormRow label={<EuiText size={'s'}>Modifier</EuiText>}>
+                            <EuiCompressedFormRow label={<EuiText size={'s'}>Modifier</EuiText>}>
                               <EuiComboBox
                                 data-test-subj={'modifier_dropdown'}
                                 options={detectionModifierOptions}
@@ -626,7 +626,7 @@ export class DetectionVisualEditor extends React.Component<
                                     : [detectionModifierOptions[0]]
                                 }
                               />
-                            </EuiFormRow>
+                            </EuiCompressedFormRow>
                           </EuiFlexItem>
                         </EuiFlexGroup>
 
@@ -683,7 +683,7 @@ export class DetectionVisualEditor extends React.Component<
                                 <EuiSpacer size={'s'} />
                               </EuiFlexItem>
                             </EuiFlexGroup>
-                            <EuiFormRow
+                            <EuiCompressedFormRow
                               isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
                               error={errors.fields[valueId]}
                               className={'detection-visual-editor-form-row'}
@@ -713,10 +713,10 @@ export class DetectionVisualEditor extends React.Component<
                                 compressed={true}
                                 isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
                               />
-                            </EuiFormRow>
+                            </EuiCompressedFormRow>
                           </>
                         ) : (
-                          <EuiFormRow
+                          <EuiCompressedFormRow
                             isInvalid={errors.touched[valueId] && !!errors.fields[valueId]}
                             error={errors.fields[valueId]}
                           >
@@ -736,7 +736,7 @@ export class DetectionVisualEditor extends React.Component<
                               }}
                               value={datum.values[0]}
                             />
-                          </EuiFormRow>
+                          </EuiCompressedFormRow>
                         )}
 
                         <EuiSpacer size={'m'} />
@@ -796,7 +796,7 @@ export class DetectionVisualEditor extends React.Component<
 
         <EuiSpacer />
 
-        <EuiFormRow
+        <EuiCompressedFormRow
           isInvalid={errors.touched.condition && !!errors.fields.condition}
           error={errors.fields.condition}
           style={{ maxWidth: '100%' }}
@@ -830,7 +830,7 @@ export class DetectionVisualEditor extends React.Component<
             }}
             data-test-subj={'rule_detection_field'}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
         {fileUploadModalState && (
           <EuiModal onClose={this.closeFileUploadModal}>

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -26,7 +26,7 @@ import {
   EuiModalHeaderTitle,
   EuiModalBody,
   EuiModalFooter,
-  EuiFilePicker,
+  EuiCompressedFilePicker,
   EuiSmallButtonEmpty,
   EuiCallOut,
   EuiCodeEditor,
@@ -857,7 +857,7 @@ export class DetectionVisualEditor extends React.Component<
                   <p>Invalid file.</p>
                 </EuiText>
               )}
-              <EuiFilePicker
+              <EuiCompressedFilePicker
                 id={'filePickerId'}
                 fullWidth
                 initialPromptText="Select or drag file containing list of values"

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -18,7 +18,7 @@ import {
   EuiCompressedFieldText,
   EuiComboBox,
   EuiPanel,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiTextArea,
   EuiSmallButton,
   EuiModal,
@@ -632,7 +632,7 @@ export class DetectionVisualEditor extends React.Component<
 
                         <EuiSpacer size="m" />
 
-                        <EuiRadioGroup
+                        <EuiCompressedRadioGroup
                           options={radioGroupOptions}
                           idSelected={datum.selectedRadioId || radioGroupOptions[0].id}
                           onChange={(id) => {

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -9,7 +9,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiSmallButton,
   EuiSpacer,
@@ -269,7 +269,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
                   <EuiSpacer />
 
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={
                       <EuiText size={'s'}>
                         <strong>Rule name</strong>
@@ -289,11 +289,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       onBlur={props.handleBlur('name')}
                       value={props.values.name}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
 
                   <EuiSpacer size={'m'} />
 
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={
                       <EuiText size={'s'}>
                         <strong>Description </strong>
@@ -314,11 +314,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       value={props.values.description}
                       placeholder={'Detects ...'}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
 
                   <EuiSpacer size={'m'} />
 
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={
                       <EuiText size={'s'}>
                         <strong>Author</strong>
@@ -340,7 +340,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       onBlur={props.handleBlur('author')}
                       value={props.values.author}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
 
                   <EuiSpacer size={'xl'} />
 
@@ -354,7 +354,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
                   <EuiFlexGroup alignItems="flexStart">
                     <EuiFlexItem style={{ maxWidth: 400 }}>
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         label={
                           <EuiText size={'s'}>
                             <strong>Log type</strong>
@@ -389,7 +389,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                               : []
                           }
                         />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false} style={{ marginTop: 36 }}>
                       <EuiSmallButton
@@ -403,7 +403,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
                   <EuiSpacer />
 
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={
                       <EuiText size={'s'}>
                         <strong>Rule level (severity)</strong>
@@ -433,11 +433,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                           : []
                       }
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
 
                   <EuiSpacer />
 
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     label={
                       <EuiText size={'s'}>
                         <strong>Rule Status</strong>
@@ -464,7 +464,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                           : []
                       }
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
 
                   <EuiSpacer size={'xxl'} />
 

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSmallButton,
   EuiSpacer,
   EuiAccordion,
@@ -279,7 +279,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     error={props.errors.name}
                     helpText={detectionRuleNameError}
                   >
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       isInvalid={(validateOnMount || props.touched.name) && !!props.errors?.name}
                       placeholder="My custom rule"
                       data-test-subj={'rule_name_field'}
@@ -305,7 +305,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     }
                     error={props.errors.description}
                   >
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       data-test-subj={'rule_description_field'}
                       onChange={(e) => {
                         props.handleChange('description')(e.target.value);
@@ -328,7 +328,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     isInvalid={(validateOnMount || props.touched.author) && !!props.errors?.author}
                     error={props.errors.author}
                   >
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       isInvalid={
                         (validateOnMount || props.touched.author) && !!props.errors?.author
                       }

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexItem,
   EuiFormRow,
   EuiFieldText,
-  EuiButton,
+  EuiSmallButton,
   EuiSpacer,
   EuiAccordion,
   EuiComboBox,
@@ -392,12 +392,12 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       </EuiFormRow>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false} style={{ marginTop: 36 }}>
-                      <EuiButton
+                      <EuiSmallButton
                         href={'opensearch_security_analytics_dashboards#/log-types'}
                         target="_blank"
                       >
                         Manage <EuiIcon type={'popout'} />
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
 
@@ -611,16 +611,16 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
             <EuiFlexGroup justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={cancel}>Cancel</EuiButton>
+                <EuiSmallButton onClick={cancel}>Cancel</EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   onClick={() => props.handleSubmit()}
                   data-test-subj={'submit_rule_form_button'}
                   fill
                 >
                   {mode === 'create' ? 'Create detection rule' : 'Save changes'}
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </Form>

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -14,7 +14,7 @@ import {
   EuiSmallButton,
   EuiSpacer,
   EuiAccordion,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiButtonGroup,
   EuiText,
   EuiTitle,
@@ -365,7 +365,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                         }
                         error={props.errors.logType}
                       >
-                        <EuiComboBox
+                        <EuiCompressedComboBox
                           isInvalid={
                             (validateOnMount || props.touched.logType) && !!props.errors?.logType
                           }
@@ -412,7 +412,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
                     error={props.errors.level}
                   >
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
                       placeholder="Select a rule level"
                       data-test-subj={'rule_severity_dropdown'}
@@ -446,7 +446,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     isInvalid={(validateOnMount || props.touched.status) && !!props.errors?.status}
                     error={props.errors.status}
                   >
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       isInvalid={
                         (validateOnMount || props.touched.status) && !!props.errors?.status
                       }

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/DetectionVisualEditor.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/DetectionVisualEditor.test.tsx.snap
@@ -21,20 +21,20 @@ Object {
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
                     class="euiFormRow__fieldWrapper"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
-                          class="euiFieldText detection-visual-editor-name euiTitle--small"
+                          class="euiFieldText detection-visual-editor-name euiTitle--small euiFieldText--compressed"
                           data-test-subj="selection_name"
                           id="some_html_id"
                           placeholder="Enter selection name"
@@ -114,7 +114,7 @@ Object {
                           style="min-width: 200px;"
                         >
                           <div
-                            class="euiFormRow"
+                            class="euiFormRow euiFormRow--compressed"
                             id="some_html_id-row"
                           >
                             <div
@@ -135,13 +135,13 @@ Object {
                               class="euiFormRow__fieldWrapper"
                             >
                               <div
-                                class="euiFormControlLayout"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
                                 <div
                                   class="euiFormControlLayout__childrenWrapper"
                                 >
                                   <input
-                                    class="euiFieldText"
+                                    class="euiFieldText euiFieldText--compressed"
                                     data-test-subj="selection_field_key_name"
                                     id="some_html_id"
                                     placeholder="Enter key name"
@@ -158,7 +158,7 @@ Object {
                           style="min-width: 200px;"
                         >
                           <div
-                            class="euiFormRow"
+                            class="euiFormRow euiFormRow--compressed"
                             id="some_html_id-row"
                           >
                             <div
@@ -181,18 +181,18 @@ Object {
                               <div
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
-                                class="euiComboBox"
+                                class="euiComboBox euiComboBox--compressed"
                                 data-test-subj="modifier_dropdown"
                                 role="combobox"
                               >
                                 <div
-                                  class="euiFormControlLayout"
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
                                 >
                                   <div
                                     class="euiFormControlLayout__childrenWrapper"
                                   >
                                     <div
-                                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                       data-test-subj="comboBoxInput"
                                       tabindex="-1"
                                     >
@@ -224,7 +224,7 @@ Object {
                                     >
                                       <button
                                         aria-label="Clear input"
-                                        class="euiFormControlLayoutClearButton"
+                                        class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                         data-test-subj="comboBoxClearButton"
                                         type="button"
                                       >
@@ -251,7 +251,7 @@ Object {
                       />
                       <div>
                         <div
-                          class="euiRadio euiRadioGroup__item"
+                          class="euiRadio euiRadio--compressed euiRadioGroup__item"
                         >
                           <input
                             checked=""
@@ -271,7 +271,7 @@ Object {
                           </label>
                         </div>
                         <div
-                          class="euiRadio euiRadioGroup__item"
+                          class="euiRadio euiRadio--compressed euiRadioGroup__item"
                         >
                           <input
                             class="euiRadio__input"
@@ -294,20 +294,20 @@ Object {
                         class="euiSpacer euiSpacer--m"
                       />
                       <div
-                        class="euiFormRow"
+                        class="euiFormRow euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
                           class="euiFormRow__fieldWrapper"
                         >
                           <div
-                            class="euiFormControlLayout"
+                            class="euiFormControlLayout euiFormControlLayout--compressed"
                           >
                             <div
                               class="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                class="euiFieldText"
+                                class="euiFieldText euiFieldText--compressed"
                                 data-test-subj="selection_field_value"
                                 id="some_html_id"
                                 placeholder="Value"
@@ -330,7 +330,7 @@ Object {
               class="euiSpacer euiSpacer--m"
             />
             <button
-              class="euiButton euiButton--primary euiButton-isDisabled"
+              class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
               disabled=""
               style="width: 70%;"
               type="button"
@@ -352,7 +352,7 @@ Object {
           class="euiSpacer euiSpacer--m"
         />
         <button
-          class="euiButton euiButton--primary euiButton--fullWidth"
+          class="euiButton euiButton--primary euiButton--small euiButton--fullWidth"
           type="button"
         >
           <span
@@ -370,7 +370,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           id="some_html_id-row"
           style="max-width: 100%;"
         >
@@ -392,7 +392,7 @@ Object {
                 Define how each selection should be included in the final query. For more options use
                  
                 <button
-                  class="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small empty-text-button"
                   type="button"
                 >
                   <span
@@ -549,20 +549,20 @@ Object {
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
                   class="euiFormRow__fieldWrapper"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <input
-                        class="euiFieldText detection-visual-editor-name euiTitle--small"
+                        class="euiFieldText detection-visual-editor-name euiTitle--small euiFieldText--compressed"
                         data-test-subj="selection_name"
                         id="some_html_id"
                         placeholder="Enter selection name"
@@ -642,7 +642,7 @@ Object {
                         style="min-width: 200px;"
                       >
                         <div
-                          class="euiFormRow"
+                          class="euiFormRow euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -663,13 +663,13 @@ Object {
                             class="euiFormRow__fieldWrapper"
                           >
                             <div
-                              class="euiFormControlLayout"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 class="euiFormControlLayout__childrenWrapper"
                               >
                                 <input
-                                  class="euiFieldText"
+                                  class="euiFieldText euiFieldText--compressed"
                                   data-test-subj="selection_field_key_name"
                                   id="some_html_id"
                                   placeholder="Enter key name"
@@ -686,7 +686,7 @@ Object {
                         style="min-width: 200px;"
                       >
                         <div
-                          class="euiFormRow"
+                          class="euiFormRow euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -709,18 +709,18 @@ Object {
                             <div
                               aria-expanded="false"
                               aria-haspopup="listbox"
-                              class="euiComboBox"
+                              class="euiComboBox euiComboBox--compressed"
                               data-test-subj="modifier_dropdown"
                               role="combobox"
                             >
                               <div
-                                class="euiFormControlLayout"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
                                 <div
                                   class="euiFormControlLayout__childrenWrapper"
                                 >
                                   <div
-                                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                    class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                     data-test-subj="comboBoxInput"
                                     tabindex="-1"
                                   >
@@ -752,7 +752,7 @@ Object {
                                   >
                                     <button
                                       aria-label="Clear input"
-                                      class="euiFormControlLayoutClearButton"
+                                      class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                       data-test-subj="comboBoxClearButton"
                                       type="button"
                                     >
@@ -779,7 +779,7 @@ Object {
                     />
                     <div>
                       <div
-                        class="euiRadio euiRadioGroup__item"
+                        class="euiRadio euiRadio--compressed euiRadioGroup__item"
                       >
                         <input
                           checked=""
@@ -799,7 +799,7 @@ Object {
                         </label>
                       </div>
                       <div
-                        class="euiRadio euiRadioGroup__item"
+                        class="euiRadio euiRadio--compressed euiRadioGroup__item"
                       >
                         <input
                           class="euiRadio__input"
@@ -822,20 +822,20 @@ Object {
                       class="euiSpacer euiSpacer--m"
                     />
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="some_html_id-row"
                     >
                       <div
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          class="euiFormControlLayout"
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
-                              class="euiFieldText"
+                              class="euiFieldText euiFieldText--compressed"
                               data-test-subj="selection_field_value"
                               id="some_html_id"
                               placeholder="Value"
@@ -858,7 +858,7 @@ Object {
             class="euiSpacer euiSpacer--m"
           />
           <button
-            class="euiButton euiButton--primary euiButton-isDisabled"
+            class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
             disabled=""
             style="width: 70%;"
             type="button"
@@ -880,7 +880,7 @@ Object {
         class="euiSpacer euiSpacer--m"
       />
       <button
-        class="euiButton euiButton--primary euiButton--fullWidth"
+        class="euiButton euiButton--primary euiButton--small euiButton--fullWidth"
         type="button"
       >
         <span
@@ -898,7 +898,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
         style="max-width: 100%;"
       >
@@ -920,7 +920,7 @@ Object {
               Define how each selection should be included in the final query. For more options use
                
               <button
-                class="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
+                class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small empty-text-button"
                 type="button"
               >
                 <span

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorContainer.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorContainer.test.tsx.snap
@@ -329,9 +329,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 describedByIds={Array []}
-                display="row"
+                display="rowCompressed"
                 fullWidth={false}
                 hasChildLabel={true}
                 hasEmptyLabelSpace={false}
@@ -348,7 +348,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 labelType="label"
               >
                 <div
-                  className="euiFormRow"
+                  className="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -381,7 +381,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   <div
                     className="euiFormRow__fieldWrapper"
                   >
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       aria-describedby="some_html_id-help-0"
                       data-test-subj="rule_name_field"
                       id="some_html_id"
@@ -391,35 +391,50 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                       placeholder="My custom rule"
                       value=""
                     >
-                      <EuiFormControlLayout
-                        fullWidth={false}
-                        inputId="some_html_id"
+                      <EuiFieldText
+                        aria-describedby="some_html_id-help-0"
+                        compressed={true}
+                        data-test-subj="rule_name_field"
+                        id="some_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="My custom rule"
+                        value=""
                       >
-                        <div
-                          className="euiFormControlLayout"
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={false}
+                          inputId="some_html_id"
                         >
                           <div
-                            className="euiFormControlLayout__childrenWrapper"
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
                           >
-                            <EuiValidatableControl>
-                              <input
-                                aria-describedby="some_html_id-help-0"
-                                className="euiFieldText"
-                                data-test-subj="rule_name_field"
-                                id="some_html_id"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder="My custom rule"
-                                type="text"
-                                value=""
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  aria-describedby="some_html_id-help-0"
+                                  className="euiFieldText euiFieldText--compressed"
+                                  data-test-subj="rule_name_field"
+                                  id="some_html_id"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder="My custom rule"
+                                  type="text"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
                               />
-                            </EuiValidatableControl>
-                            <EuiFormControlLayoutIcons />
+                            </div>
                           </div>
-                        </div>
-                      </EuiFormControlLayout>
-                    </EuiFieldText>
+                        </EuiFormControlLayout>
+                      </EuiFieldText>
+                    </EuiCompressedFieldText>
                     <EuiFormHelpText
                       className="euiFormRow__text"
                       id="some_html_id-help-0"
@@ -434,7 +449,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                     </EuiFormHelpText>
                   </div>
                 </div>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer
                 size="m"
               >
@@ -442,9 +457,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   className="euiSpacer euiSpacer--m"
                 />
               </EuiSpacer>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 describedByIds={Array []}
-                display="row"
+                display="rowCompressed"
                 fullWidth={false}
                 hasChildLabel={true}
                 hasEmptyLabelSpace={false}
@@ -463,7 +478,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 labelType="label"
               >
                 <div
-                  className="euiFormRow"
+                  className="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -499,7 +514,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   <div
                     className="euiFormRow__fieldWrapper"
                   >
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       data-test-subj="rule_description_field"
                       id="some_html_id"
                       onBlur={[Function]}
@@ -508,37 +523,51 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                       placeholder="Detects ..."
                       value=""
                     >
-                      <EuiFormControlLayout
-                        fullWidth={false}
-                        inputId="some_html_id"
+                      <EuiFieldText
+                        compressed={true}
+                        data-test-subj="rule_description_field"
+                        id="some_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Detects ..."
+                        value=""
                       >
-                        <div
-                          className="euiFormControlLayout"
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={false}
+                          inputId="some_html_id"
                         >
                           <div
-                            className="euiFormControlLayout__childrenWrapper"
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
                           >
-                            <EuiValidatableControl>
-                              <input
-                                className="euiFieldText"
-                                data-test-subj="rule_description_field"
-                                id="some_html_id"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder="Detects ..."
-                                type="text"
-                                value=""
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldText euiFieldText--compressed"
+                                  data-test-subj="rule_description_field"
+                                  id="some_html_id"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder="Detects ..."
+                                  type="text"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
                               />
-                            </EuiValidatableControl>
-                            <EuiFormControlLayoutIcons />
+                            </div>
                           </div>
-                        </div>
-                      </EuiFormControlLayout>
-                    </EuiFieldText>
+                        </EuiFormControlLayout>
+                      </EuiFieldText>
+                    </EuiCompressedFieldText>
                   </div>
                 </div>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer
                 size="m"
               >
@@ -546,9 +575,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   className="euiSpacer euiSpacer--m"
                 />
               </EuiSpacer>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 describedByIds={Array []}
-                display="row"
+                display="rowCompressed"
                 fullWidth={false}
                 hasChildLabel={true}
                 hasEmptyLabelSpace={false}
@@ -565,7 +594,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 labelType="label"
               >
                 <div
-                  className="euiFormRow"
+                  className="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -598,7 +627,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   <div
                     className="euiFormRow__fieldWrapper"
                   >
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       aria-describedby="some_html_id-help-0"
                       data-test-subj="rule_author_field"
                       id="some_html_id"
@@ -608,35 +637,50 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                       placeholder="Enter author name"
                       value=""
                     >
-                      <EuiFormControlLayout
-                        fullWidth={false}
-                        inputId="some_html_id"
+                      <EuiFieldText
+                        aria-describedby="some_html_id-help-0"
+                        compressed={true}
+                        data-test-subj="rule_author_field"
+                        id="some_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Enter author name"
+                        value=""
                       >
-                        <div
-                          className="euiFormControlLayout"
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={false}
+                          inputId="some_html_id"
                         >
                           <div
-                            className="euiFormControlLayout__childrenWrapper"
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
                           >
-                            <EuiValidatableControl>
-                              <input
-                                aria-describedby="some_html_id-help-0"
-                                className="euiFieldText"
-                                data-test-subj="rule_author_field"
-                                id="some_html_id"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder="Enter author name"
-                                type="text"
-                                value=""
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  aria-describedby="some_html_id-help-0"
+                                  className="euiFieldText euiFieldText--compressed"
+                                  data-test-subj="rule_author_field"
+                                  id="some_html_id"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder="Enter author name"
+                                  type="text"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
                               />
-                            </EuiValidatableControl>
-                            <EuiFormControlLayoutIcons />
+                            </div>
                           </div>
-                        </div>
-                      </EuiFormControlLayout>
-                    </EuiFieldText>
+                        </EuiFormControlLayout>
+                      </EuiFieldText>
+                    </EuiCompressedFieldText>
                     <EuiFormHelpText
                       className="euiFormRow__text"
                       id="some_html_id-help-0"
@@ -651,7 +695,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                     </EuiFormHelpText>
                   </div>
                 </div>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer
                 size="xl"
               >
@@ -698,9 +742,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                         }
                       }
                     >
-                      <EuiFormRow
+                      <EuiCompressedFormRow
                         describedByIds={Array []}
-                        display="row"
+                        display="rowCompressed"
                         fullWidth={false}
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
@@ -716,7 +760,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                         labelType="label"
                       >
                         <div
-                          className="euiFormRow"
+                          className="euiFormRow euiFormRow--compressed"
                           id="some_html_id-row"
                         >
                           <div
@@ -749,9 +793,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                           <div
                             className="euiFormRow__fieldWrapper"
                           >
-                            <EuiComboBox
+                            <EuiCompressedComboBox
                               async={false}
-                              compressed={false}
+                              compressed={true}
                               data-test-subj="rule_type_dropdown"
                               fullWidth={false}
                               id="some_html_id"
@@ -772,14 +816,14 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                               <div
                                 aria-expanded={false}
                                 aria-haspopup="listbox"
-                                className="euiComboBox"
+                                className="euiComboBox euiComboBox--compressed"
                                 data-test-subj="rule_type_dropdown"
                                 onKeyDown={[Function]}
                                 role="combobox"
                               >
                                 <EuiComboBoxInput
                                   autoSizeInputRef={[Function]}
-                                  compressed={false}
+                                  compressed={true}
                                   fullWidth={false}
                                   hasSelectedOptions={false}
                                   id="some_html_id"
@@ -807,7 +851,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                   value=""
                                 >
                                   <EuiFormControlLayout
-                                    compressed={false}
+                                    compressed={true}
                                     fullWidth={false}
                                     icon={
                                       Object {
@@ -822,13 +866,13 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                     }
                                   >
                                     <div
-                                      className="euiFormControlLayout"
+                                      className="euiFormControlLayout euiFormControlLayout--compressed"
                                     >
                                       <div
                                         className="euiFormControlLayout__childrenWrapper"
                                       >
                                         <div
-                                          className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                          className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                           data-test-subj="comboBoxInput"
                                           onClick={[Function]}
                                           tabIndex={-1}
@@ -899,7 +943,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           </AutosizeInput>
                                         </div>
                                         <EuiFormControlLayoutIcons
-                                          compressed={false}
+                                          compressed={true}
                                           icon={
                                             Object {
                                               "aria-label": "Open list of options",
@@ -920,7 +964,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                               data-test-subj="comboBoxToggleListButton"
                                               iconRef={[Function]}
                                               onClick={[Function]}
-                                              size="m"
+                                              size="s"
                                               type="arrowDown"
                                             >
                                               <button
@@ -933,7 +977,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 <EuiIcon
                                                   aria-hidden="true"
                                                   className="euiFormControlLayoutCustomIcon__icon"
-                                                  size="m"
+                                                  size="s"
                                                   type="arrowDown"
                                                 >
                                                   EuiIconMock
@@ -947,10 +991,10 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                   </EuiFormControlLayout>
                                 </EuiComboBoxInput>
                               </div>
-                            </EuiComboBox>
+                            </EuiCompressedComboBox>
                           </div>
                         </div>
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </div>
                   </EuiFlexItem>
                   <EuiFlexItem
@@ -969,57 +1013,64 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                         }
                       }
                     >
-                      <EuiButton
+                      <EuiSmallButton
                         href="opensearch_security_analytics_dashboards#/log-types"
                         target="_blank"
                       >
-                        <EuiButtonDisplay
-                          baseClassName="euiButton"
-                          element="a"
+                        <EuiButton
                           href="opensearch_security_analytics_dashboards#/log-types"
-                          isDisabled={false}
-                          rel="noopener noreferrer"
+                          size="s"
                           target="_blank"
                         >
-                          <a
-                            className="euiButton euiButton--primary"
-                            disabled={false}
+                          <EuiButtonDisplay
+                            baseClassName="euiButton"
+                            element="a"
                             href="opensearch_security_analytics_dashboards#/log-types"
+                            isDisabled={false}
                             rel="noopener noreferrer"
-                            style={
-                              Object {
-                                "minWidth": undefined,
-                              }
-                            }
+                            size="s"
                             target="_blank"
                           >
-                            <EuiButtonContent
-                              className="euiButton__content"
-                              iconSide="left"
-                              textProps={
+                            <a
+                              className="euiButton euiButton--primary euiButton--small"
+                              disabled={false}
+                              href="opensearch_security_analytics_dashboards#/log-types"
+                              rel="noopener noreferrer"
+                              style={
                                 Object {
-                                  "className": "euiButton__text",
+                                  "minWidth": undefined,
                                 }
                               }
+                              target="_blank"
                             >
-                              <span
-                                className="euiButtonContent euiButton__content"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text",
+                                  }
+                                }
                               >
                                 <span
-                                  className="euiButton__text"
+                                  className="euiButtonContent euiButton__content"
                                 >
-                                  Manage 
-                                  <EuiIcon
-                                    type="popout"
+                                  <span
+                                    className="euiButton__text"
                                   >
-                                    EuiIconMock
-                                  </EuiIcon>
+                                    Manage 
+                                    <EuiIcon
+                                      type="popout"
+                                    >
+                                      EuiIconMock
+                                    </EuiIcon>
+                                  </span>
                                 </span>
-                              </span>
-                            </EuiButtonContent>
-                          </a>
-                        </EuiButtonDisplay>
-                      </EuiButton>
+                              </EuiButtonContent>
+                            </a>
+                          </EuiButtonDisplay>
+                        </EuiButton>
+                      </EuiSmallButton>
                     </div>
                   </EuiFlexItem>
                 </div>
@@ -1029,9 +1080,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 describedByIds={Array []}
-                display="row"
+                display="rowCompressed"
                 fullWidth={false}
                 hasChildLabel={true}
                 hasEmptyLabelSpace={false}
@@ -1047,7 +1098,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 labelType="label"
               >
                 <div
-                  className="euiFormRow"
+                  className="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -1080,9 +1131,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   <div
                     className="euiFormRow__fieldWrapper"
                   >
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       async={false}
-                      compressed={false}
+                      compressed={true}
                       data-test-subj="rule_severity_dropdown"
                       fullWidth={false}
                       id="some_html_id"
@@ -1126,14 +1177,14 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                       <div
                         aria-expanded={false}
                         aria-haspopup="listbox"
-                        className="euiComboBox"
+                        className="euiComboBox euiComboBox--compressed"
                         data-test-subj="rule_severity_dropdown"
                         onKeyDown={[Function]}
                         role="combobox"
                       >
                         <EuiComboBoxInput
                           autoSizeInputRef={[Function]}
-                          compressed={false}
+                          compressed={true}
                           fullWidth={false}
                           hasSelectedOptions={false}
                           id="some_html_id"
@@ -1161,7 +1212,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                           value=""
                         >
                           <EuiFormControlLayout
-                            compressed={false}
+                            compressed={true}
                             fullWidth={false}
                             icon={
                               Object {
@@ -1176,13 +1227,13 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                             }
                           >
                             <div
-                              className="euiFormControlLayout"
+                              className="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 className="euiFormControlLayout__childrenWrapper"
                               >
                                 <div
-                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                   data-test-subj="comboBoxInput"
                                   onClick={[Function]}
                                   tabIndex={-1}
@@ -1253,7 +1304,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                   </AutosizeInput>
                                 </div>
                                 <EuiFormControlLayoutIcons
-                                  compressed={false}
+                                  compressed={true}
                                   icon={
                                     Object {
                                       "aria-label": "Open list of options",
@@ -1274,7 +1325,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                       data-test-subj="comboBoxToggleListButton"
                                       iconRef={[Function]}
                                       onClick={[Function]}
-                                      size="m"
+                                      size="s"
                                       type="arrowDown"
                                     >
                                       <button
@@ -1287,7 +1338,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                         <EuiIcon
                                           aria-hidden="true"
                                           className="euiFormControlLayoutCustomIcon__icon"
-                                          size="m"
+                                          size="s"
                                           type="arrowDown"
                                         >
                                           EuiIconMock
@@ -1301,18 +1352,18 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                           </EuiFormControlLayout>
                         </EuiComboBoxInput>
                       </div>
-                    </EuiComboBox>
+                    </EuiCompressedComboBox>
                   </div>
                 </div>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer>
                 <div
                   className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 describedByIds={Array []}
-                display="row"
+                display="rowCompressed"
                 fullWidth={false}
                 hasChildLabel={true}
                 hasEmptyLabelSpace={false}
@@ -1328,7 +1379,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 labelType="label"
               >
                 <div
-                  className="euiFormRow"
+                  className="euiFormRow euiFormRow--compressed"
                   id="some_html_id-row"
                 >
                   <div
@@ -1361,9 +1412,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                   <div
                     className="euiFormRow__fieldWrapper"
                   >
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       async={false}
-                      compressed={false}
+                      compressed={true}
                       data-test-subj="rule_status_dropdown"
                       fullWidth={false}
                       id="some_html_id"
@@ -1406,14 +1457,14 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                       <div
                         aria-expanded={false}
                         aria-haspopup="listbox"
-                        className="euiComboBox"
+                        className="euiComboBox euiComboBox--compressed"
                         data-test-subj="rule_status_dropdown"
                         onKeyDown={[Function]}
                         role="combobox"
                       >
                         <EuiComboBoxInput
                           autoSizeInputRef={[Function]}
-                          compressed={false}
+                          compressed={true}
                           fullWidth={false}
                           hasSelectedOptions={true}
                           id="some_html_id"
@@ -1454,7 +1505,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                 "onClick": [Function],
                               }
                             }
-                            compressed={false}
+                            compressed={true}
                             fullWidth={false}
                             icon={
                               Object {
@@ -1469,13 +1520,13 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                             }
                           >
                             <div
-                              className="euiFormControlLayout"
+                              className="euiFormControlLayout euiFormControlLayout--compressed"
                             >
                               <div
                                 className="euiFormControlLayout__childrenWrapper"
                               >
                                 <div
-                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                   data-test-subj="comboBoxInput"
                                   onClick={[Function]}
                                   tabIndex={-1}
@@ -1566,7 +1617,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                       "onClick": [Function],
                                     }
                                   }
-                                  compressed={false}
+                                  compressed={true}
                                   icon={
                                     Object {
                                       "aria-label": "Open list of options",
@@ -1585,7 +1636,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                     <EuiFormControlLayoutClearButton
                                       data-test-subj="comboBoxClearButton"
                                       onClick={[Function]}
-                                      size="m"
+                                      size="s"
                                     >
                                       <EuiI18n
                                         default="Clear input"
@@ -1593,7 +1644,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                       >
                                         <button
                                           aria-label="Clear input"
-                                          className="euiFormControlLayoutClearButton"
+                                          className="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                           data-test-subj="comboBoxClearButton"
                                           onClick={[Function]}
                                           type="button"
@@ -1612,7 +1663,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                       data-test-subj="comboBoxToggleListButton"
                                       iconRef={[Function]}
                                       onClick={[Function]}
-                                      size="m"
+                                      size="s"
                                       type="arrowDown"
                                     >
                                       <button
@@ -1625,7 +1676,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                         <EuiIcon
                                           aria-hidden="true"
                                           className="euiFormControlLayoutCustomIcon__icon"
-                                          size="m"
+                                          size="s"
                                           type="arrowDown"
                                         >
                                           EuiIconMock
@@ -1639,10 +1690,10 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                           </EuiFormControlLayout>
                         </EuiComboBoxInput>
                       </div>
-                    </EuiComboBox>
+                    </EuiCompressedComboBox>
                   </div>
                 </div>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer
                 size="xxl"
               >
@@ -1717,22 +1768,22 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                               <div
                                 className="euiFlexItem"
                               >
-                                <EuiFormRow
+                                <EuiCompressedFormRow
                                   describedByIds={Array []}
-                                  display="row"
+                                  display="rowCompressed"
                                   fullWidth={false}
                                   hasChildLabel={true}
                                   hasEmptyLabelSpace={false}
                                   labelType="label"
                                 >
                                   <div
-                                    className="euiFormRow"
+                                    className="euiFormRow euiFormRow--compressed"
                                     id="some_html_id-row"
                                   >
                                     <div
                                       className="euiFormRow__fieldWrapper"
                                     >
-                                      <EuiFieldText
+                                      <EuiCompressedFieldText
                                         className="detection-visual-editor-name euiTitle--small"
                                         data-test-subj="selection_name"
                                         id="some_html_id"
@@ -1742,37 +1793,52 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                         placeholder="Enter selection name"
                                         value="Selection_1"
                                       >
-                                        <EuiFormControlLayout
-                                          fullWidth={false}
-                                          inputId="some_html_id"
+                                        <EuiFieldText
+                                          className="detection-visual-editor-name euiTitle--small"
+                                          compressed={true}
+                                          data-test-subj="selection_name"
+                                          id="some_html_id"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          placeholder="Enter selection name"
+                                          value="Selection_1"
                                         >
-                                          <div
-                                            className="euiFormControlLayout"
+                                          <EuiFormControlLayout
+                                            compressed={true}
+                                            fullWidth={false}
+                                            inputId="some_html_id"
                                           >
                                             <div
-                                              className="euiFormControlLayout__childrenWrapper"
+                                              className="euiFormControlLayout euiFormControlLayout--compressed"
                                             >
-                                              <EuiValidatableControl>
-                                                <input
-                                                  className="euiFieldText detection-visual-editor-name euiTitle--small"
-                                                  data-test-subj="selection_name"
-                                                  id="some_html_id"
-                                                  onBlur={[Function]}
-                                                  onChange={[Function]}
-                                                  onFocus={[Function]}
-                                                  placeholder="Enter selection name"
-                                                  type="text"
-                                                  value="Selection_1"
+                                              <div
+                                                className="euiFormControlLayout__childrenWrapper"
+                                              >
+                                                <EuiValidatableControl>
+                                                  <input
+                                                    className="euiFieldText detection-visual-editor-name euiTitle--small euiFieldText--compressed"
+                                                    data-test-subj="selection_name"
+                                                    id="some_html_id"
+                                                    onBlur={[Function]}
+                                                    onChange={[Function]}
+                                                    onFocus={[Function]}
+                                                    placeholder="Enter selection name"
+                                                    type="text"
+                                                    value="Selection_1"
+                                                  />
+                                                </EuiValidatableControl>
+                                                <EuiFormControlLayoutIcons
+                                                  compressed={true}
                                                 />
-                                              </EuiValidatableControl>
-                                              <EuiFormControlLayoutIcons />
+                                              </div>
                                             </div>
-                                          </div>
-                                        </EuiFormControlLayout>
-                                      </EuiFieldText>
+                                          </EuiFormControlLayout>
+                                        </EuiFieldText>
+                                      </EuiCompressedFieldText>
                                     </div>
                                   </div>
-                                </EuiFormRow>
+                                </EuiCompressedFormRow>
                                 <EuiText
                                   size="s"
                                 >
@@ -1911,9 +1977,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 }
                                               }
                                             >
-                                              <EuiFormRow
+                                              <EuiCompressedFormRow
                                                 describedByIds={Array []}
-                                                display="row"
+                                                display="rowCompressed"
                                                 fullWidth={false}
                                                 hasChildLabel={true}
                                                 hasEmptyLabelSpace={false}
@@ -1927,7 +1993,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 labelType="label"
                                               >
                                                 <div
-                                                  className="euiFormRow"
+                                                  className="euiFormRow euiFormRow--compressed"
                                                   id="some_html_id-row"
                                                 >
                                                   <div
@@ -1958,7 +2024,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                   <div
                                                     className="euiFormRow__fieldWrapper"
                                                   >
-                                                    <EuiFieldText
+                                                    <EuiCompressedFieldText
                                                       data-test-subj="selection_field_key_name"
                                                       id="some_html_id"
                                                       onBlur={[Function]}
@@ -1967,37 +2033,51 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                       placeholder="Enter key name"
                                                       value=""
                                                     >
-                                                      <EuiFormControlLayout
-                                                        fullWidth={false}
-                                                        inputId="some_html_id"
+                                                      <EuiFieldText
+                                                        compressed={true}
+                                                        data-test-subj="selection_field_key_name"
+                                                        id="some_html_id"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onFocus={[Function]}
+                                                        placeholder="Enter key name"
+                                                        value=""
                                                       >
-                                                        <div
-                                                          className="euiFormControlLayout"
+                                                        <EuiFormControlLayout
+                                                          compressed={true}
+                                                          fullWidth={false}
+                                                          inputId="some_html_id"
                                                         >
                                                           <div
-                                                            className="euiFormControlLayout__childrenWrapper"
+                                                            className="euiFormControlLayout euiFormControlLayout--compressed"
                                                           >
-                                                            <EuiValidatableControl>
-                                                              <input
-                                                                className="euiFieldText"
-                                                                data-test-subj="selection_field_key_name"
-                                                                id="some_html_id"
-                                                                onBlur={[Function]}
-                                                                onChange={[Function]}
-                                                                onFocus={[Function]}
-                                                                placeholder="Enter key name"
-                                                                type="text"
-                                                                value=""
+                                                            <div
+                                                              className="euiFormControlLayout__childrenWrapper"
+                                                            >
+                                                              <EuiValidatableControl>
+                                                                <input
+                                                                  className="euiFieldText euiFieldText--compressed"
+                                                                  data-test-subj="selection_field_key_name"
+                                                                  id="some_html_id"
+                                                                  onBlur={[Function]}
+                                                                  onChange={[Function]}
+                                                                  onFocus={[Function]}
+                                                                  placeholder="Enter key name"
+                                                                  type="text"
+                                                                  value=""
+                                                                />
+                                                              </EuiValidatableControl>
+                                                              <EuiFormControlLayoutIcons
+                                                                compressed={true}
                                                               />
-                                                            </EuiValidatableControl>
-                                                            <EuiFormControlLayoutIcons />
+                                                            </div>
                                                           </div>
-                                                        </div>
-                                                      </EuiFormControlLayout>
-                                                    </EuiFieldText>
+                                                        </EuiFormControlLayout>
+                                                      </EuiFieldText>
+                                                    </EuiCompressedFieldText>
                                                   </div>
                                                 </div>
-                                              </EuiFormRow>
+                                              </EuiCompressedFormRow>
                                             </div>
                                           </EuiFlexItem>
                                           <EuiFlexItem
@@ -2016,9 +2096,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 }
                                               }
                                             >
-                                              <EuiFormRow
+                                              <EuiCompressedFormRow
                                                 describedByIds={Array []}
-                                                display="row"
+                                                display="rowCompressed"
                                                 fullWidth={false}
                                                 hasChildLabel={true}
                                                 hasEmptyLabelSpace={false}
@@ -2032,7 +2112,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 labelType="label"
                                               >
                                                 <div
-                                                  className="euiFormRow"
+                                                  className="euiFormRow euiFormRow--compressed"
                                                   id="some_html_id-row"
                                                 >
                                                   <div
@@ -2063,9 +2143,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                   <div
                                                     className="euiFormRow__fieldWrapper"
                                                   >
-                                                    <EuiComboBox
+                                                    <EuiCompressedComboBox
                                                       async={false}
-                                                      compressed={false}
+                                                      compressed={true}
                                                       data-test-subj="modifier_dropdown"
                                                       fullWidth={false}
                                                       id="some_html_id"
@@ -2119,14 +2199,14 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                       <div
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
-                                                        className="euiComboBox"
+                                                        className="euiComboBox euiComboBox--compressed"
                                                         data-test-subj="modifier_dropdown"
                                                         onKeyDown={[Function]}
                                                         role="combobox"
                                                       >
                                                         <EuiComboBoxInput
                                                           autoSizeInputRef={[Function]}
-                                                          compressed={false}
+                                                          compressed={true}
                                                           fullWidth={false}
                                                           hasSelectedOptions={true}
                                                           id="some_html_id"
@@ -2166,7 +2246,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                                 "onClick": [Function],
                                                               }
                                                             }
-                                                            compressed={false}
+                                                            compressed={true}
                                                             fullWidth={false}
                                                             icon={
                                                               Object {
@@ -2181,13 +2261,13 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                             }
                                                           >
                                                             <div
-                                                              className="euiFormControlLayout"
+                                                              className="euiFormControlLayout euiFormControlLayout--compressed"
                                                             >
                                                               <div
                                                                 className="euiFormControlLayout__childrenWrapper"
                                                               >
                                                                 <div
-                                                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                                                   data-test-subj="comboBoxInput"
                                                                   onClick={[Function]}
                                                                   tabIndex={-1}
@@ -2278,7 +2358,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                                       "onClick": [Function],
                                                                     }
                                                                   }
-                                                                  compressed={false}
+                                                                  compressed={true}
                                                                   icon={
                                                                     Object {
                                                                       "aria-label": "Open list of options",
@@ -2297,7 +2377,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                                     <EuiFormControlLayoutClearButton
                                                                       data-test-subj="comboBoxClearButton"
                                                                       onClick={[Function]}
-                                                                      size="m"
+                                                                      size="s"
                                                                     >
                                                                       <EuiI18n
                                                                         default="Clear input"
@@ -2305,7 +2385,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                                       >
                                                                         <button
                                                                           aria-label="Clear input"
-                                                                          className="euiFormControlLayoutClearButton"
+                                                                          className="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                                                           data-test-subj="comboBoxClearButton"
                                                                           onClick={[Function]}
                                                                           type="button"
@@ -2324,7 +2404,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                                       data-test-subj="comboBoxToggleListButton"
                                                                       iconRef={[Function]}
                                                                       onClick={[Function]}
-                                                                      size="m"
+                                                                      size="s"
                                                                       type="arrowDown"
                                                                     >
                                                                       <button
@@ -2337,7 +2417,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                                         <EuiIcon
                                                                           aria-hidden="true"
                                                                           className="euiFormControlLayoutCustomIcon__icon"
-                                                                          size="m"
+                                                                          size="s"
                                                                           type="arrowDown"
                                                                         >
                                                                           EuiIconMock
@@ -2351,10 +2431,10 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                           </EuiFormControlLayout>
                                                         </EuiComboBoxInput>
                                                       </div>
-                                                    </EuiComboBox>
+                                                    </EuiCompressedComboBox>
                                                   </div>
                                                 </div>
-                                              </EuiFormRow>
+                                              </EuiCompressedFormRow>
                                             </div>
                                           </EuiFlexItem>
                                         </div>
@@ -2366,7 +2446,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                      <EuiRadioGroup
+                                      <EuiCompressedRadioGroup
                                         idSelected="selection-map-value-0-0"
                                         onChange={[Function]}
                                         options={
@@ -2382,67 +2462,87 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           ]
                                         }
                                       >
-                                        <div>
-                                          <EuiRadio
-                                            checked={true}
-                                            className="euiRadioGroup__item"
-                                            id="selection-map-value-0-0"
-                                            key="0"
-                                            label="Value"
-                                            onChange={[Function]}
-                                          >
-                                            <div
-                                              className="euiRadio euiRadioGroup__item"
+                                        <EuiRadioGroup
+                                          compressed={true}
+                                          idSelected="selection-map-value-0-0"
+                                          onChange={[Function]}
+                                          options={
+                                            Array [
+                                              Object {
+                                                "id": "selection-map-value-0-0",
+                                                "label": "Value",
+                                              },
+                                              Object {
+                                                "id": "selection-map-list-0-0",
+                                                "label": "List",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <div>
+                                            <EuiRadio
+                                              checked={true}
+                                              className="euiRadioGroup__item"
+                                              compressed={true}
+                                              id="selection-map-value-0-0"
+                                              key="0"
+                                              label="Value"
+                                              onChange={[Function]}
                                             >
-                                              <input
-                                                checked={true}
-                                                className="euiRadio__input"
-                                                id="selection-map-value-0-0"
-                                                onChange={[Function]}
-                                                type="radio"
-                                              />
                                               <div
-                                                className="euiRadio__circle"
-                                              />
-                                              <label
-                                                className="euiRadio__label"
-                                                htmlFor="selection-map-value-0-0"
+                                                className="euiRadio euiRadio--compressed euiRadioGroup__item"
                                               >
-                                                Value
-                                              </label>
-                                            </div>
-                                          </EuiRadio>
-                                          <EuiRadio
-                                            checked={false}
-                                            className="euiRadioGroup__item"
-                                            id="selection-map-list-0-0"
-                                            key="1"
-                                            label="List"
-                                            onChange={[Function]}
-                                          >
-                                            <div
-                                              className="euiRadio euiRadioGroup__item"
+                                                <input
+                                                  checked={true}
+                                                  className="euiRadio__input"
+                                                  id="selection-map-value-0-0"
+                                                  onChange={[Function]}
+                                                  type="radio"
+                                                />
+                                                <div
+                                                  className="euiRadio__circle"
+                                                />
+                                                <label
+                                                  className="euiRadio__label"
+                                                  htmlFor="selection-map-value-0-0"
+                                                >
+                                                  Value
+                                                </label>
+                                              </div>
+                                            </EuiRadio>
+                                            <EuiRadio
+                                              checked={false}
+                                              className="euiRadioGroup__item"
+                                              compressed={true}
+                                              id="selection-map-list-0-0"
+                                              key="1"
+                                              label="List"
+                                              onChange={[Function]}
                                             >
-                                              <input
-                                                checked={false}
-                                                className="euiRadio__input"
-                                                id="selection-map-list-0-0"
-                                                onChange={[Function]}
-                                                type="radio"
-                                              />
                                               <div
-                                                className="euiRadio__circle"
-                                              />
-                                              <label
-                                                className="euiRadio__label"
-                                                htmlFor="selection-map-list-0-0"
+                                                className="euiRadio euiRadio--compressed euiRadioGroup__item"
                                               >
-                                                List
-                                              </label>
-                                            </div>
-                                          </EuiRadio>
-                                        </div>
-                                      </EuiRadioGroup>
+                                                <input
+                                                  checked={false}
+                                                  className="euiRadio__input"
+                                                  id="selection-map-list-0-0"
+                                                  onChange={[Function]}
+                                                  type="radio"
+                                                />
+                                                <div
+                                                  className="euiRadio__circle"
+                                                />
+                                                <label
+                                                  className="euiRadio__label"
+                                                  htmlFor="selection-map-list-0-0"
+                                                >
+                                                  List
+                                                </label>
+                                              </div>
+                                            </EuiRadio>
+                                          </div>
+                                        </EuiRadioGroup>
+                                      </EuiCompressedRadioGroup>
                                       <EuiSpacer
                                         size="m"
                                       >
@@ -2450,22 +2550,22 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                      <EuiFormRow
+                                      <EuiCompressedFormRow
                                         describedByIds={Array []}
-                                        display="row"
+                                        display="rowCompressed"
                                         fullWidth={false}
                                         hasChildLabel={true}
                                         hasEmptyLabelSpace={false}
                                         labelType="label"
                                       >
                                         <div
-                                          className="euiFormRow"
+                                          className="euiFormRow euiFormRow--compressed"
                                           id="some_html_id-row"
                                         >
                                           <div
                                             className="euiFormRow__fieldWrapper"
                                           >
-                                            <EuiFieldText
+                                            <EuiCompressedFieldText
                                               data-test-subj="selection_field_value"
                                               id="some_html_id"
                                               onBlur={[Function]}
@@ -2474,37 +2574,51 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                               placeholder="Value"
                                               value=""
                                             >
-                                              <EuiFormControlLayout
-                                                fullWidth={false}
-                                                inputId="some_html_id"
+                                              <EuiFieldText
+                                                compressed={true}
+                                                data-test-subj="selection_field_value"
+                                                id="some_html_id"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                placeholder="Value"
+                                                value=""
                                               >
-                                                <div
-                                                  className="euiFormControlLayout"
+                                                <EuiFormControlLayout
+                                                  compressed={true}
+                                                  fullWidth={false}
+                                                  inputId="some_html_id"
                                                 >
                                                   <div
-                                                    className="euiFormControlLayout__childrenWrapper"
+                                                    className="euiFormControlLayout euiFormControlLayout--compressed"
                                                   >
-                                                    <EuiValidatableControl>
-                                                      <input
-                                                        className="euiFieldText"
-                                                        data-test-subj="selection_field_value"
-                                                        id="some_html_id"
-                                                        onBlur={[Function]}
-                                                        onChange={[Function]}
-                                                        onFocus={[Function]}
-                                                        placeholder="Value"
-                                                        type="text"
-                                                        value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
+                                                    >
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText euiFieldText--compressed"
+                                                          data-test-subj="selection_field_value"
+                                                          id="some_html_id"
+                                                          onBlur={[Function]}
+                                                          onChange={[Function]}
+                                                          onFocus={[Function]}
+                                                          placeholder="Value"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons
+                                                        compressed={true}
                                                       />
-                                                    </EuiValidatableControl>
-                                                    <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </div>
-                                              </EuiFormControlLayout>
-                                            </EuiFieldText>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </EuiCompressedFieldText>
                                           </div>
                                         </div>
-                                      </EuiFormRow>
+                                      </EuiCompressedFormRow>
                                       <EuiSpacer
                                         size="m"
                                       >
@@ -2526,7 +2640,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                             className="euiSpacer euiSpacer--m"
                           />
                         </EuiSpacer>
-                        <EuiButton
+                        <EuiSmallButton
                           disabled={true}
                           iconType="plusInCircle"
                           onClick={[Function]}
@@ -2536,63 +2650,76 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                             }
                           }
                         >
-                          <EuiButtonDisplay
-                            baseClassName="euiButton"
+                          <EuiButton
                             disabled={true}
-                            element="button"
                             iconType="plusInCircle"
-                            isDisabled={true}
                             onClick={[Function]}
+                            size="s"
                             style={
                               Object {
                                 "width": "70%",
                               }
                             }
-                            type="button"
                           >
-                            <button
-                              className="euiButton euiButton--primary euiButton-isDisabled"
+                            <EuiButtonDisplay
+                              baseClassName="euiButton"
                               disabled={true}
+                              element="button"
+                              iconType="plusInCircle"
+                              isDisabled={true}
                               onClick={[Function]}
+                              size="s"
                               style={
                                 Object {
-                                  "minWidth": undefined,
                                   "width": "70%",
                                 }
                               }
                               type="button"
                             >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="left"
-                                iconType="plusInCircle"
-                                textProps={
+                              <button
+                                className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
+                                disabled={true}
+                                onClick={[Function]}
+                                style={
                                   Object {
-                                    "className": "euiButton__text",
+                                    "minWidth": undefined,
+                                    "width": "70%",
                                   }
                                 }
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButton__content"
+                                <EuiButtonContent
+                                  className="euiButton__content"
+                                  iconSide="left"
+                                  iconType="plusInCircle"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButton__text",
+                                    }
+                                  }
                                 >
-                                  <EuiIcon
-                                    className="euiButtonContent__icon"
-                                    color="inherit"
-                                    size="m"
-                                    type="plusInCircle"
-                                  >
-                                    EuiIconMock
-                                  </EuiIcon>
                                   <span
-                                    className="euiButton__text"
+                                    className="euiButtonContent euiButton__content"
                                   >
-                                    Add map
+                                    <EuiIcon
+                                      className="euiButtonContent__icon"
+                                      color="inherit"
+                                      size="m"
+                                      type="plusInCircle"
+                                    >
+                                      EuiIconMock
+                                    </EuiIcon>
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Add map
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonDisplay>
-                        </EuiButton>
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonDisplay>
+                          </EuiButton>
+                        </EuiSmallButton>
                       </div>
                     </EuiPanel>
                   </div>
@@ -2603,71 +2730,79 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                       className="euiSpacer euiSpacer--m"
                     />
                   </EuiSpacer>
-                  <EuiButton
+                  <EuiSmallButton
                     fullWidth={true}
                     iconType="plusInCircle"
                     onClick={[Function]}
                   >
-                    <EuiButtonDisplay
-                      baseClassName="euiButton"
-                      disabled={false}
-                      element="button"
+                    <EuiButton
                       fullWidth={true}
                       iconType="plusInCircle"
-                      isDisabled={false}
                       onClick={[Function]}
-                      type="button"
+                      size="s"
                     >
-                      <button
-                        className="euiButton euiButton--primary euiButton--fullWidth"
+                      <EuiButtonDisplay
+                        baseClassName="euiButton"
                         disabled={false}
+                        element="button"
+                        fullWidth={true}
+                        iconType="plusInCircle"
+                        isDisabled={false}
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
+                        size="s"
                         type="button"
                       >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          iconType="plusInCircle"
-                          textProps={
+                        <button
+                          className="euiButton euiButton--primary euiButton--small euiButton--fullWidth"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
                             Object {
-                              "className": "euiButton__text",
+                              "minWidth": undefined,
                             }
                           }
+                          type="button"
                         >
-                          <span
-                            className="euiButtonContent euiButton__content"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            iconType="plusInCircle"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text",
+                              }
+                            }
                           >
-                            <EuiIcon
-                              className="euiButtonContent__icon"
-                              color="inherit"
-                              size="m"
-                              type="plusInCircle"
-                            >
-                              EuiIconMock
-                            </EuiIcon>
                             <span
-                              className="euiButton__text"
+                              className="euiButtonContent euiButton__content"
                             >
-                              Add selection
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="plusInCircle"
+                              >
+                                EuiIconMock
+                              </EuiIcon>
+                              <span
+                                className="euiButton__text"
+                              >
+                                Add selection
+                              </span>
                             </span>
-                          </span>
-                        </EuiButtonContent>
-                      </button>
-                    </EuiButtonDisplay>
-                  </EuiButton>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonDisplay>
+                    </EuiButton>
+                  </EuiSmallButton>
                   <EuiSpacer>
                     <div
                       className="euiSpacer euiSpacer--l"
                     />
                   </EuiSpacer>
-                  <EuiFormRow
+                  <EuiCompressedFormRow
                     describedByIds={Array []}
-                    display="row"
+                    display="rowCompressed"
                     fullWidth={false}
                     hasChildLabel={true}
                     hasEmptyLabelSpace={false}
@@ -2685,7 +2820,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                         >
                           Define how each selection should be included in the final query. For more options use
                            
-                          <EuiButtonEmpty
+                          <EuiSmallButtonEmpty
                             className="empty-text-button"
                             onClick={[Function]}
                           >
@@ -2694,7 +2829,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                             >
                               YAML editor
                             </EuiText>
-                          </EuiButtonEmpty>
+                          </EuiSmallButtonEmpty>
                           .
                         </EuiText>
                       </React.Fragment>
@@ -2707,7 +2842,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                     }
                   >
                     <div
-                      className="euiFormRow"
+                      className="euiFormRow euiFormRow--compressed"
                       id="some_html_id-row"
                       style={
                         Object {
@@ -2745,46 +2880,52 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                               >
                                 Define how each selection should be included in the final query. For more options use
                                  
-                                <EuiButtonEmpty
+                                <EuiSmallButtonEmpty
                                   className="empty-text-button"
                                   onClick={[Function]}
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
-                                    disabled={false}
+                                  <EuiButtonEmpty
+                                    className="empty-text-button"
                                     onClick={[Function]}
-                                    type="button"
+                                    size="s"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="left"
-                                      iconSize="m"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small empty-text-button"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="m"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
                                       >
                                         <span
-                                          className="euiButtonEmpty__text"
+                                          className="euiButtonContent euiButtonEmpty__content"
                                         >
-                                          <EuiText
-                                            size="s"
+                                          <span
+                                            className="euiButtonEmpty__text"
                                           >
-                                            <div
-                                              className="euiText euiText--small"
+                                            <EuiText
+                                              size="s"
                                             >
-                                              YAML editor
-                                            </div>
-                                          </EuiText>
+                                              <div
+                                                className="euiText euiText--small"
+                                              >
+                                                YAML editor
+                                              </div>
+                                            </EuiText>
+                                          </span>
                                         </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </EuiSmallButtonEmpty>
                                 .
                               </div>
                             </EuiText>
@@ -2915,7 +3056,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                         </EuiCodeEditor>
                       </div>
                     </div>
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </div>
               </DetectionVisualEditor>
               <EuiSpacer
@@ -3032,9 +3173,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                 onChange={[Function]}
                                 placeholder="tag"
                               >
-                                <EuiFormRow
+                                <EuiCompressedFormRow
                                   describedByIds={Array []}
-                                  display="row"
+                                  display="rowCompressed"
                                   error=""
                                   fullWidth={false}
                                   hasChildLabel={true}
@@ -3066,7 +3207,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                   labelType="label"
                                 >
                                   <div
-                                    className="euiFormRow"
+                                    className="euiFormRow euiFormRow--compressed"
                                     id="some_html_id-row"
                                   >
                                     <div
@@ -3141,38 +3282,50 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 }
                                               }
                                             >
-                                              <EuiFieldText
+                                              <EuiCompressedFieldText
                                                 data-test-subj="rule_tags_field_0"
                                                 name="tags"
                                                 onChange={[Function]}
                                                 placeholder="tag"
                                                 value=""
                                               >
-                                                <EuiFormControlLayout
-                                                  fullWidth={false}
+                                                <EuiFieldText
+                                                  compressed={true}
+                                                  data-test-subj="rule_tags_field_0"
+                                                  name="tags"
+                                                  onChange={[Function]}
+                                                  placeholder="tag"
+                                                  value=""
                                                 >
-                                                  <div
-                                                    className="euiFormControlLayout"
+                                                  <EuiFormControlLayout
+                                                    compressed={true}
+                                                    fullWidth={false}
                                                   >
                                                     <div
-                                                      className="euiFormControlLayout__childrenWrapper"
+                                                      className="euiFormControlLayout euiFormControlLayout--compressed"
                                                     >
-                                                      <EuiValidatableControl>
-                                                        <input
-                                                          className="euiFieldText"
-                                                          data-test-subj="rule_tags_field_0"
-                                                          name="tags"
-                                                          onChange={[Function]}
-                                                          placeholder="tag"
-                                                          type="text"
-                                                          value=""
+                                                      <div
+                                                        className="euiFormControlLayout__childrenWrapper"
+                                                      >
+                                                        <EuiValidatableControl>
+                                                          <input
+                                                            className="euiFieldText euiFieldText--compressed"
+                                                            data-test-subj="rule_tags_field_0"
+                                                            name="tags"
+                                                            onChange={[Function]}
+                                                            placeholder="tag"
+                                                            type="text"
+                                                            value=""
+                                                          />
+                                                        </EuiValidatableControl>
+                                                        <EuiFormControlLayoutIcons
+                                                          compressed={true}
                                                         />
-                                                      </EuiValidatableControl>
-                                                      <EuiFormControlLayoutIcons />
+                                                      </div>
                                                     </div>
-                                                  </div>
-                                                </EuiFormControlLayout>
-                                              </EuiFieldText>
+                                                  </EuiFormControlLayout>
+                                                </EuiFieldText>
+                                              </EuiCompressedFieldText>
                                             </div>
                                           </EuiFlexItem>
                                         </div>
@@ -3184,56 +3337,64 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                      <EuiButton
+                                      <EuiSmallButton
                                         className="secondary"
                                         onClick={[Function]}
                                         type="button"
                                       >
-                                        <EuiButtonDisplay
-                                          baseClassName="euiButton"
+                                        <EuiButton
                                           className="secondary"
-                                          disabled={false}
-                                          element="button"
-                                          isDisabled={false}
                                           onClick={[Function]}
+                                          size="s"
                                           type="button"
                                         >
-                                          <button
-                                            className="euiButton euiButton--primary secondary"
+                                          <EuiButtonDisplay
+                                            baseClassName="euiButton"
+                                            className="secondary"
                                             disabled={false}
+                                            element="button"
+                                            isDisabled={false}
                                             onClick={[Function]}
-                                            style={
-                                              Object {
-                                                "minWidth": undefined,
-                                              }
-                                            }
+                                            size="s"
                                             type="button"
                                           >
-                                            <EuiButtonContent
-                                              className="euiButton__content"
-                                              iconSide="left"
-                                              textProps={
+                                            <button
+                                              className="euiButton euiButton--primary euiButton--small secondary"
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              style={
                                                 Object {
-                                                  "className": "euiButton__text",
+                                                  "minWidth": undefined,
                                                 }
                                               }
+                                              type="button"
                                             >
-                                              <span
-                                                className="euiButtonContent euiButton__content"
+                                              <EuiButtonContent
+                                                className="euiButton__content"
+                                                iconSide="left"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButton__text",
+                                                  }
+                                                }
                                               >
                                                 <span
-                                                  className="euiButton__text"
+                                                  className="euiButtonContent euiButton__content"
                                                 >
-                                                  Add tag
+                                                  <span
+                                                    className="euiButton__text"
+                                                  >
+                                                    Add tag
+                                                  </span>
                                                 </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonDisplay>
-                                      </EuiButton>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonDisplay>
+                                        </EuiButton>
+                                      </EuiSmallButton>
                                     </div>
                                   </div>
-                                </EuiFormRow>
+                                </EuiCompressedFormRow>
                                 <EuiSpacer>
                                   <div
                                     className="euiSpacer euiSpacer--l"
@@ -3272,9 +3433,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                 onChange={[Function]}
                                 placeholder="http://"
                               >
-                                <EuiFormRow
+                                <EuiCompressedFormRow
                                   describedByIds={Array []}
-                                  display="row"
+                                  display="rowCompressed"
                                   error=""
                                   fullWidth={false}
                                   hasChildLabel={true}
@@ -3306,7 +3467,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                   labelType="label"
                                 >
                                   <div
-                                    className="euiFormRow"
+                                    className="euiFormRow euiFormRow--compressed"
                                     id="some_html_id-row"
                                   >
                                     <div
@@ -3381,38 +3542,50 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 }
                                               }
                                             >
-                                              <EuiFieldText
+                                              <EuiCompressedFieldText
                                                 data-test-subj="rule_references_field_0"
                                                 name="references"
                                                 onChange={[Function]}
                                                 placeholder="http://"
                                                 value=""
                                               >
-                                                <EuiFormControlLayout
-                                                  fullWidth={false}
+                                                <EuiFieldText
+                                                  compressed={true}
+                                                  data-test-subj="rule_references_field_0"
+                                                  name="references"
+                                                  onChange={[Function]}
+                                                  placeholder="http://"
+                                                  value=""
                                                 >
-                                                  <div
-                                                    className="euiFormControlLayout"
+                                                  <EuiFormControlLayout
+                                                    compressed={true}
+                                                    fullWidth={false}
                                                   >
                                                     <div
-                                                      className="euiFormControlLayout__childrenWrapper"
+                                                      className="euiFormControlLayout euiFormControlLayout--compressed"
                                                     >
-                                                      <EuiValidatableControl>
-                                                        <input
-                                                          className="euiFieldText"
-                                                          data-test-subj="rule_references_field_0"
-                                                          name="references"
-                                                          onChange={[Function]}
-                                                          placeholder="http://"
-                                                          type="text"
-                                                          value=""
+                                                      <div
+                                                        className="euiFormControlLayout__childrenWrapper"
+                                                      >
+                                                        <EuiValidatableControl>
+                                                          <input
+                                                            className="euiFieldText euiFieldText--compressed"
+                                                            data-test-subj="rule_references_field_0"
+                                                            name="references"
+                                                            onChange={[Function]}
+                                                            placeholder="http://"
+                                                            type="text"
+                                                            value=""
+                                                          />
+                                                        </EuiValidatableControl>
+                                                        <EuiFormControlLayoutIcons
+                                                          compressed={true}
                                                         />
-                                                      </EuiValidatableControl>
-                                                      <EuiFormControlLayoutIcons />
+                                                      </div>
                                                     </div>
-                                                  </div>
-                                                </EuiFormControlLayout>
-                                              </EuiFieldText>
+                                                  </EuiFormControlLayout>
+                                                </EuiFieldText>
+                                              </EuiCompressedFieldText>
                                             </div>
                                           </EuiFlexItem>
                                         </div>
@@ -3424,56 +3597,64 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                      <EuiButton
+                                      <EuiSmallButton
                                         className="secondary"
                                         onClick={[Function]}
                                         type="button"
                                       >
-                                        <EuiButtonDisplay
-                                          baseClassName="euiButton"
+                                        <EuiButton
                                           className="secondary"
-                                          disabled={false}
-                                          element="button"
-                                          isDisabled={false}
                                           onClick={[Function]}
+                                          size="s"
                                           type="button"
                                         >
-                                          <button
-                                            className="euiButton euiButton--primary secondary"
+                                          <EuiButtonDisplay
+                                            baseClassName="euiButton"
+                                            className="secondary"
                                             disabled={false}
+                                            element="button"
+                                            isDisabled={false}
                                             onClick={[Function]}
-                                            style={
-                                              Object {
-                                                "minWidth": undefined,
-                                              }
-                                            }
+                                            size="s"
                                             type="button"
                                           >
-                                            <EuiButtonContent
-                                              className="euiButton__content"
-                                              iconSide="left"
-                                              textProps={
+                                            <button
+                                              className="euiButton euiButton--primary euiButton--small secondary"
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              style={
                                                 Object {
-                                                  "className": "euiButton__text",
+                                                  "minWidth": undefined,
                                                 }
                                               }
+                                              type="button"
                                             >
-                                              <span
-                                                className="euiButtonContent euiButton__content"
+                                              <EuiButtonContent
+                                                className="euiButton__content"
+                                                iconSide="left"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButton__text",
+                                                  }
+                                                }
                                               >
                                                 <span
-                                                  className="euiButton__text"
+                                                  className="euiButtonContent euiButton__content"
                                                 >
-                                                  Add URL
+                                                  <span
+                                                    className="euiButton__text"
+                                                  >
+                                                    Add URL
+                                                  </span>
                                                 </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonDisplay>
-                                      </EuiButton>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonDisplay>
+                                        </EuiButton>
+                                      </EuiSmallButton>
                                     </div>
                                   </div>
-                                </EuiFormRow>
+                                </EuiCompressedFormRow>
                                 <EuiSpacer>
                                   <div
                                     className="euiSpacer euiSpacer--l"
@@ -3512,9 +3693,9 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                 onChange={[Function]}
                                 placeholder="format?"
                               >
-                                <EuiFormRow
+                                <EuiCompressedFormRow
                                   describedByIds={Array []}
-                                  display="row"
+                                  display="rowCompressed"
                                   error=""
                                   fullWidth={false}
                                   hasChildLabel={true}
@@ -3546,7 +3727,7 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                   labelType="label"
                                 >
                                   <div
-                                    className="euiFormRow"
+                                    className="euiFormRow euiFormRow--compressed"
                                     id="some_html_id-row"
                                   >
                                     <div
@@ -3621,38 +3802,50 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                                 }
                                               }
                                             >
-                                              <EuiFieldText
+                                              <EuiCompressedFieldText
                                                 data-test-subj="rule_false_positives_field_0"
                                                 name="false_positives"
                                                 onChange={[Function]}
                                                 placeholder="format?"
                                                 value=""
                                               >
-                                                <EuiFormControlLayout
-                                                  fullWidth={false}
+                                                <EuiFieldText
+                                                  compressed={true}
+                                                  data-test-subj="rule_false_positives_field_0"
+                                                  name="false_positives"
+                                                  onChange={[Function]}
+                                                  placeholder="format?"
+                                                  value=""
                                                 >
-                                                  <div
-                                                    className="euiFormControlLayout"
+                                                  <EuiFormControlLayout
+                                                    compressed={true}
+                                                    fullWidth={false}
                                                   >
                                                     <div
-                                                      className="euiFormControlLayout__childrenWrapper"
+                                                      className="euiFormControlLayout euiFormControlLayout--compressed"
                                                     >
-                                                      <EuiValidatableControl>
-                                                        <input
-                                                          className="euiFieldText"
-                                                          data-test-subj="rule_false_positives_field_0"
-                                                          name="false_positives"
-                                                          onChange={[Function]}
-                                                          placeholder="format?"
-                                                          type="text"
-                                                          value=""
+                                                      <div
+                                                        className="euiFormControlLayout__childrenWrapper"
+                                                      >
+                                                        <EuiValidatableControl>
+                                                          <input
+                                                            className="euiFieldText euiFieldText--compressed"
+                                                            data-test-subj="rule_false_positives_field_0"
+                                                            name="false_positives"
+                                                            onChange={[Function]}
+                                                            placeholder="format?"
+                                                            type="text"
+                                                            value=""
+                                                          />
+                                                        </EuiValidatableControl>
+                                                        <EuiFormControlLayoutIcons
+                                                          compressed={true}
                                                         />
-                                                      </EuiValidatableControl>
-                                                      <EuiFormControlLayoutIcons />
+                                                      </div>
                                                     </div>
-                                                  </div>
-                                                </EuiFormControlLayout>
-                                              </EuiFieldText>
+                                                  </EuiFormControlLayout>
+                                                </EuiFieldText>
+                                              </EuiCompressedFieldText>
                                             </div>
                                           </EuiFlexItem>
                                         </div>
@@ -3664,56 +3857,64 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                           className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                      <EuiButton
+                                      <EuiSmallButton
                                         className="secondary"
                                         onClick={[Function]}
                                         type="button"
                                       >
-                                        <EuiButtonDisplay
-                                          baseClassName="euiButton"
+                                        <EuiButton
                                           className="secondary"
-                                          disabled={false}
-                                          element="button"
-                                          isDisabled={false}
                                           onClick={[Function]}
+                                          size="s"
                                           type="button"
                                         >
-                                          <button
-                                            className="euiButton euiButton--primary secondary"
+                                          <EuiButtonDisplay
+                                            baseClassName="euiButton"
+                                            className="secondary"
                                             disabled={false}
+                                            element="button"
+                                            isDisabled={false}
                                             onClick={[Function]}
-                                            style={
-                                              Object {
-                                                "minWidth": undefined,
-                                              }
-                                            }
+                                            size="s"
                                             type="button"
                                           >
-                                            <EuiButtonContent
-                                              className="euiButton__content"
-                                              iconSide="left"
-                                              textProps={
+                                            <button
+                                              className="euiButton euiButton--primary euiButton--small secondary"
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              style={
                                                 Object {
-                                                  "className": "euiButton__text",
+                                                  "minWidth": undefined,
                                                 }
                                               }
+                                              type="button"
                                             >
-                                              <span
-                                                className="euiButtonContent euiButton__content"
+                                              <EuiButtonContent
+                                                className="euiButton__content"
+                                                iconSide="left"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButton__text",
+                                                  }
+                                                }
                                               >
                                                 <span
-                                                  className="euiButton__text"
+                                                  className="euiButtonContent euiButton__content"
                                                 >
-                                                  Add false positive
+                                                  <span
+                                                    className="euiButton__text"
+                                                  >
+                                                    Add false positive
+                                                  </span>
                                                 </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonDisplay>
-                                      </EuiButton>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonDisplay>
+                                        </EuiButton>
+                                      </EuiSmallButton>
                                     </div>
                                   </div>
-                                </EuiFormRow>
+                                </EuiCompressedFormRow>
                                 <EuiSpacer>
                                   <div
                                     className="euiSpacer euiSpacer--l"
@@ -3747,50 +3948,56 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 <div
                   className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiButton
+                  <EuiSmallButton
                     onClick={[Function]}
                   >
-                    <EuiButtonDisplay
-                      baseClassName="euiButton"
-                      disabled={false}
-                      element="button"
-                      isDisabled={false}
+                    <EuiButton
                       onClick={[Function]}
-                      type="button"
+                      size="s"
                     >
-                      <button
-                        className="euiButton euiButton--primary"
+                      <EuiButtonDisplay
+                        baseClassName="euiButton"
                         disabled={false}
+                        element="button"
+                        isDisabled={false}
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
+                        size="s"
                         type="button"
                       >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
+                        <button
+                          className="euiButton euiButton--primary euiButton--small"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
                             Object {
-                              "className": "euiButton__text",
+                              "minWidth": undefined,
                             }
                           }
+                          type="button"
                         >
-                          <span
-                            className="euiButtonContent euiButton__content"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text",
+                              }
+                            }
                           >
                             <span
-                              className="euiButton__text"
+                              className="euiButtonContent euiButton__content"
                             >
-                              Cancel
+                              <span
+                                className="euiButton__text"
+                              >
+                                Cancel
+                              </span>
                             </span>
-                          </span>
-                        </EuiButtonContent>
-                      </button>
-                    </EuiButtonDisplay>
-                  </EuiButton>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonDisplay>
+                    </EuiButton>
+                  </EuiSmallButton>
                 </div>
               </EuiFlexItem>
               <EuiFlexItem
@@ -3799,55 +4006,63 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                 <div
                   className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj="submit_rule_form_button"
                     fill={true}
                     onClick={[Function]}
                   >
-                    <EuiButtonDisplay
-                      baseClassName="euiButton"
+                    <EuiButton
                       data-test-subj="submit_rule_form_button"
-                      disabled={false}
-                      element="button"
                       fill={true}
-                      isDisabled={false}
                       onClick={[Function]}
-                      type="button"
+                      size="s"
                     >
-                      <button
-                        className="euiButton euiButton--primary euiButton--fill"
+                      <EuiButtonDisplay
+                        baseClassName="euiButton"
                         data-test-subj="submit_rule_form_button"
                         disabled={false}
+                        element="button"
+                        fill={true}
+                        isDisabled={false}
                         onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
+                        size="s"
                         type="button"
                       >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
+                        <button
+                          className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                          data-test-subj="submit_rule_form_button"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
                             Object {
-                              "className": "euiButton__text",
+                              "minWidth": undefined,
                             }
                           }
+                          type="button"
                         >
-                          <span
-                            className="euiButtonContent euiButton__content"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text",
+                              }
+                            }
                           >
                             <span
-                              className="euiButton__text"
+                              className="euiButtonContent euiButton__content"
                             >
-                              Create detection rule
+                              <span
+                                className="euiButton__text"
+                              >
+                                Create detection rule
+                              </span>
                             </span>
-                          </span>
-                        </EuiButtonContent>
-                      </button>
-                    </EuiButtonDisplay>
-                  </EuiButton>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonDisplay>
+                    </EuiButton>
+                  </EuiSmallButton>
                 </div>
               </EuiFlexItem>
             </div>

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorForm.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorForm.test.tsx.snap
@@ -305,9 +305,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 className="euiSpacer euiSpacer--l"
               />
             </EuiSpacer>
-            <EuiFormRow
+            <EuiCompressedFormRow
               describedByIds={Array []}
-              display="row"
+              display="rowCompressed"
               fullWidth={false}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
@@ -324,7 +324,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               labelType="label"
             >
               <div
-                className="euiFormRow"
+                className="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -357,7 +357,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 <div
                   className="euiFormRow__fieldWrapper"
                 >
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     aria-describedby="some_html_id-help-0"
                     data-test-subj="rule_name_field"
                     id="some_html_id"
@@ -367,35 +367,50 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                     placeholder="My custom rule"
                     value=""
                   >
-                    <EuiFormControlLayout
-                      fullWidth={false}
-                      inputId="some_html_id"
+                    <EuiFieldText
+                      aria-describedby="some_html_id-help-0"
+                      compressed={true}
+                      data-test-subj="rule_name_field"
+                      id="some_html_id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder="My custom rule"
+                      value=""
                     >
-                      <div
-                        className="euiFormControlLayout"
+                      <EuiFormControlLayout
+                        compressed={true}
+                        fullWidth={false}
+                        inputId="some_html_id"
                       >
                         <div
-                          className="euiFormControlLayout__childrenWrapper"
+                          className="euiFormControlLayout euiFormControlLayout--compressed"
                         >
-                          <EuiValidatableControl>
-                            <input
-                              aria-describedby="some_html_id-help-0"
-                              className="euiFieldText"
-                              data-test-subj="rule_name_field"
-                              id="some_html_id"
-                              onBlur={[Function]}
-                              onChange={[Function]}
-                              onFocus={[Function]}
-                              placeholder="My custom rule"
-                              type="text"
-                              value=""
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                className="euiFieldText euiFieldText--compressed"
+                                data-test-subj="rule_name_field"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="My custom rule"
+                                type="text"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              compressed={true}
                             />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons />
+                          </div>
                         </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiFieldText>
+                      </EuiFormControlLayout>
+                    </EuiFieldText>
+                  </EuiCompressedFieldText>
                   <EuiFormHelpText
                     className="euiFormRow__text"
                     id="some_html_id-help-0"
@@ -410,7 +425,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                   </EuiFormHelpText>
                 </div>
               </div>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer
               size="m"
             >
@@ -418,9 +433,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 className="euiSpacer euiSpacer--m"
               />
             </EuiSpacer>
-            <EuiFormRow
+            <EuiCompressedFormRow
               describedByIds={Array []}
-              display="row"
+              display="rowCompressed"
               fullWidth={false}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
@@ -439,7 +454,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               labelType="label"
             >
               <div
-                className="euiFormRow"
+                className="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -475,7 +490,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 <div
                   className="euiFormRow__fieldWrapper"
                 >
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     data-test-subj="rule_description_field"
                     id="some_html_id"
                     onBlur={[Function]}
@@ -484,37 +499,51 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                     placeholder="Detects ..."
                     value=""
                   >
-                    <EuiFormControlLayout
-                      fullWidth={false}
-                      inputId="some_html_id"
+                    <EuiFieldText
+                      compressed={true}
+                      data-test-subj="rule_description_field"
+                      id="some_html_id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder="Detects ..."
+                      value=""
                     >
-                      <div
-                        className="euiFormControlLayout"
+                      <EuiFormControlLayout
+                        compressed={true}
+                        fullWidth={false}
+                        inputId="some_html_id"
                       >
                         <div
-                          className="euiFormControlLayout__childrenWrapper"
+                          className="euiFormControlLayout euiFormControlLayout--compressed"
                         >
-                          <EuiValidatableControl>
-                            <input
-                              className="euiFieldText"
-                              data-test-subj="rule_description_field"
-                              id="some_html_id"
-                              onBlur={[Function]}
-                              onChange={[Function]}
-                              onFocus={[Function]}
-                              placeholder="Detects ..."
-                              type="text"
-                              value=""
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                className="euiFieldText euiFieldText--compressed"
+                                data-test-subj="rule_description_field"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Detects ..."
+                                type="text"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              compressed={true}
                             />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons />
+                          </div>
                         </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiFieldText>
+                      </EuiFormControlLayout>
+                    </EuiFieldText>
+                  </EuiCompressedFieldText>
                 </div>
               </div>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer
               size="m"
             >
@@ -522,9 +551,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 className="euiSpacer euiSpacer--m"
               />
             </EuiSpacer>
-            <EuiFormRow
+            <EuiCompressedFormRow
               describedByIds={Array []}
-              display="row"
+              display="rowCompressed"
               fullWidth={false}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
@@ -541,7 +570,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               labelType="label"
             >
               <div
-                className="euiFormRow"
+                className="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -574,7 +603,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 <div
                   className="euiFormRow__fieldWrapper"
                 >
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     aria-describedby="some_html_id-help-0"
                     data-test-subj="rule_author_field"
                     id="some_html_id"
@@ -584,35 +613,50 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                     placeholder="Enter author name"
                     value=""
                   >
-                    <EuiFormControlLayout
-                      fullWidth={false}
-                      inputId="some_html_id"
+                    <EuiFieldText
+                      aria-describedby="some_html_id-help-0"
+                      compressed={true}
+                      data-test-subj="rule_author_field"
+                      id="some_html_id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder="Enter author name"
+                      value=""
                     >
-                      <div
-                        className="euiFormControlLayout"
+                      <EuiFormControlLayout
+                        compressed={true}
+                        fullWidth={false}
+                        inputId="some_html_id"
                       >
                         <div
-                          className="euiFormControlLayout__childrenWrapper"
+                          className="euiFormControlLayout euiFormControlLayout--compressed"
                         >
-                          <EuiValidatableControl>
-                            <input
-                              aria-describedby="some_html_id-help-0"
-                              className="euiFieldText"
-                              data-test-subj="rule_author_field"
-                              id="some_html_id"
-                              onBlur={[Function]}
-                              onChange={[Function]}
-                              onFocus={[Function]}
-                              placeholder="Enter author name"
-                              type="text"
-                              value=""
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                className="euiFieldText euiFieldText--compressed"
+                                data-test-subj="rule_author_field"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Enter author name"
+                                type="text"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              compressed={true}
                             />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons />
+                          </div>
                         </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiFieldText>
+                      </EuiFormControlLayout>
+                    </EuiFieldText>
+                  </EuiCompressedFieldText>
                   <EuiFormHelpText
                     className="euiFormRow__text"
                     id="some_html_id-help-0"
@@ -627,7 +671,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                   </EuiFormHelpText>
                 </div>
               </div>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer
               size="xl"
             >
@@ -674,9 +718,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                       }
                     }
                   >
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       describedByIds={Array []}
-                      display="row"
+                      display="rowCompressed"
                       fullWidth={false}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
@@ -692,7 +736,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                       labelType="label"
                     >
                       <div
-                        className="euiFormRow"
+                        className="euiFormRow euiFormRow--compressed"
                         id="some_html_id-row"
                       >
                         <div
@@ -725,9 +769,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                         <div
                           className="euiFormRow__fieldWrapper"
                         >
-                          <EuiComboBox
+                          <EuiCompressedComboBox
                             async={false}
-                            compressed={false}
+                            compressed={true}
                             data-test-subj="rule_type_dropdown"
                             fullWidth={false}
                             id="some_html_id"
@@ -748,14 +792,14 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                             <div
                               aria-expanded={false}
                               aria-haspopup="listbox"
-                              className="euiComboBox"
+                              className="euiComboBox euiComboBox--compressed"
                               data-test-subj="rule_type_dropdown"
                               onKeyDown={[Function]}
                               role="combobox"
                             >
                               <EuiComboBoxInput
                                 autoSizeInputRef={[Function]}
-                                compressed={false}
+                                compressed={true}
                                 fullWidth={false}
                                 hasSelectedOptions={false}
                                 id="some_html_id"
@@ -783,7 +827,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                 value=""
                               >
                                 <EuiFormControlLayout
-                                  compressed={false}
+                                  compressed={true}
                                   fullWidth={false}
                                   icon={
                                     Object {
@@ -798,13 +842,13 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                   }
                                 >
                                   <div
-                                    className="euiFormControlLayout"
+                                    className="euiFormControlLayout euiFormControlLayout--compressed"
                                   >
                                     <div
                                       className="euiFormControlLayout__childrenWrapper"
                                     >
                                       <div
-                                        className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                        className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                         data-test-subj="comboBoxInput"
                                         onClick={[Function]}
                                         tabIndex={-1}
@@ -875,7 +919,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         </AutosizeInput>
                                       </div>
                                       <EuiFormControlLayoutIcons
-                                        compressed={false}
+                                        compressed={true}
                                         icon={
                                           Object {
                                             "aria-label": "Open list of options",
@@ -896,7 +940,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                             data-test-subj="comboBoxToggleListButton"
                                             iconRef={[Function]}
                                             onClick={[Function]}
-                                            size="m"
+                                            size="s"
                                             type="arrowDown"
                                           >
                                             <button
@@ -909,7 +953,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               <EuiIcon
                                                 aria-hidden="true"
                                                 className="euiFormControlLayoutCustomIcon__icon"
-                                                size="m"
+                                                size="s"
                                                 type="arrowDown"
                                               >
                                                 EuiIconMock
@@ -923,10 +967,10 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                 </EuiFormControlLayout>
                               </EuiComboBoxInput>
                             </div>
-                          </EuiComboBox>
+                          </EuiCompressedComboBox>
                         </div>
                       </div>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </div>
                 </EuiFlexItem>
                 <EuiFlexItem
@@ -945,57 +989,64 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                       }
                     }
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       href="opensearch_security_analytics_dashboards#/log-types"
                       target="_blank"
                     >
-                      <EuiButtonDisplay
-                        baseClassName="euiButton"
-                        element="a"
+                      <EuiButton
                         href="opensearch_security_analytics_dashboards#/log-types"
-                        isDisabled={false}
-                        rel="noopener noreferrer"
+                        size="s"
                         target="_blank"
                       >
-                        <a
-                          className="euiButton euiButton--primary"
-                          disabled={false}
+                        <EuiButtonDisplay
+                          baseClassName="euiButton"
+                          element="a"
                           href="opensearch_security_analytics_dashboards#/log-types"
+                          isDisabled={false}
                           rel="noopener noreferrer"
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                          size="s"
                           target="_blank"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
-                            textProps={
+                          <a
+                            className="euiButton euiButton--primary euiButton--small"
+                            disabled={false}
+                            href="opensearch_security_analytics_dashboards#/log-types"
+                            rel="noopener noreferrer"
+                            style={
                               Object {
-                                "className": "euiButton__text",
+                                "minWidth": undefined,
                               }
                             }
+                            target="_blank"
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <EuiButtonContent
+                              className="euiButton__content"
+                              iconSide="left"
+                              textProps={
+                                Object {
+                                  "className": "euiButton__text",
+                                }
+                              }
                             >
                               <span
-                                className="euiButton__text"
+                                className="euiButtonContent euiButton__content"
                               >
-                                Manage 
-                                <EuiIcon
-                                  type="popout"
+                                <span
+                                  className="euiButton__text"
                                 >
-                                  EuiIconMock
-                                </EuiIcon>
+                                  Manage 
+                                  <EuiIcon
+                                    type="popout"
+                                  >
+                                    EuiIconMock
+                                  </EuiIcon>
+                                </span>
                               </span>
-                            </span>
-                          </EuiButtonContent>
-                        </a>
-                      </EuiButtonDisplay>
-                    </EuiButton>
+                            </EuiButtonContent>
+                          </a>
+                        </EuiButtonDisplay>
+                      </EuiButton>
+                    </EuiSmallButton>
                   </div>
                 </EuiFlexItem>
               </div>
@@ -1005,9 +1056,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 className="euiSpacer euiSpacer--l"
               />
             </EuiSpacer>
-            <EuiFormRow
+            <EuiCompressedFormRow
               describedByIds={Array []}
-              display="row"
+              display="rowCompressed"
               fullWidth={false}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
@@ -1023,7 +1074,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               labelType="label"
             >
               <div
-                className="euiFormRow"
+                className="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -1056,9 +1107,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 <div
                   className="euiFormRow__fieldWrapper"
                 >
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     async={false}
-                    compressed={false}
+                    compressed={true}
                     data-test-subj="rule_severity_dropdown"
                     fullWidth={false}
                     id="some_html_id"
@@ -1102,14 +1153,14 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                     <div
                       aria-expanded={false}
                       aria-haspopup="listbox"
-                      className="euiComboBox"
+                      className="euiComboBox euiComboBox--compressed"
                       data-test-subj="rule_severity_dropdown"
                       onKeyDown={[Function]}
                       role="combobox"
                     >
                       <EuiComboBoxInput
                         autoSizeInputRef={[Function]}
-                        compressed={false}
+                        compressed={true}
                         fullWidth={false}
                         hasSelectedOptions={false}
                         id="some_html_id"
@@ -1137,7 +1188,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                         value=""
                       >
                         <EuiFormControlLayout
-                          compressed={false}
+                          compressed={true}
                           fullWidth={false}
                           icon={
                             Object {
@@ -1152,13 +1203,13 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                           }
                         >
                           <div
-                            className="euiFormControlLayout"
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
                           >
                             <div
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <div
-                                className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                 data-test-subj="comboBoxInput"
                                 onClick={[Function]}
                                 tabIndex={-1}
@@ -1229,7 +1280,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                 </AutosizeInput>
                               </div>
                               <EuiFormControlLayoutIcons
-                                compressed={false}
+                                compressed={true}
                                 icon={
                                   Object {
                                     "aria-label": "Open list of options",
@@ -1250,7 +1301,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                     data-test-subj="comboBoxToggleListButton"
                                     iconRef={[Function]}
                                     onClick={[Function]}
-                                    size="m"
+                                    size="s"
                                     type="arrowDown"
                                   >
                                     <button
@@ -1263,7 +1314,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                       <EuiIcon
                                         aria-hidden="true"
                                         className="euiFormControlLayoutCustomIcon__icon"
-                                        size="m"
+                                        size="s"
                                         type="arrowDown"
                                       >
                                         EuiIconMock
@@ -1277,18 +1328,18 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                         </EuiFormControlLayout>
                       </EuiComboBoxInput>
                     </div>
-                  </EuiComboBox>
+                  </EuiCompressedComboBox>
                 </div>
               </div>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer>
               <div
                 className="euiSpacer euiSpacer--l"
               />
             </EuiSpacer>
-            <EuiFormRow
+            <EuiCompressedFormRow
               describedByIds={Array []}
-              display="row"
+              display="rowCompressed"
               fullWidth={false}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
@@ -1304,7 +1355,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               labelType="label"
             >
               <div
-                className="euiFormRow"
+                className="euiFormRow euiFormRow--compressed"
                 id="some_html_id-row"
               >
                 <div
@@ -1337,9 +1388,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                 <div
                   className="euiFormRow__fieldWrapper"
                 >
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     async={false}
-                    compressed={false}
+                    compressed={true}
                     data-test-subj="rule_status_dropdown"
                     fullWidth={false}
                     id="some_html_id"
@@ -1382,14 +1433,14 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                     <div
                       aria-expanded={false}
                       aria-haspopup="listbox"
-                      className="euiComboBox"
+                      className="euiComboBox euiComboBox--compressed"
                       data-test-subj="rule_status_dropdown"
                       onKeyDown={[Function]}
                       role="combobox"
                     >
                       <EuiComboBoxInput
                         autoSizeInputRef={[Function]}
-                        compressed={false}
+                        compressed={true}
                         fullWidth={false}
                         hasSelectedOptions={true}
                         id="some_html_id"
@@ -1430,7 +1481,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                               "onClick": [Function],
                             }
                           }
-                          compressed={false}
+                          compressed={true}
                           fullWidth={false}
                           icon={
                             Object {
@@ -1445,13 +1496,13 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                           }
                         >
                           <div
-                            className="euiFormControlLayout"
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
                           >
                             <div
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <div
-                                className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                 data-test-subj="comboBoxInput"
                                 onClick={[Function]}
                                 tabIndex={-1}
@@ -1542,7 +1593,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                     "onClick": [Function],
                                   }
                                 }
-                                compressed={false}
+                                compressed={true}
                                 icon={
                                   Object {
                                     "aria-label": "Open list of options",
@@ -1561,7 +1612,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                   <EuiFormControlLayoutClearButton
                                     data-test-subj="comboBoxClearButton"
                                     onClick={[Function]}
-                                    size="m"
+                                    size="s"
                                   >
                                     <EuiI18n
                                       default="Clear input"
@@ -1569,7 +1620,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                     >
                                       <button
                                         aria-label="Clear input"
-                                        className="euiFormControlLayoutClearButton"
+                                        className="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                         data-test-subj="comboBoxClearButton"
                                         onClick={[Function]}
                                         type="button"
@@ -1588,7 +1639,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                     data-test-subj="comboBoxToggleListButton"
                                     iconRef={[Function]}
                                     onClick={[Function]}
-                                    size="m"
+                                    size="s"
                                     type="arrowDown"
                                   >
                                     <button
@@ -1601,7 +1652,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                       <EuiIcon
                                         aria-hidden="true"
                                         className="euiFormControlLayoutCustomIcon__icon"
-                                        size="m"
+                                        size="s"
                                         type="arrowDown"
                                       >
                                         EuiIconMock
@@ -1615,10 +1666,10 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                         </EuiFormControlLayout>
                       </EuiComboBoxInput>
                     </div>
-                  </EuiComboBox>
+                  </EuiCompressedComboBox>
                 </div>
               </div>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer
               size="xxl"
             >
@@ -1693,22 +1744,22 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                             <div
                               className="euiFlexItem"
                             >
-                              <EuiFormRow
+                              <EuiCompressedFormRow
                                 describedByIds={Array []}
-                                display="row"
+                                display="rowCompressed"
                                 fullWidth={false}
                                 hasChildLabel={true}
                                 hasEmptyLabelSpace={false}
                                 labelType="label"
                               >
                                 <div
-                                  className="euiFormRow"
+                                  className="euiFormRow euiFormRow--compressed"
                                   id="some_html_id-row"
                                 >
                                   <div
                                     className="euiFormRow__fieldWrapper"
                                   >
-                                    <EuiFieldText
+                                    <EuiCompressedFieldText
                                       className="detection-visual-editor-name euiTitle--small"
                                       data-test-subj="selection_name"
                                       id="some_html_id"
@@ -1718,37 +1769,52 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                       placeholder="Enter selection name"
                                       value="Selection_1"
                                     >
-                                      <EuiFormControlLayout
-                                        fullWidth={false}
-                                        inputId="some_html_id"
+                                      <EuiFieldText
+                                        className="detection-visual-editor-name euiTitle--small"
+                                        compressed={true}
+                                        data-test-subj="selection_name"
+                                        id="some_html_id"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        placeholder="Enter selection name"
+                                        value="Selection_1"
                                       >
-                                        <div
-                                          className="euiFormControlLayout"
+                                        <EuiFormControlLayout
+                                          compressed={true}
+                                          fullWidth={false}
+                                          inputId="some_html_id"
                                         >
                                           <div
-                                            className="euiFormControlLayout__childrenWrapper"
+                                            className="euiFormControlLayout euiFormControlLayout--compressed"
                                           >
-                                            <EuiValidatableControl>
-                                              <input
-                                                className="euiFieldText detection-visual-editor-name euiTitle--small"
-                                                data-test-subj="selection_name"
-                                                id="some_html_id"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                onFocus={[Function]}
-                                                placeholder="Enter selection name"
-                                                type="text"
-                                                value="Selection_1"
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiValidatableControl>
+                                                <input
+                                                  className="euiFieldText detection-visual-editor-name euiTitle--small euiFieldText--compressed"
+                                                  data-test-subj="selection_name"
+                                                  id="some_html_id"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  onFocus={[Function]}
+                                                  placeholder="Enter selection name"
+                                                  type="text"
+                                                  value="Selection_1"
+                                                />
+                                              </EuiValidatableControl>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
                                               />
-                                            </EuiValidatableControl>
-                                            <EuiFormControlLayoutIcons />
+                                            </div>
                                           </div>
-                                        </div>
-                                      </EuiFormControlLayout>
-                                    </EuiFieldText>
+                                        </EuiFormControlLayout>
+                                      </EuiFieldText>
+                                    </EuiCompressedFieldText>
                                   </div>
                                 </div>
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                               <EuiText
                                 size="s"
                               >
@@ -1887,9 +1953,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               }
                                             }
                                           >
-                                            <EuiFormRow
+                                            <EuiCompressedFormRow
                                               describedByIds={Array []}
-                                              display="row"
+                                              display="rowCompressed"
                                               fullWidth={false}
                                               hasChildLabel={true}
                                               hasEmptyLabelSpace={false}
@@ -1903,7 +1969,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               labelType="label"
                                             >
                                               <div
-                                                className="euiFormRow"
+                                                className="euiFormRow euiFormRow--compressed"
                                                 id="some_html_id-row"
                                               >
                                                 <div
@@ -1934,7 +2000,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                 <div
                                                   className="euiFormRow__fieldWrapper"
                                                 >
-                                                  <EuiFieldText
+                                                  <EuiCompressedFieldText
                                                     data-test-subj="selection_field_key_name"
                                                     id="some_html_id"
                                                     onBlur={[Function]}
@@ -1943,37 +2009,51 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                     placeholder="Enter key name"
                                                     value=""
                                                   >
-                                                    <EuiFormControlLayout
-                                                      fullWidth={false}
-                                                      inputId="some_html_id"
+                                                    <EuiFieldText
+                                                      compressed={true}
+                                                      data-test-subj="selection_field_key_name"
+                                                      id="some_html_id"
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      onFocus={[Function]}
+                                                      placeholder="Enter key name"
+                                                      value=""
                                                     >
-                                                      <div
-                                                        className="euiFormControlLayout"
+                                                      <EuiFormControlLayout
+                                                        compressed={true}
+                                                        fullWidth={false}
+                                                        inputId="some_html_id"
                                                       >
                                                         <div
-                                                          className="euiFormControlLayout__childrenWrapper"
+                                                          className="euiFormControlLayout euiFormControlLayout--compressed"
                                                         >
-                                                          <EuiValidatableControl>
-                                                            <input
-                                                              className="euiFieldText"
-                                                              data-test-subj="selection_field_key_name"
-                                                              id="some_html_id"
-                                                              onBlur={[Function]}
-                                                              onChange={[Function]}
-                                                              onFocus={[Function]}
-                                                              placeholder="Enter key name"
-                                                              type="text"
-                                                              value=""
+                                                          <div
+                                                            className="euiFormControlLayout__childrenWrapper"
+                                                          >
+                                                            <EuiValidatableControl>
+                                                              <input
+                                                                className="euiFieldText euiFieldText--compressed"
+                                                                data-test-subj="selection_field_key_name"
+                                                                id="some_html_id"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                onFocus={[Function]}
+                                                                placeholder="Enter key name"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </EuiValidatableControl>
+                                                            <EuiFormControlLayoutIcons
+                                                              compressed={true}
                                                             />
-                                                          </EuiValidatableControl>
-                                                          <EuiFormControlLayoutIcons />
+                                                          </div>
                                                         </div>
-                                                      </div>
-                                                    </EuiFormControlLayout>
-                                                  </EuiFieldText>
+                                                      </EuiFormControlLayout>
+                                                    </EuiFieldText>
+                                                  </EuiCompressedFieldText>
                                                 </div>
                                               </div>
-                                            </EuiFormRow>
+                                            </EuiCompressedFormRow>
                                           </div>
                                         </EuiFlexItem>
                                         <EuiFlexItem
@@ -1992,9 +2072,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               }
                                             }
                                           >
-                                            <EuiFormRow
+                                            <EuiCompressedFormRow
                                               describedByIds={Array []}
-                                              display="row"
+                                              display="rowCompressed"
                                               fullWidth={false}
                                               hasChildLabel={true}
                                               hasEmptyLabelSpace={false}
@@ -2008,7 +2088,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               labelType="label"
                                             >
                                               <div
-                                                className="euiFormRow"
+                                                className="euiFormRow euiFormRow--compressed"
                                                 id="some_html_id-row"
                                               >
                                                 <div
@@ -2039,9 +2119,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                 <div
                                                   className="euiFormRow__fieldWrapper"
                                                 >
-                                                  <EuiComboBox
+                                                  <EuiCompressedComboBox
                                                     async={false}
-                                                    compressed={false}
+                                                    compressed={true}
                                                     data-test-subj="modifier_dropdown"
                                                     fullWidth={false}
                                                     id="some_html_id"
@@ -2095,14 +2175,14 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                     <div
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
-                                                      className="euiComboBox"
+                                                      className="euiComboBox euiComboBox--compressed"
                                                       data-test-subj="modifier_dropdown"
                                                       onKeyDown={[Function]}
                                                       role="combobox"
                                                     >
                                                       <EuiComboBoxInput
                                                         autoSizeInputRef={[Function]}
-                                                        compressed={false}
+                                                        compressed={true}
                                                         fullWidth={false}
                                                         hasSelectedOptions={true}
                                                         id="some_html_id"
@@ -2142,7 +2222,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                               "onClick": [Function],
                                                             }
                                                           }
-                                                          compressed={false}
+                                                          compressed={true}
                                                           fullWidth={false}
                                                           icon={
                                                             Object {
@@ -2157,13 +2237,13 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                           }
                                                         >
                                                           <div
-                                                            className="euiFormControlLayout"
+                                                            className="euiFormControlLayout euiFormControlLayout--compressed"
                                                           >
                                                             <div
                                                               className="euiFormControlLayout__childrenWrapper"
                                                             >
                                                               <div
-                                                                className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                                                 data-test-subj="comboBoxInput"
                                                                 onClick={[Function]}
                                                                 tabIndex={-1}
@@ -2254,7 +2334,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                                     "onClick": [Function],
                                                                   }
                                                                 }
-                                                                compressed={false}
+                                                                compressed={true}
                                                                 icon={
                                                                   Object {
                                                                     "aria-label": "Open list of options",
@@ -2273,7 +2353,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                                   <EuiFormControlLayoutClearButton
                                                                     data-test-subj="comboBoxClearButton"
                                                                     onClick={[Function]}
-                                                                    size="m"
+                                                                    size="s"
                                                                   >
                                                                     <EuiI18n
                                                                       default="Clear input"
@@ -2281,7 +2361,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                                     >
                                                                       <button
                                                                         aria-label="Clear input"
-                                                                        className="euiFormControlLayoutClearButton"
+                                                                        className="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                                                                         data-test-subj="comboBoxClearButton"
                                                                         onClick={[Function]}
                                                                         type="button"
@@ -2300,7 +2380,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                                     data-test-subj="comboBoxToggleListButton"
                                                                     iconRef={[Function]}
                                                                     onClick={[Function]}
-                                                                    size="m"
+                                                                    size="s"
                                                                     type="arrowDown"
                                                                   >
                                                                     <button
@@ -2313,7 +2393,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                                       <EuiIcon
                                                                         aria-hidden="true"
                                                                         className="euiFormControlLayoutCustomIcon__icon"
-                                                                        size="m"
+                                                                        size="s"
                                                                         type="arrowDown"
                                                                       >
                                                                         EuiIconMock
@@ -2327,10 +2407,10 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                                         </EuiFormControlLayout>
                                                       </EuiComboBoxInput>
                                                     </div>
-                                                  </EuiComboBox>
+                                                  </EuiCompressedComboBox>
                                                 </div>
                                               </div>
-                                            </EuiFormRow>
+                                            </EuiCompressedFormRow>
                                           </div>
                                         </EuiFlexItem>
                                       </div>
@@ -2342,7 +2422,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                    <EuiRadioGroup
+                                    <EuiCompressedRadioGroup
                                       idSelected="selection-map-value-0-0"
                                       onChange={[Function]}
                                       options={
@@ -2358,67 +2438,87 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         ]
                                       }
                                     >
-                                      <div>
-                                        <EuiRadio
-                                          checked={true}
-                                          className="euiRadioGroup__item"
-                                          id="selection-map-value-0-0"
-                                          key="0"
-                                          label="Value"
-                                          onChange={[Function]}
-                                        >
-                                          <div
-                                            className="euiRadio euiRadioGroup__item"
+                                      <EuiRadioGroup
+                                        compressed={true}
+                                        idSelected="selection-map-value-0-0"
+                                        onChange={[Function]}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "id": "selection-map-value-0-0",
+                                              "label": "Value",
+                                            },
+                                            Object {
+                                              "id": "selection-map-list-0-0",
+                                              "label": "List",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <div>
+                                          <EuiRadio
+                                            checked={true}
+                                            className="euiRadioGroup__item"
+                                            compressed={true}
+                                            id="selection-map-value-0-0"
+                                            key="0"
+                                            label="Value"
+                                            onChange={[Function]}
                                           >
-                                            <input
-                                              checked={true}
-                                              className="euiRadio__input"
-                                              id="selection-map-value-0-0"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
                                             <div
-                                              className="euiRadio__circle"
-                                            />
-                                            <label
-                                              className="euiRadio__label"
-                                              htmlFor="selection-map-value-0-0"
+                                              className="euiRadio euiRadio--compressed euiRadioGroup__item"
                                             >
-                                              Value
-                                            </label>
-                                          </div>
-                                        </EuiRadio>
-                                        <EuiRadio
-                                          checked={false}
-                                          className="euiRadioGroup__item"
-                                          id="selection-map-list-0-0"
-                                          key="1"
-                                          label="List"
-                                          onChange={[Function]}
-                                        >
-                                          <div
-                                            className="euiRadio euiRadioGroup__item"
+                                              <input
+                                                checked={true}
+                                                className="euiRadio__input"
+                                                id="selection-map-value-0-0"
+                                                onChange={[Function]}
+                                                type="radio"
+                                              />
+                                              <div
+                                                className="euiRadio__circle"
+                                              />
+                                              <label
+                                                className="euiRadio__label"
+                                                htmlFor="selection-map-value-0-0"
+                                              >
+                                                Value
+                                              </label>
+                                            </div>
+                                          </EuiRadio>
+                                          <EuiRadio
+                                            checked={false}
+                                            className="euiRadioGroup__item"
+                                            compressed={true}
+                                            id="selection-map-list-0-0"
+                                            key="1"
+                                            label="List"
+                                            onChange={[Function]}
                                           >
-                                            <input
-                                              checked={false}
-                                              className="euiRadio__input"
-                                              id="selection-map-list-0-0"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
                                             <div
-                                              className="euiRadio__circle"
-                                            />
-                                            <label
-                                              className="euiRadio__label"
-                                              htmlFor="selection-map-list-0-0"
+                                              className="euiRadio euiRadio--compressed euiRadioGroup__item"
                                             >
-                                              List
-                                            </label>
-                                          </div>
-                                        </EuiRadio>
-                                      </div>
-                                    </EuiRadioGroup>
+                                              <input
+                                                checked={false}
+                                                className="euiRadio__input"
+                                                id="selection-map-list-0-0"
+                                                onChange={[Function]}
+                                                type="radio"
+                                              />
+                                              <div
+                                                className="euiRadio__circle"
+                                              />
+                                              <label
+                                                className="euiRadio__label"
+                                                htmlFor="selection-map-list-0-0"
+                                              >
+                                                List
+                                              </label>
+                                            </div>
+                                          </EuiRadio>
+                                        </div>
+                                      </EuiRadioGroup>
+                                    </EuiCompressedRadioGroup>
                                     <EuiSpacer
                                       size="m"
                                     >
@@ -2426,22 +2526,22 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                    <EuiFormRow
+                                    <EuiCompressedFormRow
                                       describedByIds={Array []}
-                                      display="row"
+                                      display="rowCompressed"
                                       fullWidth={false}
                                       hasChildLabel={true}
                                       hasEmptyLabelSpace={false}
                                       labelType="label"
                                     >
                                       <div
-                                        className="euiFormRow"
+                                        className="euiFormRow euiFormRow--compressed"
                                         id="some_html_id-row"
                                       >
                                         <div
                                           className="euiFormRow__fieldWrapper"
                                         >
-                                          <EuiFieldText
+                                          <EuiCompressedFieldText
                                             data-test-subj="selection_field_value"
                                             id="some_html_id"
                                             onBlur={[Function]}
@@ -2450,37 +2550,51 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                             placeholder="Value"
                                             value=""
                                           >
-                                            <EuiFormControlLayout
-                                              fullWidth={false}
-                                              inputId="some_html_id"
+                                            <EuiFieldText
+                                              compressed={true}
+                                              data-test-subj="selection_field_value"
+                                              id="some_html_id"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              placeholder="Value"
+                                              value=""
                                             >
-                                              <div
-                                                className="euiFormControlLayout"
+                                              <EuiFormControlLayout
+                                                compressed={true}
+                                                fullWidth={false}
+                                                inputId="some_html_id"
                                               >
                                                 <div
-                                                  className="euiFormControlLayout__childrenWrapper"
+                                                  className="euiFormControlLayout euiFormControlLayout--compressed"
                                                 >
-                                                  <EuiValidatableControl>
-                                                    <input
-                                                      className="euiFieldText"
-                                                      data-test-subj="selection_field_value"
-                                                      id="some_html_id"
-                                                      onBlur={[Function]}
-                                                      onChange={[Function]}
-                                                      onFocus={[Function]}
-                                                      placeholder="Value"
-                                                      type="text"
-                                                      value=""
+                                                  <div
+                                                    className="euiFormControlLayout__childrenWrapper"
+                                                  >
+                                                    <EuiValidatableControl>
+                                                      <input
+                                                        className="euiFieldText euiFieldText--compressed"
+                                                        data-test-subj="selection_field_value"
+                                                        id="some_html_id"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onFocus={[Function]}
+                                                        placeholder="Value"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </EuiValidatableControl>
+                                                    <EuiFormControlLayoutIcons
+                                                      compressed={true}
                                                     />
-                                                  </EuiValidatableControl>
-                                                  <EuiFormControlLayoutIcons />
+                                                  </div>
                                                 </div>
-                                              </div>
-                                            </EuiFormControlLayout>
-                                          </EuiFieldText>
+                                              </EuiFormControlLayout>
+                                            </EuiFieldText>
+                                          </EuiCompressedFieldText>
                                         </div>
                                       </div>
-                                    </EuiFormRow>
+                                    </EuiCompressedFormRow>
                                     <EuiSpacer
                                       size="m"
                                     >
@@ -2502,7 +2616,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                           className="euiSpacer euiSpacer--m"
                         />
                       </EuiSpacer>
-                      <EuiButton
+                      <EuiSmallButton
                         disabled={true}
                         iconType="plusInCircle"
                         onClick={[Function]}
@@ -2512,63 +2626,76 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                           }
                         }
                       >
-                        <EuiButtonDisplay
-                          baseClassName="euiButton"
+                        <EuiButton
                           disabled={true}
-                          element="button"
                           iconType="plusInCircle"
-                          isDisabled={true}
                           onClick={[Function]}
+                          size="s"
                           style={
                             Object {
                               "width": "70%",
                             }
                           }
-                          type="button"
                         >
-                          <button
-                            className="euiButton euiButton--primary euiButton-isDisabled"
+                          <EuiButtonDisplay
+                            baseClassName="euiButton"
                             disabled={true}
+                            element="button"
+                            iconType="plusInCircle"
+                            isDisabled={true}
                             onClick={[Function]}
+                            size="s"
                             style={
                               Object {
-                                "minWidth": undefined,
                                 "width": "70%",
                               }
                             }
                             type="button"
                           >
-                            <EuiButtonContent
-                              className="euiButton__content"
-                              iconSide="left"
-                              iconType="plusInCircle"
-                              textProps={
+                            <button
+                              className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
+                              disabled={true}
+                              onClick={[Function]}
+                              style={
                                 Object {
-                                  "className": "euiButton__text",
+                                  "minWidth": undefined,
+                                  "width": "70%",
                                 }
                               }
+                              type="button"
                             >
-                              <span
-                                className="euiButtonContent euiButton__content"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                iconType="plusInCircle"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text",
+                                  }
+                                }
                               >
-                                <EuiIcon
-                                  className="euiButtonContent__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="plusInCircle"
-                                >
-                                  EuiIconMock
-                                </EuiIcon>
                                 <span
-                                  className="euiButton__text"
+                                  className="euiButtonContent euiButton__content"
                                 >
-                                  Add map
+                                  <EuiIcon
+                                    className="euiButtonContent__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="plusInCircle"
+                                  >
+                                    EuiIconMock
+                                  </EuiIcon>
+                                  <span
+                                    className="euiButton__text"
+                                  >
+                                    Add map
+                                  </span>
                                 </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonDisplay>
-                      </EuiButton>
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonDisplay>
+                        </EuiButton>
+                      </EuiSmallButton>
                     </div>
                   </EuiPanel>
                 </div>
@@ -2579,71 +2706,79 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                     className="euiSpacer euiSpacer--m"
                   />
                 </EuiSpacer>
-                <EuiButton
+                <EuiSmallButton
                   fullWidth={true}
                   iconType="plusInCircle"
                   onClick={[Function]}
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    disabled={false}
-                    element="button"
+                  <EuiButton
                     fullWidth={true}
                     iconType="plusInCircle"
-                    isDisabled={false}
                     onClick={[Function]}
-                    type="button"
+                    size="s"
                   >
-                    <button
-                      className="euiButton euiButton--primary euiButton--fullWidth"
+                    <EuiButtonDisplay
+                      baseClassName="euiButton"
                       disabled={false}
+                      element="button"
+                      fullWidth={true}
+                      iconType="plusInCircle"
+                      isDisabled={false}
                       onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                      size="s"
                       type="button"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="plusInCircle"
-                        textProps={
+                      <button
+                        className="euiButton euiButton--primary euiButton--small euiButton--fullWidth"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
                           Object {
-                            "className": "euiButton__text",
+                            "minWidth": undefined,
                           }
                         }
+                        type="button"
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          iconType="plusInCircle"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text",
+                            }
+                          }
                         >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="plusInCircle"
-                          >
-                            EuiIconMock
-                          </EuiIcon>
                           <span
-                            className="euiButton__text"
+                            className="euiButtonContent euiButton__content"
                           >
-                            Add selection
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="plusInCircle"
+                            >
+                              EuiIconMock
+                            </EuiIcon>
+                            <span
+                              className="euiButton__text"
+                            >
+                              Add selection
+                            </span>
                           </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonDisplay>
+                  </EuiButton>
+                </EuiSmallButton>
                 <EuiSpacer>
                   <div
                     className="euiSpacer euiSpacer--l"
                   />
                 </EuiSpacer>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   describedByIds={Array []}
-                  display="row"
+                  display="rowCompressed"
                   fullWidth={false}
                   hasChildLabel={true}
                   hasEmptyLabelSpace={false}
@@ -2661,7 +2796,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                       >
                         Define how each selection should be included in the final query. For more options use
                          
-                        <EuiButtonEmpty
+                        <EuiSmallButtonEmpty
                           className="empty-text-button"
                           onClick={[Function]}
                         >
@@ -2670,7 +2805,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                           >
                             YAML editor
                           </EuiText>
-                        </EuiButtonEmpty>
+                        </EuiSmallButtonEmpty>
                         .
                       </EuiText>
                     </React.Fragment>
@@ -2683,7 +2818,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                   }
                 >
                   <div
-                    className="euiFormRow"
+                    className="euiFormRow euiFormRow--compressed"
                     id="some_html_id-row"
                     style={
                       Object {
@@ -2721,46 +2856,52 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                             >
                               Define how each selection should be included in the final query. For more options use
                                
-                              <EuiButtonEmpty
+                              <EuiSmallButtonEmpty
                                 className="empty-text-button"
                                 onClick={[Function]}
                               >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
-                                  disabled={false}
+                                <EuiButtonEmpty
+                                  className="empty-text-button"
                                   onClick={[Function]}
-                                  type="button"
+                                  size="s"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="m"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small empty-text-button"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="left"
+                                      iconSize="m"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButtonEmpty__text"
+                                        className="euiButtonContent euiButtonEmpty__content"
                                       >
-                                        <EuiText
-                                          size="s"
+                                        <span
+                                          className="euiButtonEmpty__text"
                                         >
-                                          <div
-                                            className="euiText euiText--small"
+                                          <EuiText
+                                            size="s"
                                           >
-                                            YAML editor
-                                          </div>
-                                        </EuiText>
+                                            <div
+                                              className="euiText euiText--small"
+                                            >
+                                              YAML editor
+                                            </div>
+                                          </EuiText>
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </EuiSmallButtonEmpty>
                               .
                             </div>
                           </EuiText>
@@ -2891,7 +3032,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                       </EuiCodeEditor>
                     </div>
                   </div>
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </div>
             </DetectionVisualEditor>
             <EuiSpacer
@@ -3008,9 +3149,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                               onChange={[Function]}
                               placeholder="tag"
                             >
-                              <EuiFormRow
+                              <EuiCompressedFormRow
                                 describedByIds={Array []}
-                                display="row"
+                                display="rowCompressed"
                                 error=""
                                 fullWidth={false}
                                 hasChildLabel={true}
@@ -3042,7 +3183,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                 labelType="label"
                               >
                                 <div
-                                  className="euiFormRow"
+                                  className="euiFormRow euiFormRow--compressed"
                                   id="some_html_id-row"
                                 >
                                   <div
@@ -3117,38 +3258,50 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               }
                                             }
                                           >
-                                            <EuiFieldText
+                                            <EuiCompressedFieldText
                                               data-test-subj="rule_tags_field_0"
                                               name="tags"
                                               onChange={[Function]}
                                               placeholder="tag"
                                               value=""
                                             >
-                                              <EuiFormControlLayout
-                                                fullWidth={false}
+                                              <EuiFieldText
+                                                compressed={true}
+                                                data-test-subj="rule_tags_field_0"
+                                                name="tags"
+                                                onChange={[Function]}
+                                                placeholder="tag"
+                                                value=""
                                               >
-                                                <div
-                                                  className="euiFormControlLayout"
+                                                <EuiFormControlLayout
+                                                  compressed={true}
+                                                  fullWidth={false}
                                                 >
                                                   <div
-                                                    className="euiFormControlLayout__childrenWrapper"
+                                                    className="euiFormControlLayout euiFormControlLayout--compressed"
                                                   >
-                                                    <EuiValidatableControl>
-                                                      <input
-                                                        className="euiFieldText"
-                                                        data-test-subj="rule_tags_field_0"
-                                                        name="tags"
-                                                        onChange={[Function]}
-                                                        placeholder="tag"
-                                                        type="text"
-                                                        value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
+                                                    >
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText euiFieldText--compressed"
+                                                          data-test-subj="rule_tags_field_0"
+                                                          name="tags"
+                                                          onChange={[Function]}
+                                                          placeholder="tag"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons
+                                                        compressed={true}
                                                       />
-                                                    </EuiValidatableControl>
-                                                    <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </div>
-                                              </EuiFormControlLayout>
-                                            </EuiFieldText>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </EuiCompressedFieldText>
                                           </div>
                                         </EuiFlexItem>
                                       </div>
@@ -3160,56 +3313,64 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                    <EuiButton
+                                    <EuiSmallButton
                                       className="secondary"
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      <EuiButtonDisplay
-                                        baseClassName="euiButton"
+                                      <EuiButton
                                         className="secondary"
-                                        disabled={false}
-                                        element="button"
-                                        isDisabled={false}
                                         onClick={[Function]}
+                                        size="s"
                                         type="button"
                                       >
-                                        <button
-                                          className="euiButton euiButton--primary secondary"
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="secondary"
                                           disabled={false}
+                                          element="button"
+                                          isDisabled={false}
                                           onClick={[Function]}
-                                          style={
-                                            Object {
-                                              "minWidth": undefined,
-                                            }
-                                          }
+                                          size="s"
                                           type="button"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButton__content"
-                                            iconSide="left"
-                                            textProps={
+                                          <button
+                                            className="euiButton euiButton--primary euiButton--small secondary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            style={
                                               Object {
-                                                "className": "euiButton__text",
+                                                "minWidth": undefined,
                                               }
                                             }
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButton__content"
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text",
+                                                }
+                                              }
                                             >
                                               <span
-                                                className="euiButton__text"
+                                                className="euiButtonContent euiButton__content"
                                               >
-                                                Add tag
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Add tag
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonDisplay>
-                                    </EuiButton>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </EuiSmallButton>
                                   </div>
                                 </div>
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                               <EuiSpacer>
                                 <div
                                   className="euiSpacer euiSpacer--l"
@@ -3248,9 +3409,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                               onChange={[Function]}
                               placeholder="http://"
                             >
-                              <EuiFormRow
+                              <EuiCompressedFormRow
                                 describedByIds={Array []}
-                                display="row"
+                                display="rowCompressed"
                                 error=""
                                 fullWidth={false}
                                 hasChildLabel={true}
@@ -3282,7 +3443,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                 labelType="label"
                               >
                                 <div
-                                  className="euiFormRow"
+                                  className="euiFormRow euiFormRow--compressed"
                                   id="some_html_id-row"
                                 >
                                   <div
@@ -3357,38 +3518,50 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               }
                                             }
                                           >
-                                            <EuiFieldText
+                                            <EuiCompressedFieldText
                                               data-test-subj="rule_references_field_0"
                                               name="references"
                                               onChange={[Function]}
                                               placeholder="http://"
                                               value=""
                                             >
-                                              <EuiFormControlLayout
-                                                fullWidth={false}
+                                              <EuiFieldText
+                                                compressed={true}
+                                                data-test-subj="rule_references_field_0"
+                                                name="references"
+                                                onChange={[Function]}
+                                                placeholder="http://"
+                                                value=""
                                               >
-                                                <div
-                                                  className="euiFormControlLayout"
+                                                <EuiFormControlLayout
+                                                  compressed={true}
+                                                  fullWidth={false}
                                                 >
                                                   <div
-                                                    className="euiFormControlLayout__childrenWrapper"
+                                                    className="euiFormControlLayout euiFormControlLayout--compressed"
                                                   >
-                                                    <EuiValidatableControl>
-                                                      <input
-                                                        className="euiFieldText"
-                                                        data-test-subj="rule_references_field_0"
-                                                        name="references"
-                                                        onChange={[Function]}
-                                                        placeholder="http://"
-                                                        type="text"
-                                                        value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
+                                                    >
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText euiFieldText--compressed"
+                                                          data-test-subj="rule_references_field_0"
+                                                          name="references"
+                                                          onChange={[Function]}
+                                                          placeholder="http://"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons
+                                                        compressed={true}
                                                       />
-                                                    </EuiValidatableControl>
-                                                    <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </div>
-                                              </EuiFormControlLayout>
-                                            </EuiFieldText>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </EuiCompressedFieldText>
                                           </div>
                                         </EuiFlexItem>
                                       </div>
@@ -3400,56 +3573,64 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                    <EuiButton
+                                    <EuiSmallButton
                                       className="secondary"
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      <EuiButtonDisplay
-                                        baseClassName="euiButton"
+                                      <EuiButton
                                         className="secondary"
-                                        disabled={false}
-                                        element="button"
-                                        isDisabled={false}
                                         onClick={[Function]}
+                                        size="s"
                                         type="button"
                                       >
-                                        <button
-                                          className="euiButton euiButton--primary secondary"
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="secondary"
                                           disabled={false}
+                                          element="button"
+                                          isDisabled={false}
                                           onClick={[Function]}
-                                          style={
-                                            Object {
-                                              "minWidth": undefined,
-                                            }
-                                          }
+                                          size="s"
                                           type="button"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButton__content"
-                                            iconSide="left"
-                                            textProps={
+                                          <button
+                                            className="euiButton euiButton--primary euiButton--small secondary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            style={
                                               Object {
-                                                "className": "euiButton__text",
+                                                "minWidth": undefined,
                                               }
                                             }
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButton__content"
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text",
+                                                }
+                                              }
                                             >
                                               <span
-                                                className="euiButton__text"
+                                                className="euiButtonContent euiButton__content"
                                               >
-                                                Add URL
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Add URL
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonDisplay>
-                                    </EuiButton>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </EuiSmallButton>
                                   </div>
                                 </div>
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                               <EuiSpacer>
                                 <div
                                   className="euiSpacer euiSpacer--l"
@@ -3488,9 +3669,9 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                               onChange={[Function]}
                               placeholder="format?"
                             >
-                              <EuiFormRow
+                              <EuiCompressedFormRow
                                 describedByIds={Array []}
-                                display="row"
+                                display="rowCompressed"
                                 error=""
                                 fullWidth={false}
                                 hasChildLabel={true}
@@ -3522,7 +3703,7 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                 labelType="label"
                               >
                                 <div
-                                  className="euiFormRow"
+                                  className="euiFormRow euiFormRow--compressed"
                                   id="some_html_id-row"
                                 >
                                   <div
@@ -3597,38 +3778,50 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                               }
                                             }
                                           >
-                                            <EuiFieldText
+                                            <EuiCompressedFieldText
                                               data-test-subj="rule_false_positives_field_0"
                                               name="false_positives"
                                               onChange={[Function]}
                                               placeholder="format?"
                                               value=""
                                             >
-                                              <EuiFormControlLayout
-                                                fullWidth={false}
+                                              <EuiFieldText
+                                                compressed={true}
+                                                data-test-subj="rule_false_positives_field_0"
+                                                name="false_positives"
+                                                onChange={[Function]}
+                                                placeholder="format?"
+                                                value=""
                                               >
-                                                <div
-                                                  className="euiFormControlLayout"
+                                                <EuiFormControlLayout
+                                                  compressed={true}
+                                                  fullWidth={false}
                                                 >
                                                   <div
-                                                    className="euiFormControlLayout__childrenWrapper"
+                                                    className="euiFormControlLayout euiFormControlLayout--compressed"
                                                   >
-                                                    <EuiValidatableControl>
-                                                      <input
-                                                        className="euiFieldText"
-                                                        data-test-subj="rule_false_positives_field_0"
-                                                        name="false_positives"
-                                                        onChange={[Function]}
-                                                        placeholder="format?"
-                                                        type="text"
-                                                        value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
+                                                    >
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText euiFieldText--compressed"
+                                                          data-test-subj="rule_false_positives_field_0"
+                                                          name="false_positives"
+                                                          onChange={[Function]}
+                                                          placeholder="format?"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons
+                                                        compressed={true}
                                                       />
-                                                    </EuiValidatableControl>
-                                                    <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </div>
-                                              </EuiFormControlLayout>
-                                            </EuiFieldText>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </EuiCompressedFieldText>
                                           </div>
                                         </EuiFlexItem>
                                       </div>
@@ -3640,56 +3833,64 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                         className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                    <EuiButton
+                                    <EuiSmallButton
                                       className="secondary"
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      <EuiButtonDisplay
-                                        baseClassName="euiButton"
+                                      <EuiButton
                                         className="secondary"
-                                        disabled={false}
-                                        element="button"
-                                        isDisabled={false}
                                         onClick={[Function]}
+                                        size="s"
                                         type="button"
                                       >
-                                        <button
-                                          className="euiButton euiButton--primary secondary"
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="secondary"
                                           disabled={false}
+                                          element="button"
+                                          isDisabled={false}
                                           onClick={[Function]}
-                                          style={
-                                            Object {
-                                              "minWidth": undefined,
-                                            }
-                                          }
+                                          size="s"
                                           type="button"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButton__content"
-                                            iconSide="left"
-                                            textProps={
+                                          <button
+                                            className="euiButton euiButton--primary euiButton--small secondary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            style={
                                               Object {
-                                                "className": "euiButton__text",
+                                                "minWidth": undefined,
                                               }
                                             }
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButton__content"
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text",
+                                                }
+                                              }
                                             >
                                               <span
-                                                className="euiButton__text"
+                                                className="euiButtonContent euiButton__content"
                                               >
-                                                Add false positive
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Add false positive
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonDisplay>
-                                    </EuiButton>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </EuiSmallButton>
                                   </div>
                                 </div>
-                              </EuiFormRow>
+                              </EuiCompressedFormRow>
                               <EuiSpacer>
                                 <div
                                   className="euiSpacer euiSpacer--l"
@@ -3723,50 +3924,56 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               <div
                 className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiButton
+                <EuiSmallButton
                   onClick={[Function]}
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    disabled={false}
-                    element="button"
-                    isDisabled={false}
+                  <EuiButton
                     onClick={[Function]}
-                    type="button"
+                    size="s"
                   >
-                    <button
-                      className="euiButton euiButton--primary"
+                    <EuiButtonDisplay
+                      baseClassName="euiButton"
                       disabled={false}
+                      element="button"
+                      isDisabled={false}
                       onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                      size="s"
                       type="button"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
+                      <button
+                        className="euiButton euiButton--primary euiButton--small"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
                           Object {
-                            "className": "euiButton__text",
+                            "minWidth": undefined,
                           }
                         }
+                        type="button"
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text",
+                            }
+                          }
                         >
                           <span
-                            className="euiButton__text"
+                            className="euiButtonContent euiButton__content"
                           >
-                            Cancel
+                            <span
+                              className="euiButton__text"
+                            >
+                              Cancel
+                            </span>
                           </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonDisplay>
+                  </EuiButton>
+                </EuiSmallButton>
               </div>
             </EuiFlexItem>
             <EuiFlexItem
@@ -3775,55 +3982,63 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
               <div
                 className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="submit_rule_form_button"
                   fill={true}
                   onClick={[Function]}
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
+                  <EuiButton
                     data-test-subj="submit_rule_form_button"
-                    disabled={false}
-                    element="button"
                     fill={true}
-                    isDisabled={false}
                     onClick={[Function]}
-                    type="button"
+                    size="s"
                   >
-                    <button
-                      className="euiButton euiButton--primary euiButton--fill"
+                    <EuiButtonDisplay
+                      baseClassName="euiButton"
                       data-test-subj="submit_rule_form_button"
                       disabled={false}
+                      element="button"
+                      fill={true}
+                      isDisabled={false}
                       onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                      size="s"
                       type="button"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
+                      <button
+                        className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                        data-test-subj="submit_rule_form_button"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
                           Object {
-                            "className": "euiButton__text",
+                            "minWidth": undefined,
                           }
                         }
+                        type="button"
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text",
+                            }
+                          }
                         >
                           <span
-                            className="euiButton__text"
+                            className="euiButtonContent euiButton__content"
                           >
-                            Create detection rule
+                            <span
+                              className="euiButton__text"
+                            >
+                              Create detection rule
+                            </span>
                           </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonDisplay>
+                  </EuiButton>
+                </EuiSmallButton>
               </div>
             </EuiFlexItem>
           </div>

--- a/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
@@ -9,7 +9,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiToolTip,
 } from '@elastic/eui';
@@ -52,7 +52,7 @@ export const FieldTextArray: React.FC<FieldTextArrayProps> = ({
 
   return (
     <>
-      <EuiFormRow label={label} isInvalid={isInvalid} error={error}>
+      <EuiCompressedFormRow label={label} isInvalid={isInvalid} error={error}>
         <>
           {values.map((ref: string, index: number) => {
             return (
@@ -103,7 +103,7 @@ export const FieldTextArray: React.FC<FieldTextArrayProps> = ({
             {addButtonName}
           </EuiSmallButton>
         </>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
     </>
   );

--- a/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFieldText,
   EuiFlexGroup,
@@ -93,7 +93,7 @@ export const FieldTextArray: React.FC<FieldTextArrayProps> = ({
             );
           })}
           <EuiSpacer size="m" />
-          <EuiButton
+          <EuiSmallButton
             type="button"
             className="secondary"
             onClick={() => {
@@ -101,7 +101,7 @@ export const FieldTextArray: React.FC<FieldTextArrayProps> = ({
             }}
           >
             {addButtonName}
-          </EuiButton>
+          </EuiSmallButton>
         </>
       </EuiFormRow>
       <EuiSpacer />

--- a/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiSmallButtonIcon,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -58,7 +58,7 @@ export const FieldTextArray: React.FC<FieldTextArrayProps> = ({
             return (
               <EuiFlexGroup key={index}>
                 <EuiFlexItem style={{ minWidth: '100%' }}>
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     name={name}
                     value={ref}
                     placeholder={placeholder}

--- a/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/FieldTextArray.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -76,7 +76,7 @@ export const FieldTextArray: React.FC<FieldTextArrayProps> = ({
                 {values.length > 1 ? (
                   <EuiFlexItem grow={false} className={'field-text-array-remove'}>
                     <EuiToolTip title={'Remove'}>
-                      <EuiButtonIcon
+                      <EuiSmallButtonIcon
                         aria-label={'Remove'}
                         iconType={'trash'}
                         color="danger"

--- a/public/pages/Rules/components/RuleEditor/components/SelectionExpField.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/SelectionExpField.tsx
@@ -5,7 +5,7 @@ import {
   EuiFlexGroup,
   EuiPopover,
   EuiSelect,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiExpression,
 } from '@elastic/eui';
 import _ from 'lodash';
@@ -243,7 +243,7 @@ export const SelectionExpField: React.FC<SelectionExpFieldProps> = ({
           >
             {renderOptions(exp, idx)}
           </EuiPopover>
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             data-test-subj={`selection-exp-field-item-remove-${idx}`}
             className={'selection-exp-field-item-remove'}
             onClick={() => onRemoveSelection(idx)}
@@ -256,7 +256,7 @@ export const SelectionExpField: React.FC<SelectionExpFieldProps> = ({
       ))}
       {selections.length > usedExpressions.length && (
         <EuiFlexItem grow={false} key={`selections_add`}>
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             onClick={onAddSelection}
             color={'primary'}
             iconType="plusInCircleFilled"

--- a/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/RuleTagsComboBox.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/RuleTagsComboBox.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiFormRow, EuiText, EuiComboBox, EuiComboBoxOptionOption, EuiSpacer } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiText, EuiComboBox, EuiComboBoxOptionOption, EuiSpacer } from '@elastic/eui';
 
 export interface RuleTagsComboBoxProps {
   onCreateOption: (
@@ -37,7 +37,7 @@ export const RuleTagsComboBox: React.FC<RuleTagsComboBoxProps> = ({
 
   return (
     <>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={
           <>
             <EuiText size={'m'}>
@@ -68,7 +68,7 @@ export const RuleTagsComboBox: React.FC<RuleTagsComboBoxProps> = ({
           selectedOptions={selectedOptions}
           isInvalid={isCurrentlyTypingValueInvalid}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 };

--- a/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/RuleTagsComboBox.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/RuleTagsComboBox.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiCompressedFormRow, EuiText, EuiComboBox, EuiComboBoxOptionOption, EuiSpacer } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiText, EuiCompressedComboBox, EuiComboBoxOptionOption, EuiSpacer } from '@elastic/eui';
 
 export interface RuleTagsComboBoxProps {
   onCreateOption: (
@@ -55,7 +55,7 @@ export const RuleTagsComboBox: React.FC<RuleTagsComboBoxProps> = ({
         isInvalid={isCurrentlyTypingValueInvalid}
         error={isCurrentlyTypingValueInvalid ? 'Invalid tag' : ''}
       >
-        <EuiComboBox
+        <EuiCompressedComboBox
           noSuggestions
           onSearchChange={onSearchChange}
           placeholder="tag"

--- a/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/YamlRuleEditorComponent.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/YamlRuleEditorComponent/YamlRuleEditorComponent.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { load } from 'js-yaml';
-import { EuiFormRow, EuiCodeEditor, EuiLink, EuiSpacer, EuiText, EuiCallOut } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCodeEditor, EuiLink, EuiSpacer, EuiText, EuiCallOut } from '@elastic/eui';
 import FormFieldHeader from '../../../../../../components/FormFieldHeader';
 import {
   mapRuleToYamlObject,
@@ -93,7 +93,7 @@ export const YamlRuleEditorComponent: React.FC<YamlRuleEditorComponentProps> = (
     <>
       {renderErrors()}
       <EuiSpacer size="s" />
-      <EuiFormRow label={<FormFieldHeader headerTitle={'Define rule in YAML'} />} fullWidth={true}>
+      <EuiCompressedFormRow label={<FormFieldHeader headerTitle={'Define rule in YAML'} />} fullWidth={true}>
         <>
           <EuiSpacer />
           <EuiText size="s" color="subdued">
@@ -113,7 +113,7 @@ export const YamlRuleEditorComponent: React.FC<YamlRuleEditorComponentProps> = (
             data-test-subj={'rule_yaml_editor'}
           />
         </>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 };

--- a/public/pages/Rules/components/RuleEditor/components/__snapshots__/FieldTextArray.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/components/__snapshots__/FieldTextArray.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         id="some_html_id-row"
       >
         <div
@@ -31,13 +31,13 @@ Object {
               style="min-width: 100%;"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     data-test-subj="rule_field_field_0"
                     name="field"
                     placeholder="Field placeholder"
@@ -52,7 +52,7 @@ Object {
             class="euiSpacer euiSpacer--m"
           />
           <button
-            class="euiButton euiButton--primary secondary"
+            class="euiButton euiButton--primary euiButton--small secondary"
             type="button"
           >
             <span
@@ -74,7 +74,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="some_html_id-row"
     >
       <div
@@ -99,13 +99,13 @@ Object {
             style="min-width: 100%;"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   data-test-subj="rule_field_field_0"
                   name="field"
                   placeholder="Field placeholder"
@@ -120,7 +120,7 @@ Object {
           class="euiSpacer euiSpacer--m"
         />
         <button
-          class="euiButton euiButton--primary secondary"
+          class="euiButton euiButton--primary euiButton--small secondary"
           type="button"
         >
           <span

--- a/public/pages/Rules/components/RuleViewerFlyout/RuleViewFlyoutHeaderActions.tsx
+++ b/public/pages/Rules/components/RuleViewerFlyout/RuleViewFlyoutHeaderActions.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSmallButton, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
+import { EuiSmallButton, EuiSmallButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
 import React from 'react';
 
 export interface RuleViewerFlyoutHeaderActionsProps {
@@ -40,15 +40,15 @@ export const RuleViewerFlyoutHeaderActions: React.FC<RuleViewerFlyoutHeaderActio
     >
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <EuiButtonEmpty onClick={editRule}>Edit</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={editRule}>Edit</EuiSmallButtonEmpty>
         </EuiFlexItem>
 
         <EuiFlexItem>
-          <EuiButtonEmpty onClick={duplicateRule}>Duplicate</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={duplicateRule}>Duplicate</EuiSmallButtonEmpty>
         </EuiFlexItem>
 
         <EuiFlexItem>
-          <EuiButtonEmpty onClick={deleteRule}>Delete</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={deleteRule}>Delete</EuiSmallButtonEmpty>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPopover>

--- a/public/pages/Rules/components/RuleViewerFlyout/RuleViewFlyoutHeaderActions.tsx
+++ b/public/pages/Rules/components/RuleViewerFlyout/RuleViewFlyoutHeaderActions.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
+import { EuiSmallButton, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPopover } from '@elastic/eui';
 import React from 'react';
 
 export interface RuleViewerFlyoutHeaderActionsProps {
@@ -26,13 +26,13 @@ export const RuleViewerFlyoutHeaderActions: React.FC<RuleViewerFlyoutHeaderActio
   toggleActionsPopover,
 }) => {
   return ruleSource === 'Standard' ? (
-    <EuiButton onClick={duplicateRule}>Duplicate</EuiButton>
+    <EuiSmallButton onClick={duplicateRule}>Duplicate</EuiSmallButton>
   ) : (
     <EuiPopover
       button={
-        <EuiButton iconType="arrowDown" iconSide="right" onClick={toggleActionsPopover}>
+        <EuiSmallButton iconType="arrowDown" iconSide="right" onClick={toggleActionsPopover}>
           Action
-        </EuiButton>
+        </EuiSmallButton>
       }
       isOpen={actionsPopoverOpen}
       closePopover={closeActionsPopover}

--- a/public/pages/Rules/components/RuleViewerFlyout/RuleViewerFlyout.tsx
+++ b/public/pages/Rules/components/RuleViewerFlyout/RuleViewerFlyout.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiTitle,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
 } from '@elastic/eui';
 import { ROUTES } from '../../../../utils/constants';
 import React, { useMemo, useState } from 'react';
@@ -117,7 +117,7 @@ export const RuleViewerFlyout: React.FC<RuleViewerFlyoutProps> = ({
             </EuiFlexItem>
           )}
           <EuiFlexItem grow={false}>
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               aria-label="close"
               iconType="cross"
               display="empty"

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -8,7 +8,7 @@ import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorConta
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   EuiSmallButton,
-  EuiFilePicker,
+  EuiCompressedFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
@@ -106,7 +106,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, notifications }
               <h3>Import rule</h3>
             </EuiTitle>
           </PageHeader>
-          <EuiFilePicker
+          <EuiCompressedFilePicker
             id={'filePickerId'}
             fullWidth
             initialPromptText="Select or drag yml file containing Sigma rules"

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -7,7 +7,7 @@ import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
@@ -122,7 +122,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, notifications }
         <EuiSpacer size="xl" />
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={() => history.replace(ROUTES.RULES)}>Cancel</EuiButton>
+            <EuiSmallButton onClick={() => history.replace(ROUTES.RULES)}>Cancel</EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </>

--- a/public/pages/Rules/containers/Rules/Rules.tsx
+++ b/public/pages/Rules/containers/Rules/Rules.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { RulesTable } from '../../components/RulesTable/RulesTable';
@@ -62,12 +62,12 @@ export const Rules: React.FC<RulesProps> = (props) => {
 
   const headerActions = useMemo(
     () => [
-      <EuiButton onClick={openImportPage} data-test-subj={'import_rule_button'}>
+      <EuiSmallButton onClick={openImportPage} data-test-subj={'import_rule_button'}>
         Import detection rule
-      </EuiButton>,
-      <EuiButton onClick={openCreatePage} data-test-subj={'create_rule_button'} fill={true}>
+      </EuiSmallButton>,
+      <EuiSmallButton onClick={openCreatePage} data-test-subj={'create_rule_button'} fill={true}>
         Create detection rule
-      </EuiButton>,
+      </EuiSmallButton>,
     ],
     []
   );

--- a/public/pages/ThreatIntel/components/ConfigureThreatIntelAlertTriggers/ConfigureThreatIntelAlertTriggers.tsx
+++ b/public/pages/ThreatIntel/components/ConfigureThreatIntelAlertTriggers/ConfigureThreatIntelAlertTriggers.tsx
@@ -11,7 +11,7 @@ import {
   parseNotificationChannelsToOptions,
 } from '../../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { NotificationsService } from '../../../../services';
-import { EuiButton, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiSmallButton, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { ThreatIntelIocType } from '../../../../../common/constants';
 import { getEmptyThreatIntelAlertTrigger } from '../../utils/helpers';
 
@@ -86,7 +86,7 @@ export const ConfigureThreatIntelAlertTriggers: React.FC<ConfigureThreatIntelAle
         );
       })}
       <EuiSpacer />
-      <EuiButton
+      <EuiSmallButton
         onClick={() => {
           updateTriggers([
             ...alertTriggers,
@@ -95,7 +95,7 @@ export const ConfigureThreatIntelAlertTriggers: React.FC<ConfigureThreatIntelAle
         }}
       >
         Add another alert trigger
-      </EuiButton>
+      </EuiSmallButton>
     </EuiPanel>
   );
 };

--- a/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
+++ b/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
@@ -6,7 +6,7 @@
 import {
   EuiAccordion,
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,
@@ -333,9 +333,9 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                                     />
                                   </EuiFlexItem>
                                   <EuiFlexItem grow={false}>
-                                    <EuiButton onClick={() => onFieldAliasesAdd(source, ioc)}>
+                                    <EuiSmallButton onClick={() => onFieldAliasesAdd(source, ioc)}>
                                       Done
-                                    </EuiButton>
+                                    </EuiSmallButton>
                                   </EuiFlexItem>
                                 </EuiFlexGroup>
                               </EuiPopover>

--- a/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
+++ b/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
@@ -6,7 +6,6 @@
 import {
   EuiAccordion,
   EuiBadge,
-  EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,

--- a/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
+++ b/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
@@ -12,7 +12,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiIcon,
   EuiPanel,
   EuiPopover,
@@ -185,7 +185,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
         <h2>Configure logs scan</h2>
       </EuiTitle>
       <EuiSpacer />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Select Indexes/Aliases"
         helpText={
           <span>
@@ -212,7 +212,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
             return option.index ? `${option.label} (${option.index})` : option.label;
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer size="xxl" />
       <EuiTitle size="s">
         <h4>Select fields to scan</h4>

--- a/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
+++ b/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
@@ -7,7 +7,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiSmallButtonEmpty,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -199,7 +199,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
           </span>
         }
       >
-        <EuiComboBox
+        <EuiCompressedComboBox
           options={logSourceOptions}
           placeholder={'Select an input source for the detector.'}
           isLoading={loadingLogSourceOptions}
@@ -317,7 +317,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                               >
                                 <EuiFlexGroup alignItems="flexEnd">
                                   <EuiFlexItem>
-                                    <EuiComboBox
+                                    <EuiCompressedComboBox
                                       style={{ minWidth: 300 }}
                                       options={Array.from(fieldOptionsSet).map((f) => ({
                                         label: f,

--- a/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
+++ b/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
@@ -7,7 +7,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -294,7 +294,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                             <EuiFlexItem grow={false}>
                               <EuiPopover
                                 button={
-                                  <EuiButtonEmpty
+                                  <EuiSmallButtonEmpty
                                     iconType={'plus'}
                                     onClick={() =>
                                       setIocInfoWithAddFieldOpen({
@@ -306,7 +306,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                                     }
                                   >
                                     Add fields
-                                  </EuiButtonEmpty>
+                                  </EuiSmallButtonEmpty>
                                 }
                                 panelPaddingSize="s"
                                 closePopover={() => onFieldAliasesAdd(source, ioc)}
@@ -333,9 +333,9 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                                     />
                                   </EuiFlexItem>
                                   <EuiFlexItem grow={false}>
-                                    <EuiSmallButton onClick={() => onFieldAliasesAdd(source, ioc)}>
+                                    <EuiSmallButtonEmpty onClick={() => onFieldAliasesAdd(source, ioc)}>
                                       Done
-                                    </EuiSmallButton>
+                                    </EuiSmallButtonEmpty>
                                   </EuiFlexItem>
                                 </EuiFlexGroup>
                               </EuiPopover>

--- a/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
@@ -9,7 +9,7 @@ import {
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFieldText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
 } from '@elastic/eui';
 import { NotificationChannelTypeOptions, ThreatIntelAlertTrigger } from '../../../../../types';
@@ -100,7 +100,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
       extraAction={<EuiSmallButtonIcon iconType={'trash'} onClick={onDeleteTrgger} />}
       paddingSize="l"
     >
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiFieldText
           placeholder="Trigger name"
           value={trigger.name}
@@ -111,7 +111,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
       <EuiAccordion
         id={'threat-intel-trigger-condition'}
@@ -119,7 +119,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
         initialIsOpen={true}
         paddingSize="l"
       >
-        <EuiFormRow label="Indicator type(s)">
+        <EuiCompressedFormRow label="Indicator type(s)">
           <EuiComboBox
             placeholder="Any"
             options={enabledIocTypes.map((ioc) => ({ label: ioc }))}
@@ -131,9 +131,9 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
               });
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
-        <EuiFormRow label="Log source(s)">
+        <EuiCompressedFormRow label="Log source(s)">
           <EuiComboBox
             placeholder="Any"
             options={logSources.map((logSource) => ({ label: logSource }))}
@@ -145,10 +145,10 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
               });
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiAccordion>
       <EuiSpacer />
-      <EuiFormRow label="Alert severity">
+      <EuiCompressedFormRow label="Alert severity">
         <EuiComboBox
           singleSelection
           options={Object.values(ALERT_SEVERITY_OPTIONS)}
@@ -163,7 +163,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
       <NotificationForm
         action={trigger.actions[0]}

--- a/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
@@ -6,7 +6,7 @@
 import {
   EuiAccordion,
   EuiSmallButtonIcon,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
   EuiCompressedFormRow,
@@ -120,7 +120,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
         paddingSize="l"
       >
         <EuiCompressedFormRow label="Indicator type(s)">
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Any"
             options={enabledIocTypes.map((ioc) => ({ label: ioc }))}
             selectedOptions={trigger.ioc_types.map((iocType) => ({ label: iocType }))}
@@ -134,7 +134,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
         </EuiCompressedFormRow>
         <EuiSpacer />
         <EuiCompressedFormRow label="Log source(s)">
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Any"
             options={logSources.map((logSource) => ({ label: logSource }))}
             selectedOptions={trigger.data_sources.map((source) => ({ label: source }))}
@@ -149,7 +149,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
       </EuiAccordion>
       <EuiSpacer />
       <EuiCompressedFormRow label="Alert severity">
-        <EuiComboBox
+        <EuiCompressedComboBox
           singleSelection
           options={Object.values(ALERT_SEVERITY_OPTIONS)}
           selectedOptions={[

--- a/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
@@ -8,7 +8,7 @@ import {
   EuiSmallButtonIcon,
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiSpacer,
 } from '@elastic/eui';
@@ -101,7 +101,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
       paddingSize="l"
     >
       <EuiCompressedFormRow>
-        <EuiFieldText
+        <EuiCompressedFieldText
           placeholder="Trigger name"
           value={trigger.name}
           onChange={(event) => {

--- a/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiAccordion,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFieldText,
@@ -97,7 +97,7 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
       id="threat-intel-trigger"
       initialIsOpen={true}
       buttonContent={trigger.name}
-      extraAction={<EuiButtonIcon iconType={'trash'} onClick={onDeleteTrgger} />}
+      extraAction={<EuiSmallButtonIcon iconType={'trash'} onClick={onDeleteTrgger} />}
       paddingSize="l"
     >
       <EuiFormRow>

--- a/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
@@ -5,6 +5,7 @@
 
 import {
   EuiSmallButton,
+  EuiSmallButtonEmpty,
   EuiButtonEmpty,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -209,7 +210,7 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
                   })}
                   {logSources.length > 3 && (
                     <EuiFlexItem grow={false}>
-                      <EuiButtonEmpty
+                      <EuiSmallButtonEmpty
                         onClick={() => {
                           setFlyoutContent(
                             <ThreatIntelLogSourcesFlyout
@@ -221,7 +222,7 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
                         }}
                       >
                         View {logSources.length} log sources
-                      </EuiButtonEmpty>
+                      </EuiSmallButtonEmpty>
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>

--- a/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -146,14 +146,14 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
             <EuiPopover
               id={'detectorsActionsPopover'}
               button={
-                <EuiButton
+                <EuiSmallButton
                   iconType={isPopoverOpen ? 'arrowUp' : 'arrowDown'}
                   iconSide={'right'}
                   onClick={toggleActionMenu}
                   data-test-subj={'log-scan-config-action-button'}
                 >
                   Actions
-                </EuiButton>
+                </EuiSmallButton>
               }
               isOpen={isPopoverOpen}
               closePopover={closeActionMenu}

--- a/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
@@ -13,7 +13,7 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiIcon,
   EuiLink,
   EuiPanel,
@@ -248,9 +248,9 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={2} style={{ marginLeft: 100 }}>
-                <EuiFormRow label="Scan runs every">
+                <EuiCompressedFormRow label="Scan runs every">
                   <Interval schedule={schedule} readonly onScheduleChange={() => {}} />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer size="xxl" />

--- a/public/pages/ThreatIntel/components/ThreatIntelOverviewActions/ThreatIntelOverviewActions.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelOverviewActions/ThreatIntelOverviewActions.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { StatusWithIndicator } from '../../../../components/Utility/StatusWithIndicator';
 import { RouteComponentProps } from 'react-router-dom';
 import { AlertTabId, FindingTabId, ROUTES } from '../../../../utils/constants';
@@ -111,14 +111,14 @@ export const ThreatIntelOverviewActions: React.FC<ThreatIntelOverviewActionsProp
       <EuiFlexItem>{status}</EuiFlexItem>
       {actions.map((action, idx) => (
         <EuiFlexItem grow={false} key={idx}>
-          <EuiButton
+          <EuiSmallButton
             fill={action.fill}
             disabled={action.disabled}
             isLoading={action.isLoading}
             onClick={action.onClick}
           >
             {action.label}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       ))}
     </EuiFlexGroup>

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import {
   EuiBottomBar,
   EuiSmallButton,
-  EuiCheckboxGroup,
+  EuiCompressedCheckboxGroup,
   EuiCompressedFieldText,
   EuiFilePicker,
   EuiFlexGroup,
@@ -343,7 +343,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
             <EuiCompressedFormRow label="Types of malicious indicators">
               <>
                 <EuiSpacer size="s" />
-                <EuiCheckboxGroup
+                <EuiCompressedCheckboxGroup
                   options={checkboxes}
                   idToSelectedMap={checkboxIdToSelectedMap}
                   onChange={onIocTypesChange}

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -9,7 +9,7 @@ import {
   EuiSmallButton,
   EuiCompressedCheckboxGroup,
   EuiCompressedFieldText,
-  EuiFilePicker,
+  EuiCompressedFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormLabel,
@@ -316,7 +316,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                       isInvalid={!!fileError}
                       error={fileError}
                     >
-                      <EuiFilePicker
+                      <EuiCompressedFilePicker
                         id={'filePickerId'}
                         fullWidth
                         initialPromptText="Select or drag and drop a file"

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   EuiBottomBar,
-  EuiButton,
+  EuiSmallButton,
   EuiCheckboxGroup,
   EuiFieldText,
   EuiFilePicker,
@@ -355,12 +355,12 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
           </EuiFlexItem>
           {type !== 'URL_DOWNLOAD' && (
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 style={{ visibility: isReadOnly ? 'visible' : 'hidden' }}
                 onClick={() => setIsReadOnly(false)}
               >
                 Edit
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>
@@ -371,12 +371,12 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
           <EuiBottomBar>
             <EuiFlexGroup justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={onDiscard}>Discard</EuiButton>
+                <EuiSmallButton onClick={onDiscard}>Discard</EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButton isLoading={saveInProgress} fill onClick={onSave} disabled={saveDisabled}>
+                <EuiSmallButton isLoading={saveInProgress} fill onClick={onSave} disabled={saveDisabled}>
                   Save
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiBottomBar>

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -8,7 +8,7 @@ import {
   EuiBottomBar,
   EuiSmallButton,
   EuiCheckboxGroup,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
@@ -208,11 +208,11 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
           </EuiFlexItem>
           <EuiFlexItem grow={2}>
             <EuiCompressedFormRow label="Name">
-              <EuiFieldText readOnly={isReadOnly} value={name} onChange={onNameChange} />
+              <EuiCompressedFieldText readOnly={isReadOnly} value={name} onChange={onNameChange} />
             </EuiCompressedFormRow>
             <EuiSpacer />
             <EuiCompressedFormRow label="Description">
-              <EuiFieldText
+              <EuiCompressedFieldText
                 readOnly={isReadOnly}
                 value={description}
                 onChange={onDescriptionChange}
@@ -255,7 +255,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 </EuiText>
                 <EuiSpacer />
                 <EuiCompressedFormRow label={<EuiFormLabel>IAM Role ARN</EuiFormLabel>}>
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     readOnly={isReadOnly}
                     placeholder="arn:"
                     onChange={(event) => onS3DataChange('role_arn', event.target.value)}
@@ -264,7 +264,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 </EuiCompressedFormRow>
                 <EuiSpacer />
                 <EuiCompressedFormRow label="S3 bucket directory">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     readOnly={isReadOnly}
                     placeholder="S3 bucket name"
                     onChange={(event) => onS3DataChange('bucket_name', event.target.value)}
@@ -273,7 +273,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 </EuiCompressedFormRow>
                 <EuiSpacer />
                 <EuiCompressedFormRow label="Specify a directory or file">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     readOnly={isReadOnly}
                     placeholder="Object key"
                     onChange={(event) => onS3DataChange('object_key', event.target.value)}
@@ -282,7 +282,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 </EuiCompressedFormRow>
                 <EuiSpacer />
                 <EuiCompressedFormRow label="Region">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     readOnly={isReadOnly}
                     placeholder="Region"
                     onChange={(event) => onS3DataChange('region', event.target.value)}
@@ -296,7 +296,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
               <>
                 {isReadOnly && (
                   <EuiCompressedFormRow label="Uploaded file">
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       readOnly={isReadOnly}
                       value={fileUploadSource.ioc_upload?.file_name}
                       icon={'download'}

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormLabel,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPanel,
   EuiSpacer,
   EuiSwitch,
@@ -207,17 +207,17 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={2}>
-            <EuiFormRow label="Name">
+            <EuiCompressedFormRow label="Name">
               <EuiFieldText readOnly={isReadOnly} value={name} onChange={onNameChange} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
-            <EuiFormRow label="Description">
+            <EuiCompressedFormRow label="Description">
               <EuiFieldText
                 readOnly={isReadOnly}
                 value={description}
                 onChange={onDescriptionChange}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
             {type === 'S3_CUSTOM' && schedule && (
               <>
@@ -254,58 +254,58 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                   <h4>Connection details</h4>
                 </EuiText>
                 <EuiSpacer />
-                <EuiFormRow label={<EuiFormLabel>IAM Role ARN</EuiFormLabel>}>
+                <EuiCompressedFormRow label={<EuiFormLabel>IAM Role ARN</EuiFormLabel>}>
                   <EuiFieldText
                     readOnly={isReadOnly}
                     placeholder="arn:"
                     onChange={(event) => onS3DataChange('role_arn', event.target.value)}
                     value={s3ConnectionDetails.s3.role_arn}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 <EuiSpacer />
-                <EuiFormRow label="S3 bucket directory">
+                <EuiCompressedFormRow label="S3 bucket directory">
                   <EuiFieldText
                     readOnly={isReadOnly}
                     placeholder="S3 bucket name"
                     onChange={(event) => onS3DataChange('bucket_name', event.target.value)}
                     value={s3ConnectionDetails.s3.bucket_name}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 <EuiSpacer />
-                <EuiFormRow label="Specify a directory or file">
+                <EuiCompressedFormRow label="Specify a directory or file">
                   <EuiFieldText
                     readOnly={isReadOnly}
                     placeholder="Object key"
                     onChange={(event) => onS3DataChange('object_key', event.target.value)}
                     value={s3ConnectionDetails.s3.object_key}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 <EuiSpacer />
-                <EuiFormRow label="Region">
+                <EuiCompressedFormRow label="Region">
                   <EuiFieldText
                     readOnly={isReadOnly}
                     placeholder="Region"
                     onChange={(event) => onS3DataChange('region', event.target.value)}
                     value={s3ConnectionDetails.s3.region}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
                 <EuiSpacer />
               </>
             )}
             {type === 'IOC_UPLOAD' && (
               <>
                 {isReadOnly && (
-                  <EuiFormRow label="Uploaded file">
+                  <EuiCompressedFormRow label="Uploaded file">
                     <EuiFieldText
                       readOnly={isReadOnly}
                       value={fileUploadSource.ioc_upload?.file_name}
                       icon={'download'}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 )}
                 {!isReadOnly && (
                   <>
-                    <EuiFormRow
+                    <EuiCompressedFormRow
                       label="Upload file"
                       helpText={
                         <>
@@ -327,7 +327,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                         isInvalid={!!fileError}
                         data-test-subj="import_ioc_file"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </>
                 )}
               </>
@@ -340,7 +340,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 />
               </EuiFormRow>
             )}
-            <EuiFormRow label="Types of malicious indicators">
+            <EuiCompressedFormRow label="Types of malicious indicators">
               <>
                 <EuiSpacer size="s" />
                 <EuiCheckboxGroup
@@ -350,7 +350,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                   disabled={isReadOnly}
                 />
               </>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
           </EuiFlexItem>
           {type !== 'URL_DOWNLOAD' && (

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -16,7 +16,7 @@ import {
   EuiCompressedFormRow,
   EuiPanel,
   EuiSpacer,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -239,7 +239,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                   </EuiFlexItem>
                   {(!isReadOnly || !enabled) && (
                     <EuiFlexItem grow={false}>
-                      <EuiSwitch
+                      <EuiCompressedSwitch
                         label="Download on demand only"
                         checked={!enabled}
                         onChange={(event) => onRefreshSwitchChange(event.target.checked)}

--- a/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCard,
   EuiEmptyPrompt,
@@ -42,7 +42,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
         </EuiFlexItem>
         {threatIntelSources.length > 0 && (
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               onClick={() => {
                 history.push({
                   pathname: ROUTES.THREAT_INTEL_ADD_CUSTOM_SOURCE,
@@ -50,7 +50,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
               }}
             >
               Add threat intel source
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>
@@ -98,7 +98,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
         <EuiEmptyPrompt
           title={<h3>No threat intel source present</h3>}
           actions={[
-            <EuiButton
+            <EuiSmallButton
               fill
               onClick={() => {
                 history.push({
@@ -107,7 +107,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
               }}
             >
               Add threat intel source
-            </EuiButton>,
+            </EuiSmallButton>,
           ]}
         />
       )}

--- a/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {
   EuiBadge,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCard,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -65,7 +65,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
                 description={source.description}
                 footer={
                   <>
-                    <EuiButtonEmpty
+                    <EuiSmallButtonEmpty
                       onClick={() => {
                         history.push({
                           pathname: `${ROUTES.THREAT_INTEL_SOURCE_DETAILS}/${source.id}`,
@@ -75,7 +75,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
                       iconType={'iInCircle'}
                     >
                       More details
-                    </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
                     <EuiSpacer size="m" />
                     <EuiIcon
                       type={'dot'}

--- a/public/pages/ThreatIntel/components/Utility/ConfigActionButton.tsx
+++ b/public/pages/ThreatIntel/components/Utility/ConfigActionButton.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton } from '@elastic/eui';
+import { EuiSmallButton } from '@elastic/eui';
 import React from 'react';
 
 export interface ConfigActionButtonProps {
@@ -31,8 +31,8 @@ export const ConfigActionButton: React.FC<ConfigActionButtonProps> = ({
   }
 
   return buttonText ? (
-    <EuiButton onClick={actionHandler} disabled={disabled}>
+    <EuiSmallButton onClick={actionHandler} disabled={disabled}>
       {buttonText}
-    </EuiButton>
+    </EuiSmallButton>
   ) : null;
 };

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -16,7 +16,7 @@ import {
   EuiCompressedFormRow,
   EuiPanel,
   EuiSpacer,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -530,7 +530,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               <h4>Download schedule</h4>
             </EuiText>
             <EuiSpacer />
-            <EuiSwitch
+            <EuiCompressedSwitch
               label="Download on demand only"
               checked={!source.enabled}
               onChange={(event) => onRefreshSwitchChange(event.target.checked)}

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import {
   EuiSmallButton,
   EuiCheckableCard,
-  EuiCheckboxGroup,
+  EuiCompressedCheckboxGroup,
   EuiCompressedFieldText,
   EuiFilePicker,
   EuiFlexGroup,
@@ -597,7 +597,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
         </EuiText>
         <EuiSpacer size="m" />
         <EuiFormRow isInvalid={!!inputErrors.ioc_types} error={inputErrors.ioc_types}>
-          <EuiCheckboxGroup
+          <EuiCompressedCheckboxGroup
             options={checkboxes}
             idToSelectedMap={checkboxIdToSelectedMap}
             onChange={onIocTypesChange}

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiCheckableCard,
   EuiCheckboxGroup,
   EuiFieldText,
@@ -608,17 +608,17 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
       <EuiSpacer />
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => history.push(ROUTES.THREAT_INTEL_OVERVIEW)}>Cancel</EuiButton>
+          <EuiSmallButton onClick={() => history.push(ROUTES.THREAT_INTEL_OVERVIEW)}>Cancel</EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             disabled={!shouldEnableSubmit()}
             isLoading={submitInProgress}
             fill
             onClick={onSubmit}
           >
             Add threat intel source
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormLabel,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPanel,
   EuiSpacer,
   EuiSwitch,
@@ -378,7 +378,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
           <h4>Details</h4>
         </EuiText>
         <EuiSpacer />
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Name"
           helpText="Source name must contain 1-128 characters. Valid characters are a-z, A-Z, 0-9, hyphens, spaces, and underscores."
           isInvalid={!!inputErrors.name}
@@ -390,9 +390,9 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
             onBlur={onNameChange}
             value={source.name}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
-        <EuiFormRow
+        <EuiCompressedFormRow
           label={
             <>
               {'Description - '}
@@ -406,7 +406,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
             onBlur={onDescriptionChange}
             value={source.description}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
         <EuiText size="xs">
           <b>Threat intel source type</b>
@@ -463,7 +463,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               <h4>Connection details</h4>
             </EuiText>
             <EuiSpacer />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label={
                 <>
                   <EuiFormLabel className={!!inputErrors.s3?.role_arn ? 'label--danger' : ''}>
@@ -485,9 +485,9 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
                 onBlur={(event) => onS3DataChange('role_arn', event.target.value)}
                 value={s3ConnectionDetails.s3.role_arn}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="S3 bucket directory"
               isInvalid={!!inputErrors.s3?.bucket_name}
               error={inputErrors.s3?.bucket_name}
@@ -498,9 +498,9 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
                 onBlur={(event) => onS3DataChange('bucket_name', event.target.value)}
                 value={s3ConnectionDetails.s3.bucket_name}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Specify a directory or file"
               isInvalid={!!inputErrors.s3?.object_key}
               error={inputErrors.s3?.object_key}
@@ -511,9 +511,9 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
                 onBlur={(event) => onS3DataChange('object_key', event.target.value)}
                 value={s3ConnectionDetails.s3.object_key}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Region"
               isInvalid={!!inputErrors.s3?.region}
               error={inputErrors.s3?.region}
@@ -524,7 +524,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
                 onBlur={(event) => onS3DataChange('region', event.target.value)}
                 value={s3ConnectionDetails.s3.region}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
             <EuiText>
               <h4>Download schedule</h4>
@@ -560,7 +560,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               <h4>Upload a file</h4>
             </EuiText>
             <EuiSpacer />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="File"
               helpText={
                 <>
@@ -582,7 +582,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
                 isInvalid={!!inputErrors.fileUpload?.file}
                 data-test-subj="import_ioc_file"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer />
           </>
         )}

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -9,7 +9,7 @@ import {
   EuiCheckableCard,
   EuiCompressedCheckboxGroup,
   EuiCompressedFieldText,
-  EuiFilePicker,
+  EuiCompressedFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormLabel,
@@ -571,7 +571,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               isInvalid={!!inputErrors.fileUpload?.file}
               error={inputErrors.fileUpload?.file}
             >
-              <EuiFilePicker
+              <EuiCompressedFilePicker
                 id={'filePickerId'}
                 fullWidth
                 initialPromptText="Select or drag and drop a file"

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -8,7 +8,7 @@ import {
   EuiSmallButton,
   EuiCheckableCard,
   EuiCheckboxGroup,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
@@ -384,7 +384,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
           isInvalid={!!inputErrors.name}
           error={inputErrors.name}
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="Title"
             onChange={onNameChange}
             onBlur={onNameChange}
@@ -400,7 +400,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
             </>
           }
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="Description"
             onChange={onDescriptionChange}
             onBlur={onDescriptionChange}
@@ -479,7 +479,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               isInvalid={!!inputErrors.s3?.role_arn}
               error={inputErrors.s3?.role_arn}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 placeholder="arn:"
                 onChange={(event) => onS3DataChange('role_arn', event.target.value)}
                 onBlur={(event) => onS3DataChange('role_arn', event.target.value)}
@@ -492,7 +492,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               isInvalid={!!inputErrors.s3?.bucket_name}
               error={inputErrors.s3?.bucket_name}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 placeholder="S3 bucket name"
                 onChange={(event) => onS3DataChange('bucket_name', event.target.value)}
                 onBlur={(event) => onS3DataChange('bucket_name', event.target.value)}
@@ -505,7 +505,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               isInvalid={!!inputErrors.s3?.object_key}
               error={inputErrors.s3?.object_key}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 placeholder="Object key"
                 onChange={(event) => onS3DataChange('object_key', event.target.value)}
                 onBlur={(event) => onS3DataChange('object_key', event.target.value)}
@@ -518,7 +518,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
               isInvalid={!!inputErrors.s3?.region}
               error={inputErrors.s3?.region}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 placeholder="Region"
                 onChange={(event) => onS3DataChange('region', event.target.value)}
                 onBlur={(event) => onS3DataChange('region', event.target.value)}

--- a/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
+++ b/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiAccordion,
-  EuiButton,
+  EuiSmallButton,
   EuiCard,
   EuiFlexGroup,
   EuiFlexItem,
@@ -223,9 +223,9 @@ export const ThreatIntelOverview: React.FC<ThreatIntelOverviewProps> = ({
                   title={title}
                   description={description}
                   footer={
-                    <EuiButton disabled={disabled} onClick={nextStepClickHandlerById[id]}>
+                    <EuiSmallButton disabled={disabled} onClick={nextStepClickHandlerById[id]}>
                       {text}
-                    </EuiButton>
+                    </EuiSmallButton>
                   }
                 />
               </EuiFlexItem>

--- a/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
+++ b/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -348,28 +348,28 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
 
         {currentStep === ConfigureThreatIntelScanStep.SelectLogSources && (
           <EuiFlexItem grow={false}>
-            <EuiButton fill={true} onClick={onNextClick} disabled={!stepDataValid[currentStep]}>
+            <EuiSmallButton fill={true} onClick={onNextClick} disabled={!stepDataValid[currentStep]}>
               Next
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         )}
 
         {currentStep === ConfigureThreatIntelScanStep.SetupAlertTriggers && (
           <>
             <EuiFlexItem grow={false}>
-              <EuiButton disabled={configureInProgress} onClick={onPreviousClick}>
+              <EuiSmallButton disabled={configureInProgress} onClick={onPreviousClick}>
                 Back
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 disabled={configureInProgress || !stepDataValid[currentStep]}
                 isLoading={configureInProgress}
                 fill={true}
                 onClick={onSubmit}
               >
                 Save and start monitoring
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </>
         )}

--- a/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
+++ b/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -341,9 +341,9 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
       <EuiSpacer />
       <EuiFlexGroup alignItems={'center'} justifyContent={'flexEnd'}>
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty href={`${PLUGIN_NAME}#${ROUTES.THREAT_INTEL_OVERVIEW}`}>
+          <EuiSmallButtonEmpty href={`${PLUGIN_NAME}#${ROUTES.THREAT_INTEL_OVERVIEW}`}>
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
 
         {currentStep === ConfigureThreatIntelScanStep.SelectLogSources && (

--- a/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
@@ -9,7 +9,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS, DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
 import { useEffect } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -176,17 +176,17 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
           <EuiIcon type={'iInCircle'} />
         </span>
       </EuiToolTip>,
-      <EuiButton color={enabled_for_scan ? 'danger' : 'primary'} onClick={toggleActiveState}>
+      <EuiSmallButton color={enabled_for_scan ? 'danger' : 'primary'} onClick={toggleActiveState}>
         {enabled_for_scan ? 'Deactivate' : 'Activate'}
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
   if (type === 'S3_CUSTOM') {
     headerControls.push(
-      <EuiButton fill onClick={onRefresh}>
+      <EuiSmallButton fill onClick={onRefresh}>
         Refresh
-      </EuiButton>
+      </EuiSmallButton>
     );
   }
 
@@ -265,7 +265,7 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
           onClickDelete={onDeleteConfirmed}
           confirmation
           confirmButtonText="Delete"
-          additionalWarning="You can also deactivate this source temporarily and reactivate later. 
+          additionalWarning="You can also deactivate this source temporarily and reactivate later.
           Cancel to exit and then choose Deactivate."
         />
       )}

--- a/public/store/DetectorsStore.tsx
+++ b/public/store/DetectorsStore.tsx
@@ -11,7 +11,7 @@ import { ICalloutProps, resolveType, TCalloutColor } from '../pages/Main/compone
 import { CreateDetectorResponse, ISavedObjectsService, ServerResponse } from '../../types';
 import { CreateMappingsResponse } from '../../server/models/interfaces';
 import { logTypesWithDashboards, ROUTES } from '../utils/constants';
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiSmallButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { Toast } from '@opensearch-project/oui/src/eui_components/toast/global_toast_list';
 import { RouteComponentProps } from 'react-router-dom';
 import { DataStore } from './DataStore';
@@ -138,7 +138,7 @@ export class DetectorsStore implements IDetectorsStore {
     };
 
     const btn = btnText && (
-      <EuiButton
+      <EuiSmallButton
         color={type}
         onClick={(e: any) => {
           btnHandler && btnHandler(e);
@@ -148,7 +148,7 @@ export class DetectorsStore implements IDetectorsStore {
         size="s"
       >
         {btnText}
-      </EuiButton>
+      </EuiSmallButton>
     );
 
     const messageBody = (

--- a/public/store/DetectorsStore.tsx
+++ b/public/store/DetectorsStore.tsx
@@ -11,7 +11,7 @@ import { ICalloutProps, resolveType, TCalloutColor } from '../pages/Main/compone
 import { CreateDetectorResponse, ISavedObjectsService, ServerResponse } from '../../types';
 import { CreateMappingsResponse } from '../../server/models/interfaces';
 import { logTypesWithDashboards, ROUTES } from '../utils/constants';
-import { EuiSmallButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { Toast } from '@opensearch-project/oui/src/eui_components/toast/global_toast_list';
 import { RouteComponentProps } from 'react-router-dom';
 import { DataStore } from './DataStore';
@@ -138,7 +138,7 @@ export class DetectorsStore implements IDetectorsStore {
     };
 
     const btn = btnText && (
-      <EuiSmallButton
+      <EuiButton
         color={type}
         onClick={(e: any) => {
           btnHandler && btnHandler(e);
@@ -148,7 +148,7 @@ export class DetectorsStore implements IDetectorsStore {
         size="s"
       >
         {btnText}
-      </EuiSmallButton>
+      </EuiButton>
     );
 
     const messageBody = (

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -8,7 +8,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiLink,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
   EuiSpacer,
   EuiText,
@@ -267,7 +267,7 @@ export function createSelectComponent(
   return (
     <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiSelect id={id} options={options} value={value} onChange={onChange} prepend="Group by" />
+        <EuiCompressedSelect id={id} options={options} value={value} onChange={onChange} prepend="Group by" />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -6,7 +6,7 @@
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSelect,
   EuiSelectOption,
@@ -70,7 +70,7 @@ export function createTextDetailsGroup(
   ) => {
     const dataTestSubj = label.toLowerCase().replace(/ /g, '-');
     return (
-      <EuiFormRow fullWidth label={label}>
+      <EuiCompressedFormRow fullWidth label={label}>
         {url ? (
           <EuiLink
             href={url}
@@ -84,7 +84,7 @@ export function createTextDetailsGroup(
             {content ?? DEFAULT_EMPTY_DATA}
           </EuiText>
         )}
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
   return data.length <= 1 ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,14 +883,6 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
-"@types/hoist-non-react-statics@^3.3.1":
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
-  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -3010,11 +3002,10 @@ form-data@~2.3.2:
     mime-types "^2.1.12"
 
 formik@^2.2.6:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.5.tgz#f899b5b7a6f103a8fabb679823e8fafc7e0ee1b4"
-  integrity sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.2.tgz#a1115457cfb012a5c782cea3ad4b40b2fe36fa18"
+  integrity sha512-C6nx0hifW2uENP3M6HpPmnAE6HFWCcd8/sqBZEOHZY6lpHJ5qehsfAy43ktpFLEmkBmhiZDei726utcUB9leqg==
   dependencies:
-    "@types/hoist-non-react-statics" "^3.3.1"
     deepmerge "^2.1.1"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.21"


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).