### PR TITLE
Page header updates to share common UI language in OSD

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -3,7 +3,7 @@
   "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["opensearch_security_analytics"],
-  "requiredPlugins": ["data"],
+  "requiredPlugins": ["data", "navigation", "opensearchDashboardsUtils"],
   "optionalPlugins": ["dataSource", "dataSourceManagement"],
   "server": true,
   "ui": true,

--- a/public/components/PageHeader/PageHeader.tsx
+++ b/public/components/PageHeader/PageHeader.tsx
@@ -5,25 +5,32 @@
 
 import React from 'react';
 import { getApplication, getNavigationUI, getUseUpdatedUx } from '../../utils/constants';
-import { TopNavControlData } from '../../../../../src/plugins/navigation/public';
+import {
+  TopNavControlData,
+  TopNavControlDescriptionData,
+  TopNavControlLinkData,
+} from '../../../../../src/plugins/navigation/public';
 
 export interface PageHeaderProps {
   appRightControls?: TopNavControlData[];
   appBadgeControls?: TopNavControlData[];
+  appDescriptionControls?: (TopNavControlDescriptionData | TopNavControlLinkData)[];
 }
 
 export const PageHeader: React.FC<PageHeaderProps> = ({
   children,
   appBadgeControls,
   appRightControls,
+  appDescriptionControls,
 }) => {
   const { HeaderControl } = getNavigationUI();
-  const { setAppBadgeControls, setAppRightControls } = getApplication();
+  const { setAppBadgeControls, setAppRightControls, setAppDescriptionControls } = getApplication();
 
   return getUseUpdatedUx() ? (
     <>
       <HeaderControl setMountPoint={setAppBadgeControls} controls={appBadgeControls} />
       <HeaderControl setMountPoint={setAppRightControls} controls={appRightControls} />
+      <HeaderControl setMountPoint={setAppDescriptionControls} controls={appDescriptionControls} />
     </>
   ) : (
     <>{children}</>

--- a/public/components/PageHeader/PageHeader.tsx
+++ b/public/components/PageHeader/PageHeader.tsx
@@ -4,12 +4,12 @@
  */
 
 import React from 'react';
-import { getApplication, getNavigationUI, getUseUpdatedUx } from '../../utils/constants';
 import {
   TopNavControlData,
   TopNavControlDescriptionData,
   TopNavControlLinkData,
 } from '../../../../../src/plugins/navigation/public';
+import { getApplication, getNavigationUI, getUseUpdatedUx } from '../../services/utils/constants';
 
 export interface PageHeaderProps {
   appRightControls?: TopNavControlData[];

--- a/public/components/PageHeader/PageHeader.tsx
+++ b/public/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { getApplication, getNavigationUI, getUseUpdatedUx } from '../../utils/constants';
+import { TopNavControlData } from '../../../../../src/plugins/navigation/public';
+
+export interface PageHeaderProps {
+  appRightControls?: TopNavControlData[];
+  appBadgeControls?: TopNavControlData[];
+}
+
+export const PageHeader: React.FC<PageHeaderProps> = ({
+  children,
+  appBadgeControls,
+  appRightControls,
+}) => {
+  const { HeaderControl } = getNavigationUI();
+  const { setAppBadgeControls, setAppRightControls } = getApplication();
+
+  return getUseUpdatedUx() ? (
+    <>
+      <HeaderControl setMountPoint={setAppBadgeControls} controls={appBadgeControls} />
+      <HeaderControl setMountPoint={setAppRightControls} controls={appRightControls} />
+    </>
+  ) : (
+    <>{children}</>
+  );
+};

--- a/public/pages/Alerts/containers/Alerts/Alerts.test.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.test.tsx
@@ -11,6 +11,11 @@ import alertsMock from '../../../../../test/mocks/Alerts/Alerts.mock';
 import { shallowToJson } from 'enzyme-to-json';
 import { Router } from 'react-router-dom';
 import browserHistoryMock from '../../../../../test/mocks/services/browserHistory.mock';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 describe('<Alerts /> spec', () => {
   it('renders the component', () => {

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -40,7 +40,6 @@ import {
   DEFAULT_EMPTY_DATA,
   MAX_RECENTLY_USED_TIME_RANGES,
 } from '../../../../utils/constants';
-import { CoreServicesContext } from '../../../../components/core_services';
 import AlertsService from '../../../../services/AlertsService';
 import DetectorService from '../../../../services/DetectorService';
 import { AlertFlyout } from '../../components/AlertFlyout/AlertFlyout';
@@ -60,6 +59,7 @@ import {
   getDuration,
   renderTime,
   renderVisualization,
+  setBreadcrumbs,
   successNotificationToast,
 } from '../../../../utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -76,6 +76,7 @@ import {
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
 import { DataStore } from '../../../../store/DataStore';
 import { ThreatIntelAlertsTable } from '../../components/ThreatIntelAlertsTable/ThreatIntelAlertsTable';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 type FilterAlertParams =
   | { alerts: AlertItem[]; timeField: 'last_notification_time' }
@@ -126,7 +127,6 @@ const groupByOptions = [
 ];
 
 export class Alerts extends Component<AlertsProps, AlertsState> {
-  static contextType = CoreServicesContext;
   private abortControllers: AbortController[] = [];
 
   constructor(props: AlertsProps) {
@@ -560,7 +560,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
   }
 
   componentDidMount(): void {
-    this.context.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.ALERTS]);
+    setBreadcrumbs([BREADCRUMBS.ALERTS]);
     this.onRefresh();
   }
 
@@ -1077,6 +1077,18 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
       },
     ];
 
+    const datePicker = (
+      <EuiSuperDatePicker
+        start={dateTimeFilter.startTime}
+        end={dateTimeFilter.endTime}
+        recentlyUsedRanges={recentlyUsedRanges}
+        isLoading={loading}
+        onTimeChange={this.onTimeChange}
+        onRefresh={this.onRefresh}
+        updateButtonProps={{ fill: false }}
+      />
+    );
+
     return (
       <>
         {flyoutData && (
@@ -1098,27 +1110,26 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           />
         )}
         <EuiFlexGroup direction="column">
-          <EuiFlexItem>
-            <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
-              <EuiFlexItem>
-                <EuiTitle size="m">
-                  <h1>Security alerts</h1>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiSuperDatePicker
-                  start={dateTimeFilter.startTime}
-                  end={dateTimeFilter.endTime}
-                  recentlyUsedRanges={recentlyUsedRanges}
-                  isLoading={loading}
-                  onTimeChange={this.onTimeChange}
-                  onRefresh={this.onRefresh}
-                  updateButtonProps={{ fill: false }}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer size={'m'} />
-          </EuiFlexItem>
+          <PageHeader
+            appRightControls={[
+              {
+                renderComponent: datePicker,
+              },
+            ]}
+          >
+            <EuiFlexItem>
+              <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
+                <EuiFlexItem>
+                  <EuiTitle size="m">
+                    <h1>Security alerts</h1>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>{datePicker}</EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer size={'m'} />
+            </EuiFlexItem>
+          </PageHeader>
+
           <EuiFlexItem>
             <EuiPanel>
               <EuiFlexGroup direction="column">

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -213,295 +213,342 @@ exports[`<Alerts /> spec renders the component 1`] = `
       <div
         className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
       >
-        <EuiFlexItem>
-          <div
-            className="euiFlexItem"
-          >
-            <EuiFlexGroup
-              gutterSize="s"
-              justifyContent="spaceBetween"
+        <PageHeader
+          appRightControls={
+            Array [
+              Object {
+                "renderComponent": <EuiSuperDatePicker
+                  commonlyUsedRanges={
+                    Array [
+                      Object {
+                        "end": "now/d",
+                        "label": "Today",
+                        "start": "now/d",
+                      },
+                      Object {
+                        "end": "now/w",
+                        "label": "This week",
+                        "start": "now/w",
+                      },
+                      Object {
+                        "end": "now/M",
+                        "label": "This month",
+                        "start": "now/M",
+                      },
+                      Object {
+                        "end": "now/y",
+                        "label": "This year",
+                        "start": "now/y",
+                      },
+                      Object {
+                        "end": "now-1d/d",
+                        "label": "Yesterday",
+                        "start": "now-1d/d",
+                      },
+                      Object {
+                        "end": "now",
+                        "label": "Week to date",
+                        "start": "now/w",
+                      },
+                      Object {
+                        "end": "now",
+                        "label": "Month to date",
+                        "start": "now/M",
+                      },
+                      Object {
+                        "end": "now",
+                        "label": "Year to date",
+                        "start": "now/y",
+                      },
+                    ]
+                  }
+                  compressed={false}
+                  dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                  end="now"
+                  isAutoRefreshOnly={false}
+                  isDisabled={false}
+                  isLoading={true}
+                  isPaused={true}
+                  onRefresh={[Function]}
+                  onTimeChange={[Function]}
+                  recentlyUsedRanges={
+                    Array [
+                      Object {
+                        "end": "now",
+                        "start": "now-24h",
+                      },
+                    ]
+                  }
+                  refreshInterval={0}
+                  showUpdateButton={true}
+                  start="now-24h"
+                  timeFormat="HH:mm"
+                  updateButtonProps={
+                    Object {
+                      "fill": false,
+                    }
+                  }
+                />,
+              },
+            ]
+          }
+        >
+          <EuiFlexItem>
+            <div
+              className="euiFlexItem"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                gutterSize="s"
+                justifyContent="spaceBetween"
               >
-                <EuiFlexItem>
-                  <div
-                    className="euiFlexItem"
-                  >
-                    <EuiTitle
-                      size="m"
-                    >
-                      <h1
-                        className="euiTitle euiTitle--medium"
-                      >
-                        Security alerts
-                      </h1>
-                    </EuiTitle>
-                  </div>
-                </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                  >
-                    <EuiSuperDatePicker
-                      commonlyUsedRanges={
-                        Array [
-                          Object {
-                            "end": "now/d",
-                            "label": "Today",
-                            "start": "now/d",
-                          },
-                          Object {
-                            "end": "now/w",
-                            "label": "This week",
-                            "start": "now/w",
-                          },
-                          Object {
-                            "end": "now/M",
-                            "label": "This month",
-                            "start": "now/M",
-                          },
-                          Object {
-                            "end": "now/y",
-                            "label": "This year",
-                            "start": "now/y",
-                          },
-                          Object {
-                            "end": "now-1d/d",
-                            "label": "Yesterday",
-                            "start": "now-1d/d",
-                          },
-                          Object {
-                            "end": "now",
-                            "label": "Week to date",
-                            "start": "now/w",
-                          },
-                          Object {
-                            "end": "now",
-                            "label": "Month to date",
-                            "start": "now/M",
-                          },
-                          Object {
-                            "end": "now",
-                            "label": "Year to date",
-                            "start": "now/y",
-                          },
-                        ]
-                      }
-                      compressed={false}
-                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                      end="now"
-                      isAutoRefreshOnly={false}
-                      isDisabled={false}
-                      isLoading={true}
-                      isPaused={true}
-                      onRefresh={[Function]}
-                      onTimeChange={[Function]}
-                      recentlyUsedRanges={
-                        Array [
-                          Object {
-                            "end": "now",
-                            "start": "now-24h",
-                          },
-                        ]
-                      }
-                      refreshInterval={0}
-                      showUpdateButton={true}
-                      start="now-24h"
-                      timeFormat="HH:mm"
-                      updateButtonProps={
-                        Object {
-                          "fill": false,
-                        }
-                      }
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
                     >
-                      <EuiFlexGroup
-                        className="euiSuperDatePicker__flexWrapper"
-                        gutterSize="s"
-                        responsive={false}
+                      <EuiTitle
+                        size="m"
                       >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper"
+                        <h1
+                          className="euiTitle euiTitle--medium"
                         >
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiFormControlLayout
-                                className="euiSuperDatePicker"
-                                compressed={false}
-                                isDisabled={false}
-                                prepend={
-                                  <EuiQuickSelectPopover
-                                    applyTime={[Function]}
-                                    commonlyUsedRanges={
-                                      Array [
-                                        Object {
-                                          "end": "now/d",
-                                          "label": "Today",
-                                          "start": "now/d",
-                                        },
-                                        Object {
-                                          "end": "now/w",
-                                          "label": "This week",
-                                          "start": "now/w",
-                                        },
-                                        Object {
-                                          "end": "now/M",
-                                          "label": "This month",
-                                          "start": "now/M",
-                                        },
-                                        Object {
-                                          "end": "now/y",
-                                          "label": "This year",
-                                          "start": "now/y",
-                                        },
-                                        Object {
-                                          "end": "now-1d/d",
-                                          "label": "Yesterday",
-                                          "start": "now-1d/d",
-                                        },
-                                        Object {
-                                          "end": "now",
-                                          "label": "Week to date",
-                                          "start": "now/w",
-                                        },
-                                        Object {
-                                          "end": "now",
-                                          "label": "Month to date",
-                                          "start": "now/M",
-                                        },
-                                        Object {
-                                          "end": "now",
-                                          "label": "Year to date",
-                                          "start": "now/y",
-                                        },
-                                      ]
-                                    }
-                                    dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                    end="now"
-                                    isAutoRefreshOnly={false}
-                                    isDisabled={false}
-                                    isPaused={true}
-                                    recentlyUsedRanges={
-                                      Array [
-                                        Object {
-                                          "end": "now",
-                                          "start": "now-24h",
-                                        },
-                                      ]
-                                    }
-                                    refreshInterval={0}
-                                    start="now-24h"
-                                  />
-                                }
+                          Security alerts
+                        </h1>
+                      </EuiTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={false}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isLoading={true}
+                        isPaused={true}
+                        onRefresh={[Function]}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now",
+                              "start": "now-24h",
+                            },
+                          ]
+                        }
+                        refreshInterval={0}
+                        showUpdateButton={true}
+                        start="now-24h"
+                        timeFormat="HH:mm"
+                        updateButtonProps={
+                          Object {
+                            "fill": false,
+                          }
+                        }
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
                               >
-                                <div
-                                  className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                                >
-                                  <EuiQuickSelectPopover
-                                    applyTime={[Function]}
-                                    className="euiFormControlLayout__prepend"
-                                    commonlyUsedRanges={
-                                      Array [
-                                        Object {
-                                          "end": "now/d",
-                                          "label": "Today",
-                                          "start": "now/d",
-                                        },
-                                        Object {
-                                          "end": "now/w",
-                                          "label": "This week",
-                                          "start": "now/w",
-                                        },
-                                        Object {
-                                          "end": "now/M",
-                                          "label": "This month",
-                                          "start": "now/M",
-                                        },
-                                        Object {
-                                          "end": "now/y",
-                                          "label": "This year",
-                                          "start": "now/y",
-                                        },
-                                        Object {
-                                          "end": "now-1d/d",
-                                          "label": "Yesterday",
-                                          "start": "now-1d/d",
-                                        },
-                                        Object {
-                                          "end": "now",
-                                          "label": "Week to date",
-                                          "start": "now/w",
-                                        },
-                                        Object {
-                                          "end": "now",
-                                          "label": "Month to date",
-                                          "start": "now/M",
-                                        },
-                                        Object {
-                                          "end": "now",
-                                          "label": "Year to date",
-                                          "start": "now/y",
-                                        },
-                                      ]
-                                    }
-                                    dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                    end="now"
-                                    isAutoRefreshOnly={false}
-                                    isDisabled={false}
-                                    isPaused={true}
-                                    key="0/.0"
-                                    recentlyUsedRanges={
-                                      Array [
-                                        Object {
-                                          "end": "now",
-                                          "start": "now-24h",
-                                        },
-                                      ]
-                                    }
-                                    refreshInterval={0}
-                                    start="now-24h"
-                                  >
-                                    <EuiPopover
-                                      anchorClassName="euiQuickSelectPopover__anchor"
-                                      anchorPosition="downLeft"
-                                      button={
-                                        <EuiButtonEmpty
-                                          aria-label="Date quick select"
-                                          className="euiFormControlLayout__prepend"
-                                          data-test-subj="superDatePickerToggleQuickMenuButton"
-                                          iconSide="right"
-                                          iconType="arrowDown"
-                                          isDisabled={false}
-                                          onClick={[Function]}
-                                          size="xs"
-                                          textProps={
-                                            Object {
-                                              "className": "euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <EuiIcon
-                                            type="calendar"
-                                          />
-                                        </EuiButtonEmpty>
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={false}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
                                       }
-                                      closePopover={[Function]}
-                                      display="inlineBlock"
-                                      hasArrow={true}
-                                      isOpen={false}
-                                      ownFocus={true}
-                                      panelPaddingSize="s"
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now",
+                                            "start": "now-24h",
+                                          },
+                                        ]
+                                      }
+                                      refreshInterval={0}
+                                      start="now-24h"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now",
+                                            "start": "now-24h",
+                                          },
+                                        ]
+                                      }
+                                      refreshInterval={0}
+                                      start="now-24h"
                                     >
-                                      <div
-                                        className="euiPopover euiPopover--anchorDownLeft"
-                                      >
-                                        <div
-                                          className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                        >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
                                           <EuiButtonEmpty
                                             aria-label="Date quick select"
                                             className="euiFormControlLayout__prepend"
@@ -517,148 +564,160 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                               }
                                             }
                                           >
-                                            <button
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
                                               aria-label="Date quick select"
-                                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                              className="euiFormControlLayout__prepend"
                                               data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              disabled={false}
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
                                               onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="right"
-                                                iconSize="s"
-                                                iconType="arrowDown"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                  }
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
                                                 }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
                                                 >
-                                                  <EuiIcon
-                                                    className="euiButtonContent__icon"
-                                                    color="inherit"
-                                                    size="s"
-                                                    type="arrowDown"
-                                                  >
-                                                    EuiIconMock
-                                                  </EuiIcon>
                                                   <span
-                                                    className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                                   >
                                                     <EuiIcon
-                                                      type="calendar"
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
                                                     >
                                                       EuiIconMock
                                                     </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        EuiIconMock
+                                                      </EuiIcon>
+                                                    </span>
                                                   </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </EuiPopover>
-                                  </EuiQuickSelectPopover>
-                                  <div
-                                    className="euiFormControlLayout__childrenWrapper"
-                                  >
-                                    <EuiDatePickerRange
-                                      className="euiDatePickerRange--inGroup"
-                                      endDateControl={<div />}
-                                      iconType={false}
-                                      isCustom={true}
-                                      startDateControl={<div />}
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
                                     >
-                                      <div
-                                        className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
                                       >
-                                        <button
-                                          className="euiSuperDatePicker__prettyFormat"
-                                          data-test-subj="superDatePickerShowDatesButton"
-                                          disabled={false}
-                                          onClick={[Function]}
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
                                         >
-                                          Last 24 hours
-                                          <span
-                                            className="euiSuperDatePicker__prettyFormatLink"
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
                                           >
-                                            <EuiI18n
-                                              default="Show dates"
-                                              token="euiSuperDatePicker.showDatesButtonLabel"
+                                            Last 24 hours
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
                                             >
-                                              Show dates
-                                            </EuiI18n>
-                                          </span>
-                                        </button>
-                                      </div>
-                                    </EuiDatePickerRange>
-                                    <EuiFormControlLayoutIcons
-                                      compressed={false}
-                                    />
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={false}
+                                      />
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiFormControlLayout>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                            <EuiFlexItem
+                              grow={false}
                             >
-                              <EuiSuperUpdateButton
-                                compressed={false}
-                                data-test-subj="superDatePickerApplyTimeButton"
-                                fill={false}
-                                isDisabled={false}
-                                isLoading={true}
-                                needsUpdate={false}
-                                onClick={[Function]}
-                                showTooltip={true}
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
                               >
-                                <EuiToolTip
-                                  delay="regular"
-                                  position="bottom"
+                                <EuiSuperUpdateButton
+                                  compressed={false}
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  fill={false}
+                                  isDisabled={false}
+                                  isLoading={true}
+                                  needsUpdate={false}
+                                  onClick={[Function]}
+                                  showTooltip={true}
                                 >
-                                  <span
-                                    className="euiToolTipAnchor"
-                                    onKeyUp={[Function]}
-                                    onMouseOut={[Function]}
-                                    onMouseOver={[Function]}
+                                  <EuiToolTip
+                                    delay="regular"
+                                    position="bottom"
                                   >
-                                    <EuiButton
-                                      className="euiSuperUpdateButton"
-                                      color="success"
-                                      data-test-subj="superDatePickerApplyTimeButton"
-                                      fill={false}
-                                      iconType="refresh"
-                                      isDisabled={false}
-                                      isLoading={true}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onFocus={[Function]}
-                                      size="m"
-                                      textProps={
-                                        Object {
-                                          "className": "euiSuperUpdateButton__text",
-                                        }
-                                      }
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
                                     >
-                                      <EuiButtonDisplay
-                                        baseClassName="euiButton"
+                                      <EuiButton
                                         className="euiSuperUpdateButton"
                                         color="success"
                                         data-test-subj="superDatePickerApplyTimeButton"
-                                        disabled={true}
-                                        element="button"
                                         fill={false}
                                         iconType="refresh"
-                                        isDisabled={true}
+                                        isDisabled={false}
                                         isLoading={true}
                                         onBlur={[Function]}
                                         onClick={[Function]}
@@ -669,80 +728,102 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                             "className": "euiSuperUpdateButton__text",
                                           }
                                         }
-                                        type="button"
                                       >
-                                        <button
-                                          className="euiButton euiButton--success euiButton-isDisabled euiSuperUpdateButton"
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="euiSuperUpdateButton"
+                                          color="success"
                                           data-test-subj="superDatePickerApplyTimeButton"
                                           disabled={true}
+                                          element="button"
+                                          fill={false}
+                                          iconType="refresh"
+                                          isDisabled={true}
+                                          isLoading={true}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onFocus={[Function]}
-                                          style={
+                                          size="m"
+                                          textProps={
                                             Object {
-                                              "minWidth": undefined,
+                                              "className": "euiSuperUpdateButton__text",
                                             }
                                           }
                                           type="button"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButton__content"
-                                            iconSide="left"
-                                            iconType="refresh"
-                                            isLoading={true}
-                                            textProps={
+                                          <button
+                                            className="euiButton euiButton--success euiButton-isDisabled euiSuperUpdateButton"
+                                            data-test-subj="superDatePickerApplyTimeButton"
+                                            disabled={true}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            style={
                                               Object {
-                                                "className": "euiButton__text euiSuperUpdateButton__text",
+                                                "minWidth": undefined,
                                               }
                                             }
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButton__content"
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              iconType="refresh"
+                                              isLoading={true}
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text euiSuperUpdateButton__text",
+                                                }
+                                              }
                                             >
-                                              <EuiLoadingSpinner
-                                                className="euiButtonContent__spinner"
-                                                size="m"
-                                              >
-                                                <span
-                                                  className="euiLoadingSpinner euiLoadingSpinner--medium euiButtonContent__spinner"
-                                                />
-                                              </EuiLoadingSpinner>
                                               <span
-                                                className="euiButton__text euiSuperUpdateButton__text"
+                                                className="euiButtonContent euiButton__content"
                                               >
-                                                <EuiI18n
-                                                  default="Updating"
-                                                  token="euiSuperUpdateButton.updatingButtonLabel"
+                                                <EuiLoadingSpinner
+                                                  className="euiButtonContent__spinner"
+                                                  size="m"
                                                 >
-                                                  Updating
-                                                </EuiI18n>
+                                                  <span
+                                                    className="euiLoadingSpinner euiLoadingSpinner--medium euiButtonContent__spinner"
+                                                  />
+                                                </EuiLoadingSpinner>
+                                                <span
+                                                  className="euiButton__text euiSuperUpdateButton__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Updating"
+                                                    token="euiSuperUpdateButton.updatingButtonLabel"
+                                                  >
+                                                    Updating
+                                                  </EuiI18n>
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonDisplay>
-                                    </EuiButton>
-                                  </span>
-                                </EuiToolTip>
-                              </EuiSuperUpdateButton>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                    </EuiSuperDatePicker>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-          </div>
-        </EuiFlexItem>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </span>
+                                  </EuiToolTip>
+                                </EuiSuperUpdateButton>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+            </div>
+          </EuiFlexItem>
+        </PageHeader>
         <EuiFlexItem>
           <div
             className="euiFlexItem"

--- a/public/pages/Correlations/containers/CorrelationRules.tsx
+++ b/public/pages/Correlations/containers/CorrelationRules.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useContext, useEffect, useMemo, useCallback, useState } from 'react';
+import React, { useEffect, useMemo, useCallback, useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,7 +16,6 @@ import {
 } from '@elastic/eui';
 import { BREADCRUMBS, PLUGIN_NAME, ROUTES } from '../../../utils/constants';
 import { DataStore } from '../../../store/DataStore';
-import { CoreServicesContext } from '../../../components/core_services';
 import {
   getCorrelationRulesTableColumns,
   getCorrelationRulesTableSearchConfig,
@@ -24,11 +23,12 @@ import {
 import { CorrelationRule, CorrelationRuleTableItem, DataSourceProps } from '../../../../types';
 import { RouteComponentProps } from 'react-router-dom';
 import { DeleteCorrelationRuleModal } from '../components/DeleteModal';
+import { setBreadcrumbs } from '../../../utils/helpers';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface CorrelationRulesProps extends RouteComponentProps, DataSourceProps {}
 
 export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: CorrelationRulesProps) => {
-  const context = useContext(CoreServicesContext);
   const [allRules, setAllRules] = useState<CorrelationRuleTableItem[]>([]);
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
   const [selectedRule, setSelectedRule] = useState<CorrelationRule | undefined>(undefined);
@@ -46,27 +46,23 @@ export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: Correla
   }, [DataStore.correlations.getCorrelationRules]);
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
-      BREADCRUMBS.CORRELATIONS,
-      BREADCRUMBS.CORRELATION_RULES,
-    ]);
+    setBreadcrumbs([BREADCRUMBS.CORRELATIONS, BREADCRUMBS.CORRELATION_RULES]);
   }, []);
 
   useEffect(() => {
     getCorrelationRules();
   }, [getCorrelationRules, props.dataSource]);
 
-  const headerActions = useMemo(
-    () => [
+  const createRuleAction = useMemo(
+    () => (
       <EuiButton
         href={`${PLUGIN_NAME}#${ROUTES.CORRELATION_RULE_CREATE}`}
         data-test-subj={'create_rule_button'}
         fill={true}
       >
         Create correlation rule
-      </EuiButton>,
-    ],
+      </EuiButton>
+    ),
     []
   );
 
@@ -109,25 +105,19 @@ export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: Correla
     <>
       {isDeleteModalVisible && deleteModal ? deleteModal : null}
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
-            <EuiFlexItem>
-              <EuiTitle size="m">
-                <h1>Correlation rules</h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup justifyContent="flexEnd">
-                {headerActions.map((action, idx) => (
-                  <EuiFlexItem key={idx} grow={false}>
-                    {action}
-                  </EuiFlexItem>
-                ))}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size={'m'} />
-        </EuiFlexItem>
+        <PageHeader appRightControls={[{ renderComponent: createRuleAction }]}>
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
+              <EuiFlexItem>
+                <EuiTitle size="m">
+                  <h1>Correlation rules</h1>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>{createRuleAction}</EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size={'m'} />
+          </EuiFlexItem>
+        </PageHeader>
         <EuiFlexItem>
           <EuiPanel>
             {allRules.length ? (

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -41,7 +41,6 @@ import {
   EuiHorizontalRule,
 } from '@elastic/eui';
 import { FilterItem, FilterGroup } from '../components/FilterGroup';
-import { CoreServicesContext } from '../../../components/core_services';
 import {
   BREADCRUMBS,
   DEFAULT_DATE_RANGE,
@@ -88,7 +87,6 @@ interface CorrelationsState {
 }
 
 export class Correlations extends React.Component<CorrelationsProps, CorrelationsState> {
-  static contextType = CoreServicesContext;
   private correlationGraphNetwork?: Network;
 
   constructor(props: CorrelationsProps) {

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -57,7 +57,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { Network } from 'react-graph-vis';
 import { getLogTypeLabel } from '../../LogTypes/utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { errorNotificationToast } from '../../../utils/helpers';
+import { errorNotificationToast, setBreadcrumbs } from '../../../utils/helpers';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 interface CorrelationsProps
   extends RouteComponentProps<
@@ -121,7 +122,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
   }
 
   async componentDidMount(): Promise<void> {
-    this.context.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.CORRELATIONS]);
+    setBreadcrumbs([BREADCRUMBS.CORRELATIONS]);
     this.updateState(true /* onMount */);
     this.props.onMount();
   }
@@ -467,6 +468,16 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
 
   render() {
     const findingCardsData = this.state.specificFindingInfo;
+    const datePicker = (
+      <EuiSuperDatePicker
+        start={this.startTime}
+        end={this.endTime}
+        recentlyUsedRanges={this.state.recentlyUsedRanges}
+        onTimeChange={this.onTimeChange}
+        onRefresh={this.onRefresh}
+        updateButtonProps={{ fill: false }}
+      />
+    );
 
     return (
       <>
@@ -540,25 +551,24 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
           </EuiFlyout>
         ) : null}
         <EuiFlexGroup direction="column">
-          <EuiFlexItem>
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <EuiTitle size="m">
-                  <h1>Correlations</h1>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiSuperDatePicker
-                  start={this.startTime}
-                  end={this.endTime}
-                  recentlyUsedRanges={this.state.recentlyUsedRanges}
-                  onTimeChange={this.onTimeChange}
-                  onRefresh={this.onRefresh}
-                  updateButtonProps={{ fill: false }}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
+          <PageHeader
+            appRightControls={[
+              {
+                renderComponent: datePicker,
+              },
+            ]}
+          >
+            <EuiFlexItem>
+              <EuiFlexGroup>
+                <EuiFlexItem>
+                  <EuiTitle size="m">
+                    <h1>Correlations</h1>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>{datePicker}</EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </PageHeader>
           <EuiFlexItem>
             <EuiPanel>
               <EuiFlexGroup gutterSize="xs" wrap={false} justifyContent="flexEnd">

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Form, Formik, FormikErrors, FormikTouched } from 'formik';
 import { ContentPanel } from '../../../components/ContentPanel';
 import { DataStore } from '../../../store/DataStore';
@@ -50,7 +50,6 @@ import {
   OS_NOTIFICATION_PLUGIN,
   ROUTES,
 } from '../../../utils/constants';
-import { CoreServicesContext } from '../../../components/core_services';
 import { RouteComponentProps, useParams } from 'react-router-dom';
 import { validateName } from '../../../utils/validation';
 import {
@@ -65,6 +64,7 @@ import {
   getFieldsForIndex,
   getLogTypeOptions,
   getPlugins,
+  setBreadcrumbs,
 } from '../../../utils/helpers';
 import { severityOptions } from '../../../pages/Alerts/utils/constants';
 import {
@@ -77,6 +77,7 @@ import { NotificationsCallOut } from '../../../../public/components/Notification
 import { ExperimentalBanner } from '../components/ExperimentalBanner';
 import { ALERT_SEVERITY_OPTIONS } from '../../CreateDetector/components/ConfigureAlerts/utils/constants';
 import uuid from 'uuid';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface CreateCorrelationRuleProps extends DataSourceProps {
   indexService: IndexService;
@@ -414,7 +415,6 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
     props.history.push(ROUTES.CORRELATION_RULES);
   };
 
-  const context = useContext(CoreServicesContext);
   const getIndices = useCallback(async () => {
     try {
       const dataSourcesRes = await getDataSources(props.indexService, props.notifications);
@@ -830,8 +830,7 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
   };
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
+    setBreadcrumbs([
       BREADCRUMBS.CORRELATIONS,
       BREADCRUMBS.CORRELATION_RULES,
       BREADCRUMBS.CORRELATIONS_RULE_CREATE,
@@ -840,14 +839,16 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
 
   return (
     <>
-      <EuiTitle>
-        <h1>{`${action} correlation rule`}</h1>
-      </EuiTitle>
-      <EuiText size="s" color="subdued">
-        {action === 'Create' ? 'Create a' : 'Edit'} correlation rule to define threat scenarios of
-        interest between different log sources.
-      </EuiText>
-      <EuiSpacer size="l" />
+      <PageHeader>
+        <EuiTitle>
+          <h1>{`${action} correlation rule`}</h1>
+        </EuiTitle>
+        <EuiText size="s" color="subdued">
+          {action === 'Create' ? 'Create a' : 'Edit'} correlation rule to define threat scenarios of
+          interest between different log sources.
+        </EuiText>
+        <EuiSpacer size="l" />
+      </PageHeader>
       <Formik
         initialValues={initialValues}
         validate={(values) => {

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -833,19 +833,29 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
     setBreadcrumbs([
       BREADCRUMBS.CORRELATIONS,
       BREADCRUMBS.CORRELATION_RULES,
-      BREADCRUMBS.CORRELATIONS_RULE_CREATE,
+      BREADCRUMBS.CORRELATIONS_RULE_CREATE(action),
     ]);
-  }, []);
+  }, [action]);
+
+  const description = `${
+    action === 'Create' ? 'Create a' : 'Edit'
+  } correlation rule to define threat scenarios of
+  interest between different log sources.`;
 
   return (
     <>
-      <PageHeader>
+      <PageHeader
+        appDescriptionControls={[
+          {
+            description,
+          },
+        ]}
+      >
         <EuiTitle>
           <h1>{`${action} correlation rule`}</h1>
         </EuiTitle>
         <EuiText size="s" color="subdued">
-          {action === 'Create' ? 'Create a' : 'Edit'} correlation rule to define threat scenarios of
-          interest between different log sources.
+          {description}
         </EuiText>
         <EuiSpacer size="l" />
       </PageHeader>

--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
@@ -521,7 +521,7 @@ Object {
           class="euiSpacer euiSpacer--l"
         />
         <div
-          class="euiSwitch"
+          class="euiSwitch euiSwitch--primary"
         >
           <button
             aria-checked="true"
@@ -1393,7 +1393,7 @@ Object {
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiSwitch"
+        class="euiSwitch euiSwitch--primary"
       >
         <button
           aria-checked="true"

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -24,7 +24,7 @@ import {
 } from '../utils/helpers';
 import { NotificationsService } from '../../../../../services';
 import { validateName } from '../../../../../utils/validation';
-import { BREADCRUMBS, getUseUpdatedUx } from '../../../../../utils/constants';
+import { BREADCRUMBS } from '../../../../../utils/constants';
 import {
   AlertCondition,
   CreateDetectorSteps,
@@ -34,6 +34,7 @@ import {
 } from '../../../../../../types';
 import { MetricsContext } from '../../../../../metrics/MetricsContext';
 import { setBreadcrumbs } from '../../../../../utils/helpers';
+import { getUseUpdatedUx } from '../../../../../services/utils/constants';
 
 interface ConfigureAlertsProps extends RouteComponentProps {
   detector: Detector;

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -24,7 +24,6 @@ import {
 } from '../utils/helpers';
 import { NotificationsService } from '../../../../../services';
 import { validateName } from '../../../../../utils/validation';
-import { CoreServicesContext } from '../../../../../components/core_services';
 import { BREADCRUMBS } from '../../../../../utils/constants';
 import {
   AlertCondition,
@@ -67,8 +66,6 @@ const isTriggerValid = (triggers: AlertCondition[]) => {
 };
 
 export default class ConfigureAlerts extends Component<ConfigureAlertsProps, ConfigureAlertsState> {
-  static contextType = CoreServicesContext;
-
   constructor(props: ConfigureAlertsProps) {
     super(props);
     this.state = {

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -34,6 +34,7 @@ import {
   NotificationChannelTypeOptions,
 } from '../../../../../../types';
 import { MetricsContext } from '../../../../../metrics/MetricsContext';
+import { setBreadcrumbs } from '../../../../../utils/helpers';
 
 interface ConfigureAlertsProps extends RouteComponentProps {
   detector: Detector;
@@ -83,8 +84,7 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
     } = this.props;
 
     isEdit &&
-      this.context.chrome.setBreadcrumbs([
-        BREADCRUMBS.SECURITY_ANALYTICS,
+      setBreadcrumbs([
         BREADCRUMBS.DETECTORS,
         BREADCRUMBS.DETECTORS_DETAILS(name, id),
         {

--- a/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/containers/ConfigureAlerts.tsx
@@ -24,7 +24,7 @@ import {
 } from '../utils/helpers';
 import { NotificationsService } from '../../../../../services';
 import { validateName } from '../../../../../utils/validation';
-import { BREADCRUMBS } from '../../../../../utils/constants';
+import { BREADCRUMBS, getUseUpdatedUx } from '../../../../../utils/constants';
 import {
   AlertCondition,
   CreateDetectorSteps,
@@ -164,9 +164,14 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
       detector: { triggers },
     } = this.props;
 
-    let getPageTitle = (): string | JSX.Element => {
+    let getPageTitle = (): React.ReactNode => {
       if (isEdit) {
-        return <>{`Alert triggers (${triggers.length})`}</>;
+        return getUseUpdatedUx() ? null : (
+          <>
+            {`Alert triggers (${triggers.length})`}
+            <EuiSpacer size={'m'} />
+          </>
+        );
       }
 
       return (
@@ -177,6 +182,7 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
           <EuiText size="s" color="subdued">
             Get notified when specific rule conditions are found by the detector.
           </EuiText>
+          <EuiSpacer size={'m'} />
         </>
       );
     };
@@ -185,8 +191,6 @@ export default class ConfigureAlerts extends Component<ConfigureAlertsProps, Con
     const content = (
       <>
         {getPageTitle()}
-
-        <EuiSpacer size={'m'} />
 
         {triggers.map((alertCondition, index) => (
           <div key={index}>

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -37,7 +37,7 @@ import {
   DetectorCreationStep,
 } from '../../../../types';
 import { DataStore } from '../../../store/DataStore';
-import { errorNotificationToast } from '../../../utils/helpers';
+import { errorNotificationToast, setBreadcrumbs } from '../../../utils/helpers';
 import { MetricsContext } from '../../../metrics/MetricsContext';
 
 interface CreateDetectorProps extends RouteComponentProps, DataSourceProps, DataSourceManagerProps {
@@ -98,11 +98,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
   }
 
   componentDidMount(): void {
-    this.context.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
-      BREADCRUMBS.DETECTORS,
-      BREADCRUMBS.DETECTORS_CREATE,
-    ]);
+    setBreadcrumbs([BREADCRUMBS.DETECTORS, BREADCRUMBS.DETECTORS_CREATE]);
     if (!(this.props.history.location.state as any)?.detectorInput) {
       this.resetDependencies();
     }

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -20,7 +20,6 @@ import { BREADCRUMBS, EMPTY_DEFAULT_DETECTOR, PLUGIN_NAME, ROUTES } from '../../
 import ConfigureAlerts from '../components/ConfigureAlerts';
 import { FieldMapping } from '../../../../models/interfaces';
 import { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
-import { CoreServicesContext } from '../../../components/core_services';
 import { BrowserServices } from '../../../models/interfaces';
 import { CreateDetectorRulesOptions } from '../../../models/types';
 import { CreateDetectorRulesState } from '../components/DefineDetector/components/DetectionRules/DetectionRules';
@@ -39,6 +38,7 @@ import {
 import { DataStore } from '../../../store/DataStore';
 import { errorNotificationToast, setBreadcrumbs } from '../../../utils/helpers';
 import { MetricsContext } from '../../../metrics/MetricsContext';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 interface CreateDetectorProps extends RouteComponentProps, DataSourceProps, DataSourceManagerProps {
   isEdit: boolean;
@@ -59,7 +59,6 @@ export interface CreateDetectorState {
 }
 
 export default class CreateDetector extends Component<CreateDetectorProps, CreateDetectorState> {
-  static contextType = CoreServicesContext;
   private triggerCounter = 1;
 
   constructor(props: CreateDetectorProps) {
@@ -383,10 +382,12 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
           </EuiFlexItem>
           <EuiFlexItem>
             <>
-              <EuiTitle>
-                <h1>Create detector</h1>
-              </EuiTitle>
-              <EuiSpacer />
+              <PageHeader>
+                <EuiTitle>
+                  <h1>Create detector</h1>
+                </EuiTitle>
+                <EuiSpacer />
+              </PageHeader>
               {this.getStepContent()}
             </>
           </EuiFlexItem>

--- a/public/pages/Detectors/components/ReviewFieldMappings/ReviewFieldMappings.tsx
+++ b/public/pages/Detectors/components/ReviewFieldMappings/ReviewFieldMappings.tsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import { EuiTitle, EuiText } from '@elastic/eui';
 import { FieldMapping } from '../../../../../models/interfaces';
 import EditFieldMappings from '../../containers/FieldMappings/EditFieldMapping';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { ContentPanel } from '../../../../components/ContentPanel';
 import { FieldMappingService } from '../../../../services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -32,8 +31,6 @@ export default class ReviewFieldMappings extends Component<
   UpdateFieldMappingsProps,
   UpdateFieldMappingsState
 > {
-  static contextType = CoreServicesContext;
-
   constructor(props: UpdateFieldMappingsProps) {
     super(props);
 

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
@@ -24,7 +24,11 @@ import { DetectorHit, SearchDetectorsResponse } from '../../../../../server/mode
 import { BREADCRUMBS, EMPTY_DEFAULT_DETECTOR, ROUTES } from '../../../../utils/constants';
 import { ServerResponse } from '../../../../../server/models/types';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { errorNotificationToast, successNotificationToast } from '../../../../utils/helpers';
+import {
+  errorNotificationToast,
+  setBreadcrumbs,
+  successNotificationToast,
+} from '../../../../utils/helpers';
 import { CoreServicesContext } from '../../../../components/core_services';
 import ReviewFieldMappings from '../ReviewFieldMappings/ReviewFieldMappings';
 import { FieldMapping, Detector } from '../../../../../types';
@@ -66,8 +70,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
         ) as DetectorHit;
         setDetector(detectorHit._source as Detector);
 
-        context?.chrome.setBreadcrumbs([
-          BREADCRUMBS.SECURITY_ANALYTICS,
+        setBreadcrumbs([
           BREADCRUMBS.DETECTORS,
           BREADCRUMBS.DETECTORS_DETAILS(detectorHit._source.name, detectorHit._id),
           {

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateBasicDetails.tsx
@@ -29,10 +29,11 @@ import {
   setBreadcrumbs,
   successNotificationToast,
 } from '../../../../utils/helpers';
-import { CoreServicesContext } from '../../../../components/core_services';
 import ReviewFieldMappings from '../ReviewFieldMappings/ReviewFieldMappings';
 import { FieldMapping, Detector } from '../../../../../types';
 import { ThreatIntelligence } from '../../../CreateDetector/components/DefineDetector/components/ThreatIntelligence/ThreatIntelligence';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
+import { dataSourceInfo } from '../../../../services/utils/constants';
 
 export interface UpdateDetectorBasicDetailsProps
   extends RouteComponentProps<any, any, { detectorHit: DetectorHit }> {
@@ -52,7 +53,6 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
   const description = inputs[0].detector_input.description;
   const detectorId = props.location.pathname.replace(`${ROUTES.EDIT_DETECTOR_DETAILS}/`, '');
 
-  const context = useContext(CoreServicesContext);
   const [threatIntelEnabledInitially, setThreatIntelEnabledInitially] = useState(false);
 
   useEffect(() => {
@@ -73,9 +73,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
         setBreadcrumbs([
           BREADCRUMBS.DETECTORS,
           BREADCRUMBS.DETECTORS_DETAILS(detectorHit._source.name, detectorHit._id),
-          {
-            text: 'Edit detector details',
-          },
+          BREADCRUMBS.EDIT_DETECTOR_DETAILS,
         ]);
         props.history.replace({
           pathname: `${ROUTES.EDIT_DETECTOR_DETAILS}/${detectorId}`,
@@ -268,11 +266,12 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
 
   return (
     <>
-      <EuiTitle size={'m'}>
-        <h3>Edit detector details</h3>
-      </EuiTitle>
-      <EuiSpacer size="xl" />
-
+      <PageHeader>
+        <EuiTitle size={'m'}>
+          <h3>Edit detector details</h3>
+        </EuiTitle>
+        <EuiSpacer size="xl" />
+      </PageHeader>
       <EuiPanel>
         <DetectorBasicDetailsForm
           isEdit={true}
@@ -290,6 +289,7 @@ export const UpdateDetectorBasicDetails: React.FC<UpdateDetectorBasicDetailsProp
           indexService={saContext?.services?.indexService as IndexService}
           detectorIndices={inputs[0].detector_input.indices}
           fieldMappingService={saContext?.services?.fieldMappingService as FieldMappingService}
+          dataSource={dataSourceInfo.activeDataSource}
           onDetectorInputIndicesChange={onDetectorInputIndicesChange}
         />
         <EuiSpacer size={'l'} />

--- a/public/pages/Detectors/components/UpdateBasicDetails/UpdateDetectorBasicDetails.test.tsx
+++ b/public/pages/Detectors/components/UpdateBasicDetails/UpdateDetectorBasicDetails.test.tsx
@@ -10,6 +10,11 @@ import { UpdateDetectorBasicDetails } from './UpdateBasicDetails';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { coreContextMock, mockContexts } from '../../../../../test/mocks/useContext.mock';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 describe('<UpdateDetectorBasicDetails /> spec', () => {
   it('renders the component', async () => {

--- a/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateBasicDetails/__snapshots__/UpdateDetectorBasicDetails.test.tsx.snap
@@ -416,22 +416,24 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
     }
   }
 >
-  <EuiTitle
-    size="m"
-  >
-    <h3
-      className="euiTitle euiTitle--medium"
+  <PageHeader>
+    <EuiTitle
+      size="m"
     >
-      Edit detector details
-    </h3>
-  </EuiTitle>
-  <EuiSpacer
-    size="xl"
-  >
-    <div
-      className="euiSpacer euiSpacer--xl"
-    />
-  </EuiSpacer>
+      <h3
+        className="euiTitle euiTitle--medium"
+      >
+        Edit detector details
+      </h3>
+    </EuiTitle>
+    <EuiSpacer
+      size="xl"
+    >
+      <div
+        className="euiSpacer euiSpacer--xl"
+      />
+    </EuiSpacer>
+  </PageHeader>
   <EuiPanel>
     <div
       className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -662,6 +664,11 @@ exports[`<UpdateDetectorBasicDetails /> spec renders the component 1`] = `
         />
       </EuiSpacer>
       <DetectorDataSource
+        dataSource={
+          Object {
+            "id": "",
+          }
+        }
         detectorIndices={
           Array [
             ".windows",

--- a/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.test.tsx
+++ b/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.test.tsx
@@ -9,6 +9,11 @@ import props from '../../../../../test/mocks/Detectors/components/UpdateFieldMap
 import { expect } from '@jest/globals';
 import UpdateFieldMappings from './UpdateFieldMappings';
 import { coreContextMock } from '../../../../../test/mocks/useContext.mock';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 jest.mock('../../containers/FieldMappings/EditFieldMapping.tsx', () => () => {
   return <mock-component mock="EditFieldMapping" />;

--- a/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
+++ b/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
@@ -13,7 +13,11 @@ import { BREADCRUMBS, EMPTY_DEFAULT_DETECTOR, ROUTES } from '../../../../utils/c
 import { DetectorsService } from '../../../../services';
 import { ServerResponse } from '../../../../../server/models/types';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { errorNotificationToast, successNotificationToast } from '../../../../utils/helpers';
+import {
+  errorNotificationToast,
+  setBreadcrumbs,
+  successNotificationToast,
+} from '../../../../utils/helpers';
 import EditFieldMappings from '../../containers/FieldMappings/EditFieldMapping';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { Detector } from '../../../../../types';
@@ -70,8 +74,7 @@ export default class UpdateFieldMappings extends Component<
         const detector = detectorHit._source;
         detector.detector_type = detector.detector_type.toLowerCase();
 
-        this.context.chrome.setBreadcrumbs([
-          BREADCRUMBS.SECURITY_ANALYTICS,
+        setBreadcrumbs([
           BREADCRUMBS.DETECTORS,
           BREADCRUMBS.DETECTORS_DETAILS(detectorHit._source.name, detectorHit._id),
           {

--- a/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
+++ b/public/pages/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.tsx
@@ -19,8 +19,8 @@ import {
   successNotificationToast,
 } from '../../../../utils/helpers';
 import EditFieldMappings from '../../containers/FieldMappings/EditFieldMapping';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { Detector } from '../../../../../types';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface UpdateFieldMappingsProps
   extends RouteComponentProps<any, any, { detectorHit: DetectorHit }> {
@@ -41,8 +41,6 @@ export default class UpdateFieldMappings extends Component<
   UpdateFieldMappingsProps,
   UpdateFieldMappingsState
 > {
-  static contextType = CoreServicesContext;
-
   constructor(props: UpdateFieldMappingsProps) {
     super(props);
     const { location } = props;
@@ -77,9 +75,7 @@ export default class UpdateFieldMappings extends Component<
         setBreadcrumbs([
           BREADCRUMBS.DETECTORS,
           BREADCRUMBS.DETECTORS_DETAILS(detectorHit._source.name, detectorHit._id),
-          {
-            text: 'Edit field mapping',
-          },
+          BREADCRUMBS.EDIT_DETECTOR_DETAILS,
         ]);
 
         history.replace({
@@ -169,19 +165,29 @@ export default class UpdateFieldMappings extends Component<
     const { submitting, detector, fieldMappings, loading } = this.state;
     return (
       <div>
-        <EuiTitle size={'m'}>
-          <h3>Edit detector details</h3>
-        </EuiTitle>
+        <PageHeader
+          appDescriptionControls={[
+            {
+              description: `To perform threat detections, your data source will need to be in a common schema format.
+            Rule field names are automatically mapped to the most common fields in your log data
+            source.`,
+            },
+          ]}
+        >
+          <EuiTitle size={'m'}>
+            <h3>Edit detector details</h3>
+          </EuiTitle>
 
-        <EuiText size="s" color="subdued">
-          To perform threat detections, your data source will need to be in a common schema format.
-          <br />
-          Rule field names are automatically mapped to the most common fields in your log data
-          source.
-        </EuiText>
+          <EuiText size="s" color="subdued">
+            To perform threat detections, your data source will need to be in a common schema
+            format.
+            <br />
+            Rule field names are automatically mapped to the most common fields in your log data
+            source.
+          </EuiText>
 
-        <EuiSpacer size={'xxl'} />
-
+          <EuiSpacer size={'xxl'} />
+        </PageHeader>
         {!loading && (
           <EditFieldMappings
             {...this.props}

--- a/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
+++ b/public/pages/Detectors/components/UpdateRules/UpdateRules.tsx
@@ -17,8 +17,11 @@ import { BREADCRUMBS, EMPTY_DEFAULT_DETECTOR, ROUTES } from '../../../../utils/c
 import { SecurityAnalyticsContext } from '../../../../services';
 import { ServerResponse } from '../../../../../server/models/types';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { CoreServicesContext } from '../../../../components/core_services';
-import { errorNotificationToast, successNotificationToast } from '../../../../utils/helpers';
+import {
+  errorNotificationToast,
+  setBreadcrumbs,
+  successNotificationToast,
+} from '../../../../utils/helpers';
 import { RuleTableItem } from '../../../Rules/utils/helpers';
 import { RuleViewerFlyout } from '../../../Rules/components/RuleViewerFlyout/RuleViewerFlyout';
 import { ContentPanel } from '../../../../components/ContentPanel';
@@ -48,8 +51,6 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
   const [fieldMappingsIsVisible, setFieldMappingsIsVisible] = useState(false);
   const [ruleQueryFields, setRuleQueryFields] = useState<Set<string>>();
 
-  const context = useContext(CoreServicesContext);
-
   useEffect(() => {
     const getDetector = async () => {
       setLoading(true);
@@ -63,8 +64,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
         const newDetector = { ...detectorHit._source, id: detectorId } as Detector;
         setDetector(newDetector);
 
-        context?.chrome.setBreadcrumbs([
-          BREADCRUMBS.SECURITY_ANALYTICS,
+        setBreadcrumbs([
           BREADCRUMBS.DETECTORS,
           BREADCRUMBS.DETECTORS_DETAILS(detectorHit._source.name, detectorHit._id),
           {
@@ -241,7 +241,7 @@ export const UpdateDetectorRules: React.FC<UpdateDetectorRulesProps> = (props) =
       category: ruleItem.logType,
       description: ruleItem.description,
       source: ruleItem.library,
-      ruleInfo: ruleItem.ruleInfo,
+      ruleInfo: { ...ruleItem.ruleInfo, prePackaged: ruleItem.library === 'Standard' },
       ruleId: ruleItem.id,
     }));
   };

--- a/public/pages/Detectors/components/UpdateRules/__snapshots__/UpdateDetectorRules.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateRules/__snapshots__/UpdateDetectorRules.test.tsx.snap
@@ -189,7 +189,7 @@ Object {
                                 title="EuiIconMockEuiIconMock"
                               >
                                 <div
-                                  class="euiSwitch"
+                                  class="euiSwitch euiSwitch--primary"
                                 >
                                   <button
                                     aria-checked="true"
@@ -570,7 +570,7 @@ Object {
                               title="EuiIconMockEuiIconMock"
                             >
                               <div
-                                class="euiSwitch"
+                                class="euiSwitch euiSwitch--primary"
                               >
                                 <button
                                   aria-checked="true"

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.test.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.test.tsx
@@ -10,6 +10,11 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { DetectorDetails } from './DetectorDetails';
 import { coreContextMock } from '../../../../../test/mocks/useContext.mock';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 describe('<DetectorDetails /> spec', () => {
   it('renders the component', async () => {

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -31,6 +31,7 @@ import { NotificationsStart, SimpleSavedObject } from 'opensearch-dashboards/pub
 import { ISavedObjectsService, ServerResponse } from '../../../../../types';
 import { PENDING_DETECTOR_ID } from '../../../CreateDetector/utils/constants';
 import { DataStore } from '../../../../store/DataStore';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface DetectorDetailsProps
   extends RouteComponentProps<
@@ -341,7 +342,7 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
     this.setState({ loading: false });
   };
 
-  createHeaderActions(): React.ReactNode[] {
+  createHeaderActions(): React.JSX.Element[] {
     const { loading } = this.state;
     const { isActionsMenuOpen } = this.state;
     return [
@@ -475,34 +476,45 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
 
     return (
       <>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiFlexGroup alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiTitle data-test-subj={'detector-details-detector-name'}>
-                  <h1>{detector.name}</h1>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiHealth color={statusColor}>{statusText}</EuiHealth>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
-              {!creatingDetector && !createFailed
-                ? this.createHeaderActions().map(
-                    (action: React.ReactNode, idx: number): React.ReactNode => (
-                      <EuiFlexItem key={idx} grow={false}>
-                        {action}
-                      </EuiFlexItem>
+        <PageHeader
+          appBadgeControls={[
+            { renderComponent: <EuiHealth color={statusColor}>{statusText}</EuiHealth> },
+          ]}
+          appRightControls={
+            !creatingDetector && !createFailed
+              ? this.createHeaderActions().map((action) => ({ renderComponent: action }))
+              : undefined
+          }
+        >
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center">
+                <EuiFlexItem grow={false}>
+                  <EuiTitle data-test-subj={'detector-details-detector-name'}>
+                    <h1>{detector.name}</h1>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiHealth color={statusColor}>{statusText}</EuiHealth>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
+                {!creatingDetector && !createFailed
+                  ? this.createHeaderActions().map(
+                      (action: React.ReactNode, idx: number): React.ReactNode => (
+                        <EuiFlexItem key={idx} grow={false}>
+                          {action}
+                        </EuiFlexItem>
+                      )
                     )
-                  )
-                : null}
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="xl" />
+                  : null}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="xl" />
+        </PageHeader>
         <EuiTabs>{this.renderTabs()}</EuiTabs>
         <EuiSpacer size="xl" />
         {selectedTabContent}

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -19,7 +19,6 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { BREADCRUMBS, EMPTY_DEFAULT_DETECTOR_HIT, ROUTES } from '../../../../utils/constants';
 import { DetectorHit } from '../../../../../server/models/interfaces';
 import { DetectorDetailsView } from '../DetectorDetailsView/DetectorDetailsView';
@@ -27,7 +26,7 @@ import { FieldMappingsView } from '../../components/FieldMappingsView/FieldMappi
 import { AlertTriggersView } from '../AlertTriggersView/AlertTriggersView';
 import { RuleItem } from '../../../CreateDetector/components/DefineDetector/components/DetectionRules/types/interfaces';
 import { DetectorsService, IndexPatternsService } from '../../../../services';
-import { errorNotificationToast } from '../../../../utils/helpers';
+import { errorNotificationToast, setBreadcrumbs } from '../../../../utils/helpers';
 import { NotificationsStart, SimpleSavedObject } from 'opensearch-dashboards/public';
 import { ISavedObjectsService, ServerResponse } from '../../../../../types';
 import { PENDING_DETECTOR_ID } from '../../../CreateDetector/utils/constants';
@@ -69,8 +68,6 @@ enum TabId {
 }
 
 export class DetectorDetails extends React.Component<DetectorDetailsProps, DetectorDetailsState> {
-  static contextType = CoreServicesContext;
-
   private get detectorHit(): DetectorHit {
     return this.state.detectorHit;
   }
@@ -200,8 +197,7 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
         },
       });
 
-      this.context.chrome.setBreadcrumbs([
-        BREADCRUMBS.SECURITY_ANALYTICS,
+      setBreadcrumbs([
         BREADCRUMBS.DETECTORS,
         BREADCRUMBS.DETECTORS_DETAILS(detector.name, PENDING_DETECTOR_ID),
       ]);
@@ -253,8 +249,7 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
             enabled: detector._source.enabled,
           },
         };
-        this.context.chrome.setBreadcrumbs([
-          BREADCRUMBS.SECURITY_ANALYTICS,
+        setBreadcrumbs([
           BREADCRUMBS.DETECTORS,
           BREADCRUMBS.DETECTORS_DETAILS(detector._source.name, detector._id),
         ]);

--- a/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
@@ -237,139 +237,197 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
     }
   }
 >
-  <EuiFlexGroup>
-    <div
-      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-    >
-      <EuiFlexItem>
-        <div
-          className="euiFlexItem"
-        >
-          <EuiFlexGroup
-            alignItems="center"
+  <PageHeader
+    appBadgeControls={
+      Array [
+        Object {
+          "renderComponent": <EuiHealth
+            color="success"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
+            Active
+          </EuiHealth>,
+        },
+      ]
+    }
+    appRightControls={
+      Array [
+        Object {
+          "renderComponent": <EuiPopover
+            anchorPosition="downLeft"
+            button={
+              <EuiButton
+                data-test-subj="detectorsActionsButton"
+                iconSide="right"
+                iconType="arrowDown"
+                isLoading={false}
+                onClick={[Function]}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiTitle
-                    data-test-subj="detector-details-detector-name"
+                Actions
+              </EuiButton>
+            }
+            closePopover={[Function]}
+            data-test-subj="detectorsActionsPopover"
+            display="inlineBlock"
+            hasArrow={true}
+            id="detectorsActionsPopover"
+            isOpen={false}
+            ownFocus={true}
+            panelPaddingSize="none"
+          >
+            <EuiContextMenuPanel
+              hasFocus={true}
+              items={
+                Array [
+                  <EuiContextMenuItem
+                    data-test-subj="viewAlertsButton"
+                    disabled={false}
+                    icon="empty"
+                    onClick={[Function]}
                   >
-                    <h1
-                      className="euiTitle euiTitle--medium"
+                    View Alerts
+                  </EuiContextMenuItem>,
+                  <EuiContextMenuItem
+                    data-test-subj="viewFindingsButton"
+                    disabled={false}
+                    icon="empty"
+                    onClick={[Function]}
+                  >
+                    View Findings
+                  </EuiContextMenuItem>,
+                  <React.Fragment />,
+                  <EuiHorizontalRule
+                    margin="xs"
+                  />,
+                  <EuiContextMenuItem
+                    data-test-subj="deleteButton"
+                    disabled={false}
+                    icon="empty"
+                    onClick={[Function]}
+                  >
+                    Stop detector
+                  </EuiContextMenuItem>,
+                  <EuiContextMenuItem
+                    data-test-subj="editButton"
+                    disabled={false}
+                    icon="empty"
+                    onClick={[Function]}
+                  >
+                    Delete
+                  </EuiContextMenuItem>,
+                ]
+              }
+            />
+          </EuiPopover>,
+        },
+      ]
+    }
+  >
+    <EuiFlexGroup>
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <EuiFlexItem>
+          <div
+            className="euiFlexItem"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiTitle
                       data-test-subj="detector-details-detector-name"
                     >
-                      detector_name
-                    </h1>
-                  </EuiTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiHealth
-                    color="success"
-                  >
-                    <div
-                      className="euiHealth euiHealth--textSizeS"
-                    >
-                      <EuiFlexGroup
-                        alignItems="center"
-                        gutterSize="xs"
-                        responsive={false}
+                      <h1
+                        className="euiTitle euiTitle--medium"
+                        data-test-subj="detector-details-detector-name"
                       >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiIcon
-                                color="success"
-                                type="dot"
-                              >
-                                EuiIconMock
-                              </EuiIcon>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              Active
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                    </div>
-                  </EuiHealth>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-        </div>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <div
-          className="euiFlexItem"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            justifyContent="flexEnd"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-                key="0"
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                        detector_name
+                      </h1>
+                    </EuiTitle>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
                 >
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButton
-                        data-test-subj="detectorsActionsButton"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        isLoading={false}
-                        onClick={[Function]}
-                      >
-                        Actions
-                      </EuiButton>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="detectorsActionsPopover"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    id="detectorsActionsPopover"
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="detectorsActionsPopover"
-                      id="detectorsActionsPopover"
+                    <EuiHealth
+                      color="success"
                     >
                       <div
-                        className="euiPopover__anchor"
+                        className="euiHealth euiHealth--textSizeS"
                       >
+                        <EuiFlexGroup
+                          alignItems="center"
+                          gutterSize="xs"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                          >
+                            <EuiFlexItem
+                              grow={false}
+                            >
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <EuiIcon
+                                  color="success"
+                                  type="dot"
+                                >
+                                  EuiIconMock
+                                </EuiIcon>
+                              </div>
+                            </EuiFlexItem>
+                            <EuiFlexItem
+                              grow={false}
+                            >
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                Active
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </div>
+                    </EuiHealth>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <div
+            className="euiFlexItem"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              justifyContent="flexEnd"
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={false}
+                  key="0"
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiPopover
+                      anchorPosition="downLeft"
+                      button={
                         <EuiButton
                           data-test-subj="detectorsActionsButton"
                           iconSide="right"
@@ -377,80 +435,108 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           isLoading={false}
                           onClick={[Function]}
                         >
-                          <EuiButtonDisplay
-                            baseClassName="euiButton"
+                          Actions
+                        </EuiButton>
+                      }
+                      closePopover={[Function]}
+                      data-test-subj="detectorsActionsPopover"
+                      display="inlineBlock"
+                      hasArrow={true}
+                      id="detectorsActionsPopover"
+                      isOpen={false}
+                      ownFocus={true}
+                      panelPaddingSize="none"
+                    >
+                      <div
+                        className="euiPopover euiPopover--anchorDownLeft"
+                        data-test-subj="detectorsActionsPopover"
+                        id="detectorsActionsPopover"
+                      >
+                        <div
+                          className="euiPopover__anchor"
+                        >
+                          <EuiButton
                             data-test-subj="detectorsActionsButton"
-                            disabled={false}
-                            element="button"
                             iconSide="right"
                             iconType="arrowDown"
-                            isDisabled={false}
                             isLoading={false}
                             onClick={[Function]}
-                            type="button"
                           >
-                            <button
-                              className="euiButton euiButton--primary"
+                            <EuiButtonDisplay
+                              baseClassName="euiButton"
                               data-test-subj="detectorsActionsButton"
                               disabled={false}
+                              element="button"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              isDisabled={false}
+                              isLoading={false}
                               onClick={[Function]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
                               type="button"
                             >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                isLoading={false}
-                                textProps={
+                              <button
+                                className="euiButton euiButton--primary"
+                                data-test-subj="detectorsActionsButton"
+                                disabled={false}
+                                onClick={[Function]}
+                                style={
                                   Object {
-                                    "className": "euiButton__text",
+                                    "minWidth": undefined,
                                   }
                                 }
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                                <EuiButtonContent
+                                  className="euiButton__content"
+                                  iconSide="right"
+                                  iconType="arrowDown"
+                                  isLoading={false}
+                                  textProps={
+                                    Object {
+                                      "className": "euiButton__text",
+                                    }
+                                  }
                                 >
-                                  <EuiIcon
-                                    className="euiButtonContent__icon"
-                                    color="inherit"
-                                    size="m"
-                                    type="arrowDown"
-                                  >
-                                    EuiIconMock
-                                  </EuiIcon>
                                   <span
-                                    className="euiButton__text"
+                                    className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                                   >
-                                    Actions
+                                    <EuiIcon
+                                      className="euiButtonContent__icon"
+                                      color="inherit"
+                                      size="m"
+                                      type="arrowDown"
+                                    >
+                                      EuiIconMock
+                                    </EuiIcon>
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Actions
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonDisplay>
-                        </EuiButton>
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonDisplay>
+                          </EuiButton>
+                        </div>
                       </div>
-                    </div>
-                  </EuiPopover>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-        </div>
-      </EuiFlexItem>
-    </div>
-  </EuiFlexGroup>
-  <EuiSpacer
-    size="xl"
-  >
-    <div
-      className="euiSpacer euiSpacer--xl"
-    />
-  </EuiSpacer>
+                    </EuiPopover>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <EuiSpacer
+      size="xl"
+    >
+      <div
+        className="euiSpacer euiSpacer--xl"
+      />
+    </EuiSpacer>
+  </PageHeader>
   <EuiTabs>
     <div
       className="euiTabs"

--- a/public/pages/Detectors/containers/Detectors/Detectors.test.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.test.tsx
@@ -10,6 +10,11 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import Detectors from './Detectors';
 import { coreContextMock } from '../../../../../test/mocks/useContext.mock';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 describe('<Detectors /> spec', () => {
   it('renders the component', async () => {

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -30,6 +30,7 @@ import {
   formatRuleType,
   getLogTypeFilterOptions,
   renderTime,
+  setBreadcrumbs,
 } from '../../../../utils/helpers';
 import { CoreServicesContext } from '../../../../components/core_services';
 import { FieldValueSelectionFilterConfigType } from '@elastic/eui/src/components/search_bar/filters/field_value_selection_filter';
@@ -69,7 +70,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
   }
 
   async componentDidMount() {
-    this.context.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.DETECTORS]);
+    setBreadcrumbs([BREADCRUMBS.DETECTORS]);
     await this.getDetectors();
   }
 

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -32,13 +32,13 @@ import {
   renderTime,
   setBreadcrumbs,
 } from '../../../../utils/helpers';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { FieldValueSelectionFilterConfigType } from '@elastic/eui/src/components/search_bar/filters/field_value_selection_filter';
 import { DetectorsService } from '../../../../services';
 import { DetectorHit } from '../../../../../server/models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { Direction } from '@opensearch-project/oui/src/services/sort/sort_direction';
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface DetectorsProps extends RouteComponentProps {
   detectorService: DetectorsService;
@@ -55,8 +55,6 @@ interface DetectorsState {
 }
 
 export default class Detectors extends Component<DetectorsProps, DetectorsState> {
-  static contextType = CoreServicesContext;
-
   constructor(props: DetectorsProps) {
     super(props);
 
@@ -351,23 +349,33 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
     };
     return (
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiTitle size="m">
-                <h1>Threat detectors</h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup justifyContent="flexEnd">
-                {actions.map((action) => {
-                  return <EuiFlexItem grow={false}>{action}</EuiFlexItem>;
-                })}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size={'m'} />
-        </EuiFlexItem>
+        <PageHeader
+          appRightControls={actions.map((action) => ({
+            renderComponent: action,
+          }))}
+        >
+          <EuiFlexItem>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiTitle size="m">
+                  <h1>Threat detectors</h1>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFlexGroup justifyContent="flexEnd">
+                  {actions.map((action, idx) => {
+                    return (
+                      <EuiFlexItem key={idx} grow={false}>
+                        {action}
+                      </EuiFlexItem>
+                    );
+                  })}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size={'m'} />
+          </EuiFlexItem>
+        </PageHeader>
 
         <EuiFlexItem>
           <EuiPanel>

--- a/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
@@ -37,142 +37,181 @@ exports[`<Detectors /> spec renders the component 1`] = `
     <div
       className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
     >
-      <EuiFlexItem>
-        <div
-          className="euiFlexItem"
-        >
-          <EuiFlexGroup>
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiTitle
-                    size="m"
+      <PageHeader
+        appRightControls={
+          Array [
+            Object {
+              "renderComponent": <EuiButton
+                data-test-subj="detectorsRefreshButton"
+                iconType="refresh"
+                onClick={[Function]}
+              >
+                Refresh
+              </EuiButton>,
+            },
+            Object {
+              "renderComponent": <EuiPopover
+                anchorPosition="downLeft"
+                button={
+                  <EuiButton
+                    data-test-subj="detectorsActionsButton"
+                    disabled={true}
+                    iconSide="right"
+                    iconType="arrowDown"
+                    isLoading={false}
+                    onClick={[Function]}
                   >
-                    <h1
-                      className="euiTitle euiTitle--medium"
-                    >
-                      Threat detectors
-                    </h1>
-                  </EuiTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiFlexGroup
-                    justifyContent="flexEnd"
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem
-                        grow={false}
+                    Actions
+                  </EuiButton>
+                }
+                closePopover={[Function]}
+                data-test-subj="detectorsActionsPopover"
+                display="inlineBlock"
+                hasArrow={true}
+                id="detectorsActionsPopover"
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="none"
+              >
+                <EuiContextMenuPanel
+                  hasFocus={true}
+                  items={
+                    Array [
+                      <EuiContextMenuItem
+                        data-test-subj="deleteButton"
+                        disabled={true}
+                        icon="empty"
+                        onClick={[Function]}
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        Delete
+                      </EuiContextMenuItem>,
+                    ]
+                  }
+                />
+              </EuiPopover>,
+            },
+            Object {
+              "renderComponent": <EuiButton
+                data-test-subj="detectorsCreateButton"
+                fill={true}
+                href="opensearch_security_analytics_dashboards#/create-detector"
+              >
+                Create detector
+              </EuiButton>,
+            },
+          ]
+        }
+      >
+        <EuiFlexItem>
+          <div
+            className="euiFlexItem"
+          >
+            <EuiFlexGroup>
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h1
+                        className="euiTitle euiTitle--medium"
+                      >
+                        Threat detectors
+                      </h1>
+                    </EuiTitle>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFlexGroup
+                      justifyContent="flexEnd"
+                    >
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      >
+                        <EuiFlexItem
+                          grow={false}
+                          key="0"
                         >
-                          <EuiButton
-                            data-test-subj="detectorsRefreshButton"
-                            iconType="refresh"
-                            onClick={[Function]}
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
+                            <EuiButton
                               data-test-subj="detectorsRefreshButton"
-                              disabled={false}
-                              element="button"
                               iconType="refresh"
-                              isDisabled={false}
                               onClick={[Function]}
-                              type="button"
                             >
-                              <button
-                                className="euiButton euiButton--primary"
+                              <EuiButtonDisplay
+                                baseClassName="euiButton"
                                 data-test-subj="detectorsRefreshButton"
                                 disabled={false}
+                                element="button"
+                                iconType="refresh"
+                                isDisabled={false}
                                 onClick={[Function]}
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                  }
-                                }
                                 type="button"
                               >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="left"
-                                  iconType="refresh"
-                                  textProps={
+                                <button
+                                  className="euiButton euiButton--primary"
+                                  data-test-subj="detectorsRefreshButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  style={
                                     Object {
-                                      "className": "euiButton__text",
+                                      "minWidth": undefined,
                                     }
                                   }
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButton__content"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    iconType="refresh"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
                                   >
-                                    <EuiIcon
-                                      className="euiButtonContent__icon"
-                                      color="inherit"
-                                      size="m"
-                                      type="refresh"
-                                    >
-                                      EuiIconMock
-                                    </EuiIcon>
                                     <span
-                                      className="euiButton__text"
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      Refresh
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="refresh"
+                                      >
+                                        EuiIconMock
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Refresh
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonDisplay>
-                          </EuiButton>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                          key="1"
                         >
-                          <EuiPopover
-                            anchorPosition="downLeft"
-                            button={
-                              <EuiButton
-                                data-test-subj="detectorsActionsButton"
-                                disabled={true}
-                                iconSide="right"
-                                iconType="arrowDown"
-                                isLoading={false}
-                                onClick={[Function]}
-                              >
-                                Actions
-                              </EuiButton>
-                            }
-                            closePopover={[Function]}
-                            data-test-subj="detectorsActionsPopover"
-                            display="inlineBlock"
-                            hasArrow={true}
-                            id="detectorsActionsPopover"
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiPopover euiPopover--anchorDownLeft"
-                              data-test-subj="detectorsActionsPopover"
-                              id="detectorsActionsPopover"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
+                            <EuiPopover
+                              anchorPosition="downLeft"
+                              button={
                                 <EuiButton
                                   data-test-subj="detectorsActionsButton"
                                   disabled={true}
@@ -181,138 +220,168 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   isLoading={false}
                                   onClick={[Function]}
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButton"
+                                  Actions
+                                </EuiButton>
+                              }
+                              closePopover={[Function]}
+                              data-test-subj="detectorsActionsPopover"
+                              display="inlineBlock"
+                              hasArrow={true}
+                              id="detectorsActionsPopover"
+                              isOpen={false}
+                              ownFocus={true}
+                              panelPaddingSize="none"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorDownLeft"
+                                data-test-subj="detectorsActionsPopover"
+                                id="detectorsActionsPopover"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <EuiButton
                                     data-test-subj="detectorsActionsButton"
                                     disabled={true}
-                                    element="button"
                                     iconSide="right"
                                     iconType="arrowDown"
-                                    isDisabled={true}
                                     isLoading={false}
                                     onClick={[Function]}
-                                    type="button"
                                   >
-                                    <button
-                                      className="euiButton euiButton--primary euiButton-isDisabled"
+                                    <EuiButtonDisplay
+                                      baseClassName="euiButton"
                                       data-test-subj="detectorsActionsButton"
                                       disabled={true}
+                                      element="button"
+                                      iconSide="right"
+                                      iconType="arrowDown"
+                                      isDisabled={true}
+                                      isLoading={false}
                                       onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
                                       type="button"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="right"
-                                        iconType="arrowDown"
-                                        isLoading={false}
-                                        textProps={
+                                      <button
+                                        className="euiButton euiButton--primary euiButton-isDisabled"
+                                        data-test-subj="detectorsActionsButton"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        style={
                                           Object {
-                                            "className": "euiButton__text",
+                                            "minWidth": undefined,
                                           }
                                         }
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                                        <EuiButtonContent
+                                          className="euiButton__content"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          isLoading={false}
+                                          textProps={
+                                            Object {
+                                              "className": "euiButton__text",
+                                            }
+                                          }
                                         >
-                                          <EuiIcon
-                                            className="euiButtonContent__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowDown"
-                                          >
-                                            EuiIconMock
-                                          </EuiIcon>
                                           <span
-                                            className="euiButton__text"
+                                            className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                                           >
-                                            Actions
+                                            <EuiIcon
+                                              className="euiButtonContent__icon"
+                                              color="inherit"
+                                              size="m"
+                                              type="arrowDown"
+                                            >
+                                              EuiIconMock
+                                            </EuiIcon>
+                                            <span
+                                              className="euiButton__text"
+                                            >
+                                              Actions
+                                            </span>
                                           </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonDisplay>
-                                </EuiButton>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonDisplay>
+                                  </EuiButton>
+                                </div>
                               </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                            </EuiPopover>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                          key="2"
                         >
-                          <EuiButton
-                            data-test-subj="detectorsCreateButton"
-                            fill={true}
-                            href="opensearch_security_analytics_dashboards#/create-detector"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
+                            <EuiButton
                               data-test-subj="detectorsCreateButton"
-                              element="a"
                               fill={true}
                               href="opensearch_security_analytics_dashboards#/create-detector"
-                              isDisabled={false}
-                              rel="noreferrer"
                             >
-                              <a
-                                className="euiButton euiButton--primary euiButton--fill"
+                              <EuiButtonDisplay
+                                baseClassName="euiButton"
                                 data-test-subj="detectorsCreateButton"
-                                disabled={false}
+                                element="a"
+                                fill={true}
                                 href="opensearch_security_analytics_dashboards#/create-detector"
+                                isDisabled={false}
                                 rel="noreferrer"
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                  }
-                                }
                               >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="left"
-                                  textProps={
+                                <a
+                                  className="euiButton euiButton--primary euiButton--fill"
+                                  data-test-subj="detectorsCreateButton"
+                                  disabled={false}
+                                  href="opensearch_security_analytics_dashboards#/create-detector"
+                                  rel="noreferrer"
+                                  style={
                                     Object {
-                                      "className": "euiButton__text",
+                                      "minWidth": undefined,
                                     }
                                   }
                                 >
-                                  <span
-                                    className="euiButtonContent euiButton__content"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButton__text"
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      Create detector
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Create detector
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </a>
-                            </EuiButtonDisplay>
-                          </EuiButton>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-        </div>
-      </EuiFlexItem>
+                                  </EuiButtonContent>
+                                </a>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+          </div>
+        </EuiFlexItem>
+      </PageHeader>
       <EuiFlexItem>
         <div
           className="euiFlexItem"

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -38,7 +38,6 @@ import {
   getThreatIntelFindingsVisualizationSpec,
   TimeUnit,
 } from '../../../Overview/utils/helpers';
-import { CoreServicesContext } from '../../../../components/core_services';
 import {
   getNotificationChannels,
   parseNotificationChannelsToOptions,
@@ -132,7 +131,6 @@ export const groupByOptionsByTabId = {
 };
 
 class Findings extends Component<FindingsProps, FindingsState> {
-  static contextType = CoreServicesContext;
   private abortGetFindingsControllers: AbortController[] = [];
 
   constructor(props: FindingsProps) {

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -49,6 +49,7 @@ import {
   renderVisualization,
   getDuration,
   getIsNotificationPluginInstalled,
+  setBreadcrumbs,
 } from '../../../../utils/helpers';
 import { RuleSource } from '../../../../../server/models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -65,6 +66,7 @@ import {
   ThreatIntelFindingsGroupByType,
 } from '../../../../../types';
 import { ThreatIntelFindingsTable } from '../../components/FindingsTable/ThreatIntelFindingsTable';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 interface FindingsProps extends RouteComponentProps, DataSourceProps {
   detectorService: DetectorsService;
@@ -221,7 +223,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
   }
 
   componentDidMount = async () => {
-    this.context.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.FINDINGS]);
+    setBreadcrumbs([BREADCRUMBS.FINDINGS]);
     this.onRefresh();
   };
 
@@ -583,29 +585,39 @@ class Findings extends Component<FindingsProps, FindingsState> {
       },
     ];
 
+    const datePicker = (
+      <EuiSuperDatePicker
+        start={dateTimeFilter.startTime}
+        end={dateTimeFilter.endTime}
+        recentlyUsedRanges={recentlyUsedRanges}
+        isLoading={loading}
+        onTimeChange={this.onTimeChange}
+        onRefresh={this.onRefresh}
+        updateButtonProps={{ fill: false }}
+      />
+    );
+
     return (
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
-            <EuiFlexItem>
-              <EuiTitle size="m">
-                <h1>Findings</h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiSuperDatePicker
-                start={dateTimeFilter.startTime}
-                end={dateTimeFilter.endTime}
-                recentlyUsedRanges={recentlyUsedRanges}
-                isLoading={loading}
-                onTimeChange={this.onTimeChange}
-                onRefresh={this.onRefresh}
-                updateButtonProps={{ fill: false }}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size={'m'} />
-        </EuiFlexItem>
+        <PageHeader
+          appRightControls={[
+            {
+              renderComponent: datePicker,
+            },
+          ]}
+        >
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
+              <EuiFlexItem>
+                <EuiTitle size="m">
+                  <h1>Findings</h1>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>{datePicker}</EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size={'m'} />
+          </EuiFlexItem>
+        </PageHeader>
         <EuiFlexItem>
           <EuiPanel>
             <EuiFlexGroup direction="column">

--- a/public/pages/LogTypes/containers/CreateLogType.tsx
+++ b/public/pages/LogTypes/containers/CreateLogType.tsx
@@ -4,16 +4,15 @@
  */
 
 import { ContentPanel } from '../../../components/ContentPanel';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { LogTypeForm } from '../components/LogTypeForm';
 import { LogTypeBase } from '../../../../types';
 import { defaultLogType } from '../utils/constants';
 import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS, ROUTES } from '../../../utils/constants';
-import { CoreServicesContext } from '../../../components/core_services';
 import { useEffect } from 'react';
 import { DataStore } from '../../../store/DataStore';
-import { successNotificationToast } from '../../../utils/helpers';
+import { setBreadcrumbs, successNotificationToast } from '../../../utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 
 export interface CreateLogTypeProps extends RouteComponentProps {
@@ -22,15 +21,9 @@ export interface CreateLogTypeProps extends RouteComponentProps {
 
 export const CreateLogType: React.FC<CreateLogTypeProps> = ({ history, notifications }) => {
   const [logTypeDetails, setLogTypeDetails] = useState<LogTypeBase>({ ...defaultLogType });
-  const context = useContext(CoreServicesContext);
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
-      BREADCRUMBS.DETECTORS,
-      BREADCRUMBS.LOG_TYPES,
-      BREADCRUMBS.LOG_TYPE_CREATE,
-    ]);
+    setBreadcrumbs([BREADCRUMBS.DETECTORS, BREADCRUMBS.LOG_TYPES, BREADCRUMBS.LOG_TYPE_CREATE]);
   }, []);
 
   return (

--- a/public/pages/LogTypes/containers/CreateLogType.tsx
+++ b/public/pages/LogTypes/containers/CreateLogType.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ContentPanel } from '../../../components/ContentPanel';
 import React, { useState } from 'react';
 import { LogTypeForm } from '../components/LogTypeForm';
 import { LogTypeBase } from '../../../../types';
@@ -14,6 +13,8 @@ import { useEffect } from 'react';
 import { DataStore } from '../../../store/DataStore';
 import { setBreadcrumbs, successNotificationToast } from '../../../utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
+import { EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface CreateLogTypeProps extends RouteComponentProps {
   notifications: NotificationsStart;
@@ -26,14 +27,20 @@ export const CreateLogType: React.FC<CreateLogTypeProps> = ({ history, notificat
     setBreadcrumbs([BREADCRUMBS.DETECTORS, BREADCRUMBS.LOG_TYPES, BREADCRUMBS.LOG_TYPE_CREATE]);
   }, []);
 
+  const description =
+    'Create log type to categorize and identify detection rules for your data sources.';
+
   return (
-    <ContentPanel
-      title={'Create log type'}
-      subTitleText={
-        <p>Create log type to categorize and identify detection rules for your data sources.</p>
-      }
-      hideHeaderBorder={true}
-    >
+    <EuiPanel>
+      <PageHeader appDescriptionControls={[{ description }]}>
+        <EuiTitle>
+          <h3>Create log type</h3>
+        </EuiTitle>
+        <EuiText size="s" color="subdued">
+          {description}
+        </EuiText>
+        <EuiSpacer />
+      </PageHeader>
       <LogTypeForm
         logTypeDetails={{ ...logTypeDetails, id: '', detectionRulesCount: 0 }}
         isEditMode={true}
@@ -49,6 +56,6 @@ export const CreateLogType: React.FC<CreateLogTypeProps> = ({ history, notificat
           }
         }}
       />
-    </ContentPanel>
+    </EuiPanel>
   );
 };

--- a/public/pages/LogTypes/containers/LogType.tsx
+++ b/public/pages/LogTypes/containers/LogType.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useContext } from 'react';
+import React from 'react';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import { RouteComponentProps, useParams } from 'react-router-dom';
@@ -22,7 +22,6 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { DataStore } from '../../../store/DataStore';
-import { CoreServicesContext } from '../../../components/core_services';
 import { BREADCRUMBS, ROUTES } from '../../../utils/constants';
 import { logTypeDetailsTabs } from '../utils/constants';
 import { LogTypeDetails } from '../components/LogTypeDetails';
@@ -31,14 +30,18 @@ import { LogTypeDetectionRules } from '../components/LogTypeDetectionRules';
 import { RuleTableItem } from '../../Rules/utils/helpers';
 import { useCallback } from 'react';
 import { DeleteLogTypeModal } from '../components/DeleteLogTypeModal';
-import { errorNotificationToast, successNotificationToast } from '../../../utils/helpers';
+import {
+  errorNotificationToast,
+  setBreadcrumbs,
+  successNotificationToast,
+} from '../../../utils/helpers';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface LogTypeProps extends RouteComponentProps {
   notifications: NotificationsStart;
 }
 
 export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
-  const context = useContext(CoreServicesContext);
   const { logTypeId } = useParams<{ logTypeId: string }>();
   const [selectedTabId, setSelectedTabId] = useState('details');
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -91,12 +94,7 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
         return;
       }
 
-      context?.chrome.setBreadcrumbs([
-        BREADCRUMBS.SECURITY_ANALYTICS,
-        BREADCRUMBS.DETECTORS,
-        BREADCRUMBS.LOG_TYPES,
-        { text: details.name },
-      ]);
+      setBreadcrumbs([BREADCRUMBS.DETECTORS, BREADCRUMBS.LOG_TYPES, { text: details.name }]);
       const logTypeItem = { ...details, detectionRulesCount: details.detectionRules.length };
       updateRules(logTypeItem, logTypeItem);
     };
@@ -143,6 +141,12 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
     }
   };
 
+  const deleteAction = (
+    <EuiToolTip content="Delete" position="bottom">
+      <EuiButtonIcon iconType={'trash'} color="danger" onClick={() => setShowDeleteModal(true)} />
+    </EuiToolTip>
+  );
+
   return !logTypeDetails ? (
     <EuiTitle>
       <h2>{infoText}</h2>
@@ -157,23 +161,16 @@ export const LogType: React.FC<LogTypeProps> = ({ notifications, history }) => {
           onConfirm={deleteLogType}
         />
       )}
-      <EuiFlexGroup justifyContent="spaceBetween">
-        <EuiFlexItem>
-          <EuiTitle>
-            <h1>{logTypeDetails.name}</h1>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiToolTip content="Delete" position="bottom">
-            <EuiButtonIcon
-              iconType={'trash'}
-              color="danger"
-              onClick={() => setShowDeleteModal(true)}
-            />
-          </EuiToolTip>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-
+      <PageHeader appRightControls={[{ renderComponent: deleteAction }]}>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem>
+            <EuiTitle>
+              <h1>{logTypeDetails.name}</h1>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{deleteAction}</EuiFlexItem>
+        </EuiFlexGroup>
+      </PageHeader>
       <EuiSpacer />
       <EuiPanel grow={false}>
         <EuiDescriptionList

--- a/public/pages/LogTypes/containers/LogTypes.tsx
+++ b/public/pages/LogTypes/containers/LogTypes.tsx
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useContext, useEffect, useState } from 'react';
-import { EuiButton, EuiInMemoryTable } from '@elastic/eui';
-import { ContentPanel } from '../../../components/ContentPanel';
-import { CoreServicesContext } from '../../../components/core_services';
+import React, { useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { BREADCRUMBS, ROUTES } from '../../../utils/constants';
 import { DataSourceProps, LogType } from '../../../../types';
 import { DataStore } from '../../../store/DataStore';
@@ -14,15 +21,15 @@ import { getLogTypesTableColumns, getLogTypesTableSearchConfig } from '../utils/
 import { RouteComponentProps } from 'react-router-dom';
 import { useCallback } from 'react';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { successNotificationToast } from '../../../utils/helpers';
+import { setBreadcrumbs, successNotificationToast } from '../../../utils/helpers';
 import { DeleteLogTypeModal } from '../components/DeleteLogTypeModal';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface LogTypesProps extends RouteComponentProps, DataSourceProps {
   notifications: NotificationsStart;
 }
 
 export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, dataSource }) => {
-  const context = useContext(CoreServicesContext);
   const [logTypes, setLogTypes] = useState<LogType[]>([]);
   const [logTypeToDelete, setLogTypeItemToDelete] = useState<LogType | undefined>(undefined);
   const [deletionDetails, setDeletionDetails] = useState<
@@ -42,11 +49,7 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, data
   };
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
-      BREADCRUMBS.DETECTORS,
-      BREADCRUMBS.LOG_TYPES,
-    ]);
+    setBreadcrumbs([BREADCRUMBS.DETECTORS, BREADCRUMBS.LOG_TYPES]);
   }, []);
 
   useEffect(() => {
@@ -65,6 +68,12 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, data
     setDeletionDetails({ detectionRulesCount: rules.length });
   };
 
+  const createLogTypeAction = (
+    <EuiButton fill={true} onClick={() => history.push(ROUTES.LOG_TYPES_CREATE)}>
+      Create log type
+    </EuiButton>
+  );
+
   return (
     <>
       {logTypeToDelete && (
@@ -76,18 +85,25 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, data
           onConfirm={() => deleteLogType(logTypeToDelete.id)}
         />
       )}
-      <ContentPanel
-        title={'Log types'}
-        subTitleText={
-          'Log types describe the data sources the detection rules are meant to be applied to.'
-        }
-        hideHeaderBorder
-        actions={[
-          <EuiButton fill={true} onClick={() => history.push(ROUTES.LOG_TYPES_CREATE)}>
-            Create log type
-          </EuiButton>,
-        ]}
-      >
+
+      <EuiPanel>
+        <PageHeader appRightControls={[{ renderComponent: createLogTypeAction }]}>
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
+              <EuiFlexItem>
+                <EuiTitle size="m">
+                  <h1>Log types</h1>
+                </EuiTitle>
+                <EuiText size="s" color="subdued">
+                  Log types describe the data sources the detection rules are meant to be applied
+                  to.
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>{createLogTypeAction}</EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size={'m'} />
+          </EuiFlexItem>
+        </PageHeader>
         <EuiInMemoryTable
           items={logTypes}
           columns={getLogTypesTableColumns(showLogTypeDetails, onDeleteClick)}
@@ -97,7 +113,7 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, data
           search={getLogTypesTableSearchConfig()}
           sorting={true}
         />
-      </ContentPanel>
+      </EuiPanel>
     </>
   );
 };

--- a/public/pages/LogTypes/containers/LogTypes.tsx
+++ b/public/pages/LogTypes/containers/LogTypes.tsx
@@ -95,8 +95,8 @@ export const LogTypes: React.FC<LogTypesProps> = ({ history, notifications, data
                   <h1>Log types</h1>
                 </EuiTitle>
                 <EuiText size="s" color="subdued">
-                  Log types describe the data sources the detection rules are meant to be applied
-                  to.
+                  Log types describe the data sources to which the detection rules are meant to be
+                  applied.
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>{createLogTypeAction}</EuiFlexItem>

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
@@ -22,12 +22,6 @@
     .detection-visual-editor-textarea-clear-btn {
       align-items: flex-end;
     }
-
-    .detection-visual-editor-accordion {
-      .euiAccordion__childWrapper {
-        height: auto !important;
-      }
-    }
   }
 
   .detection-visual-editor-name {

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.tsx
@@ -556,9 +556,9 @@ export class DetectionVisualEditor extends React.Component<
                   const valueId = `value_${selectionIdx}_${idx}`;
                   return (
                     <div key={`Map-${idx}`} className={'detection-visual-editor-accordion-wrapper'}>
+                      {idx > 0 && <EuiSpacer />}
                       <EuiAccordion
                         className="euiAccordionForm detection-visual-editor-accordion"
-                        buttonClassName="euiAccordionForm__button"
                         id={`Map-${idx}`}
                         key={`Map-${idx}`}
                         data-test-subj={`Map-${idx}`}
@@ -581,9 +581,8 @@ export class DetectionVisualEditor extends React.Component<
                           ) : null
                         }
                         style={{ maxWidth: '70%' }}
+                        paddingSize="m"
                       >
-                        <EuiSpacer size="m" />
-
                         <EuiFlexGroup>
                           <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
                             <EuiFormRow

--- a/public/pages/Rules/components/RuleEditor/RuleEditorContainer.test.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorContainer.test.tsx
@@ -12,6 +12,11 @@ import { mockContexts } from '../../../../../test/mocks/useContext.mock';
 import { notificationsMock } from '../../../../../test/mocks/services';
 import { ReactWrapper, mount } from 'enzyme';
 import { expect } from '@jest/globals';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 describe('<RuleEditorContainer /> spec', () => {
   it('renders the component', async () => {

--- a/public/pages/Rules/components/RuleEditor/RuleEditorContainer.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorContainer.tsx
@@ -16,7 +16,7 @@ import { DataStore } from '../../../../store/DataStore';
 import { Rule } from '../../../../../types';
 
 export interface RuleEditorProps {
-  title: string | JSX.Element;
+  title?: string | JSX.Element;
   rule?: Rule;
   history: RouteComponentProps['history'];
   notifications?: NotificationsStart;

--- a/public/pages/Rules/components/RuleEditor/RuleEditorContainer.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorContainer.tsx
@@ -10,13 +10,14 @@ import { ROUTES } from '../../../../utils/constants';
 import { EuiSpacer } from '@elastic/eui';
 import { RuleEditorFormModel, ruleEditorStateDefaultValue } from './RuleEditorFormModel';
 import { mapFormToRule, mapRuleToForm } from './mappers';
-import { RuleEditorForm } from './RuleEditorForm';
+import { RuleEditorForm, VisualRuleEditorProps } from './RuleEditorForm';
 import { validateRule } from '../../utils/helpers';
 import { DataStore } from '../../../../store/DataStore';
 import { Rule } from '../../../../../types';
 
 export interface RuleEditorProps {
-  title?: string | JSX.Element;
+  title: string;
+  subtitleData?: VisualRuleEditorProps['subtitleData'];
   rule?: Rule;
   history: RouteComponentProps['history'];
   notifications?: NotificationsStart;
@@ -37,6 +38,7 @@ export const RuleEditorContainer: React.FC<RuleEditorProps> = ({
   rule,
   mode,
   validateOnMount,
+  subtitleData,
 }) => {
   const initialRuleValue = rule
     ? { ...mapRuleToForm(rule), id: ruleEditorStateDefaultValue.id }
@@ -76,6 +78,7 @@ export const RuleEditorContainer: React.FC<RuleEditorProps> = ({
         notifications={notifications}
         initialValue={initialRuleValue}
         validateOnMount={validateOnMount}
+        subtitleData={subtitleData}
         cancel={goToRulesList}
         submit={onSubmit}
       />

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.test.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.test.tsx
@@ -12,6 +12,11 @@ import { mockContexts } from '../../../../../test/mocks/useContext.mock';
 import { notificationsMock } from '../../../../../test/mocks/services';
 import { ReactWrapper, mount } from 'enzyme';
 import { expect } from '@jest/globals';
+import { setupCoreStart } from '../../../../../test/utils/helpers';
+
+beforeAll(() => {
+  setupCoreStart();
+});
 
 describe('<RuleEditorForm /> spec', () => {
   it('renders the component', async () => {

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -20,6 +20,7 @@ import {
   EuiTitle,
   EuiPanel,
   EuiIcon,
+  EuiLink,
 } from '@elastic/eui';
 import { FieldTextArray } from './components/FieldTextArray';
 import { ruleSeverity, ruleStatus, ruleTypes } from '../../utils/constants';
@@ -51,7 +52,8 @@ export interface VisualRuleEditorProps {
   submit: (values: RuleEditorFormModel) => void;
   cancel: () => void;
   mode: 'create' | 'edit';
-  title?: string | JSX.Element;
+  title: string;
+  subtitleData?: { text: string; href?: string }[];
 }
 
 const editorTypes = [
@@ -75,6 +77,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
   mode,
   title,
   validateOnMount,
+  subtitleData,
 }) => {
   const [selectedEditorType, setSelectedEditorType] = useState('visual');
   const [isDetectionInvalid, setIsDetectionInvalid] = useState(false);
@@ -192,10 +195,45 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
         return (
           <Form>
             <EuiPanel className={'rule-editor-form'}>
-              <PageHeader>
+              <PageHeader
+                appDescriptionControls={
+                  subtitleData
+                    ? subtitleData.map((slice) => {
+                        return slice.href
+                          ? {
+                              label: slice.text,
+                              href: slice.href,
+                              controlType: 'link',
+                              target: '_blank',
+                              iconType: 'popout',
+                              iconSide: 'right',
+                            }
+                          : {
+                              description: slice.text,
+                            };
+                      })
+                    : undefined
+                }
+              >
                 <EuiTitle>
                   <h3>{title}</h3>
                 </EuiTitle>
+                {subtitleData &&
+                  subtitleData.map((slice, idx) => {
+                    return (
+                      <span key={idx}>
+                        {slice.href ? (
+                          <EuiLink href={slice.href} target="_blank">
+                            {slice.text}
+                          </EuiLink>
+                        ) : (
+                          <EuiText size="s" color="subdued">
+                            {slice.text}
+                          </EuiText>
+                        )}
+                      </span>
+                    );
+                  })}
               </PageHeader>
               <EuiButtonGroup
                 data-test-subj="change-editor-type"

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.tsx
@@ -21,7 +21,6 @@ import {
   EuiPanel,
   EuiIcon,
 } from '@elastic/eui';
-import { ContentPanel } from '../../../../components/ContentPanel';
 import { FieldTextArray } from './components/FieldTextArray';
 import { ruleSeverity, ruleStatus, ruleTypes } from '../../utils/constants';
 import {
@@ -43,6 +42,7 @@ import { getLogTypeOptions } from '../../../../utils/helpers';
 import { getLogTypeLabel } from '../../../LogTypes/utils/helpers';
 import { getSeverityLabel } from '../../../Correlations/utils/constants';
 import { DataSourceContext } from '../../../../services/DataSourceContext';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface VisualRuleEditorProps {
   initialValue: RuleEditorFormModel;
@@ -51,7 +51,7 @@ export interface VisualRuleEditorProps {
   submit: (values: RuleEditorFormModel) => void;
   cancel: () => void;
   mode: 'create' | 'edit';
-  title: string | JSX.Element;
+  title?: string | JSX.Element;
 }
 
 const editorTypes = [
@@ -191,7 +191,12 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
         return (
           <Form>
-            <ContentPanel title={title} className={'rule-editor-form'}>
+            <EuiPanel className={'rule-editor-form'}>
+              <PageHeader>
+                <EuiTitle>
+                  <h3>{title}</h3>
+                </EuiTitle>
+              </PageHeader>
               <EuiButtonGroup
                 data-test-subj="change-editor-type"
                 legend="This is editor type selector"
@@ -456,7 +461,7 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
                   <EuiSpacer size={'xl'} />
 
-                  <EuiPanel style={{ maxWidth: 1000 }}>
+                  <div style={{ maxWidth: 1000 }}>
                     <EuiAccordion
                       id={'additional-details'}
                       initialIsOpen={true}
@@ -465,10 +470,9 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                           Additional details <i>- optional</i>
                         </>
                       }
+                      paddingSize="l"
                     >
                       <div className={'rule-editor-form-additional-details-panel-body'}>
-                        <EuiSpacer />
-
                         <FieldTextArray
                           name="tags"
                           placeholder={'tag'}
@@ -560,10 +564,10 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                         />
                       </div>
                     </EuiAccordion>
-                  </EuiPanel>
+                  </div>
                 </>
               )}
-            </ContentPanel>
+            </EuiPanel>
 
             <EuiSpacer />
 

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/DetectionVisualEditor.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/DetectionVisualEditor.test.tsx.snap
@@ -74,7 +74,7 @@ Object {
                   <button
                     aria-controls="Map-0"
                     aria-expanded="true"
-                    class="euiAccordion__button euiAccordionForm__button"
+                    class="euiAccordion__button"
                     id="some_html_id"
                     type="button"
                   >
@@ -104,11 +104,8 @@ Object {
                 >
                   <div>
                     <div
-                      class=""
+                      class="euiAccordion__padding--m"
                     >
-                      <div
-                        class="euiSpacer euiSpacer--m"
-                      />
                       <div
                         class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                       >
@@ -605,7 +602,7 @@ Object {
                 <button
                   aria-controls="Map-0"
                   aria-expanded="true"
-                  class="euiAccordion__button euiAccordionForm__button"
+                  class="euiAccordion__button"
                   id="some_html_id"
                   type="button"
                 >
@@ -635,11 +632,8 @@ Object {
               >
                 <div>
                   <div
-                    class=""
+                    class="euiAccordion__padding--m"
                   >
-                    <div
-                      class="euiSpacer euiSpacer--m"
-                    />
                     <div
                       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                     >

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorContainer.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorContainer.test.tsx.snap
@@ -81,2653 +81,623 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
         <form
           action="#"
         >
-          <ContentPanel
+          <EuiPanel
             className="rule-editor-form"
-            title="Rule title"
           >
-            <EuiPanel
-              className="rule-editor-form"
-              style={
-                Object {
-                  "paddingLeft": "0px",
-                  "paddingRight": "0px",
-                }
-              }
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow rule-editor-form"
             >
-              <div
-                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow rule-editor-form"
-                style={
-                  Object {
-                    "paddingLeft": "0px",
-                    "paddingRight": "0px",
-                  }
+              <PageHeader>
+                <EuiTitle>
+                  <h3
+                    className="euiTitle euiTitle--medium"
+                  >
+                    Rule title
+                  </h3>
+                </EuiTitle>
+              </PageHeader>
+              <EuiButtonGroup
+                data-test-subj="change-editor-type"
+                idSelected="visual"
+                legend="This is editor type selector"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "id": "visual",
+                      "label": "Visual Editor",
+                    },
+                    Object {
+                      "id": "yaml",
+                      "label": "YAML Editor",
+                    },
+                  ]
                 }
               >
-                <EuiFlexGroup
-                  alignItems="center"
-                  justifyContent="spaceBetween"
-                  style={
-                    Object {
-                      "padding": "0px 10px",
-                    }
-                  }
+                <fieldset
+                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                  data-test-subj="change-editor-type"
+                  disabled={false}
                 >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    style={
-                      Object {
-                        "padding": "0px 10px",
-                      }
-                    }
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiTitle
-                          size="m"
-                        >
-                          <h3
-                            className="euiTitle euiTitle--medium"
-                          >
-                            Rule title
-                          </h3>
-                        </EuiTitle>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-                <EuiHorizontalRule
-                  margin="xs"
-                >
-                  <hr
-                    className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-                  />
-                </EuiHorizontalRule>
-                <div
-                  style={
-                    Object {
-                      "padding": "0px 10px",
-                    }
-                  }
-                >
-                  <EuiButtonGroup
-                    data-test-subj="change-editor-type"
-                    idSelected="visual"
-                    legend="This is editor type selector"
-                    onChange={[Function]}
-                    options={
-                      Array [
-                        Object {
-                          "id": "visual",
-                          "label": "Visual Editor",
-                        },
-                        Object {
-                          "id": "yaml",
-                          "label": "YAML Editor",
-                        },
-                      ]
-                    }
-                  >
-                    <fieldset
-                      className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                      data-test-subj="change-editor-type"
-                      disabled={false}
+                  <EuiScreenReaderOnly>
+                    <legend
+                      className="euiScreenReaderOnly"
                     >
-                      <EuiScreenReaderOnly>
-                        <legend
-                          className="euiScreenReaderOnly"
-                        >
-                          This is editor type selector
-                        </legend>
-                      </EuiScreenReaderOnly>
-                      <div
-                        className="euiButtonGroup__buttons"
+                      This is editor type selector
+                    </legend>
+                  </EuiScreenReaderOnly>
+                  <div
+                    className="euiButtonGroup__buttons"
+                  >
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="visual"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={true}
+                      key="0"
+                      label="Visual Editor"
+                      name="some_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className="euiButtonGroupButton-isSelected"
+                        color="text"
+                        element="label"
+                        fill={true}
+                        htmlFor="some_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Visual Editor",
+                            "ref": [Function],
+                            "title": "Visual Editor",
+                          }
+                        }
                       >
-                        <EuiButtonGroupButton
-                          color="text"
-                          element="label"
-                          id="visual"
-                          isDisabled={false}
-                          isIconOnly={false}
-                          isSelected={true}
-                          key="0"
-                          label="Visual Editor"
-                          name="some_html_id"
-                          onChange={[Function]}
-                          size="s"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                          disabled={false}
+                          htmlFor="some_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <EuiButtonDisplay
-                            baseClassName="euiButtonGroupButton"
-                            className="euiButtonGroupButton-isSelected"
-                            color="text"
-                            element="label"
-                            fill={true}
-                            htmlFor="some_html_id"
-                            isDisabled={false}
-                            onClick={[Function]}
-                            size="s"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
                             textProps={
                               Object {
-                                "className": "euiButtonGroupButton__textShift",
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
                                 "data-text": "Visual Editor",
                                 "ref": [Function],
                                 "title": "Visual Editor",
                               }
                             }
                           >
-                            <label
-                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              disabled={false}
-                              htmlFor="some_html_id"
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
+                            <span
+                              className="euiButtonContent euiButton__content"
                             >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="left"
-                                textProps={
-                                  Object {
-                                    "className": "euiButton__text euiButtonGroupButton__textShift",
-                                    "data-text": "Visual Editor",
-                                    "ref": [Function],
-                                    "title": "Visual Editor",
-                                  }
-                                }
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Visual Editor"
+                                title="Visual Editor"
                               >
-                                <span
-                                  className="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    className="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Visual Editor"
-                                    title="Visual Editor"
-                                  >
-                                    <input
-                                      checked={true}
-                                      className="euiScreenReaderOnly"
-                                      data-test-subj="visual"
-                                      disabled={false}
-                                      id="some_html_id"
-                                      name="some_html_id"
-                                      onChange={[Function]}
-                                      type="radio"
-                                    />
-                                    Visual Editor
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </label>
-                          </EuiButtonDisplay>
-                        </EuiButtonGroupButton>
-                        <EuiButtonGroupButton
-                          color="text"
-                          element="label"
-                          id="yaml"
-                          isDisabled={false}
-                          isIconOnly={false}
-                          isSelected={false}
-                          key="1"
-                          label="YAML Editor"
-                          name="some_html_id"
-                          onChange={[Function]}
-                          size="s"
+                                <input
+                                  checked={true}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="visual"
+                                  disabled={false}
+                                  id="some_html_id"
+                                  name="some_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Visual Editor
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="yaml"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="1"
+                      label="YAML Editor"
+                      name="some_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="some_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "YAML Editor",
+                            "ref": [Function],
+                            "title": "YAML Editor",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="some_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <EuiButtonDisplay
-                            baseClassName="euiButtonGroupButton"
-                            className=""
-                            color="text"
-                            element="label"
-                            fill={false}
-                            htmlFor="some_html_id"
-                            isDisabled={false}
-                            onClick={[Function]}
-                            size="s"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
                             textProps={
                               Object {
-                                "className": "euiButtonGroupButton__textShift",
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
                                 "data-text": "YAML Editor",
                                 "ref": [Function],
                                 "title": "YAML Editor",
                               }
                             }
                           >
-                            <label
-                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              disabled={false}
-                              htmlFor="some_html_id"
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
+                            <span
+                              className="euiButtonContent euiButton__content"
                             >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="left"
-                                textProps={
-                                  Object {
-                                    "className": "euiButton__text euiButtonGroupButton__textShift",
-                                    "data-text": "YAML Editor",
-                                    "ref": [Function],
-                                    "title": "YAML Editor",
-                                  }
-                                }
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="YAML Editor"
+                                title="YAML Editor"
                               >
-                                <span
-                                  className="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    className="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="YAML Editor"
-                                    title="YAML Editor"
-                                  >
-                                    <input
-                                      checked={false}
-                                      className="euiScreenReaderOnly"
-                                      data-test-subj="yaml"
-                                      disabled={false}
-                                      id="some_html_id"
-                                      name="some_html_id"
-                                      onChange={[Function]}
-                                      type="radio"
-                                    />
-                                    YAML Editor
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </label>
-                          </EuiButtonDisplay>
-                        </EuiButtonGroupButton>
-                      </div>
-                    </fieldset>
-                  </EuiButtonGroup>
-                  <EuiSpacer
-                    size="xl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
-                  <FormSubmissionErrorToastNotification
-                    notifications={
-                      Object {
-                        "toasts": Object {
-                          "addDanger": [MockFunction],
-                          "addInfo": [MockFunction],
-                          "addSuccess": [MockFunction],
-                          "addWarning": [MockFunction],
-                        },
-                      }
-                    }
-                  />
-                  <EuiTitle>
-                    <EuiText
-                      className="euiTitle euiTitle--medium"
-                    >
-                      <div
-                        className="euiText euiText--medium euiTitle euiTitle--medium"
-                      >
-                        <h2>
-                          Rule overview
-                        </h2>
-                      </div>
-                    </EuiText>
-                  </EuiTitle>
-                  <EuiSpacer>
-                    <div
-                      className="euiSpacer euiSpacer--l"
-                    />
-                  </EuiSpacer>
-                  <EuiFormRow
-                    describedByIds={Array []}
-                    display="row"
-                    fullWidth={false}
-                    hasChildLabel={true}
-                    hasEmptyLabelSpace={false}
-                    helpText="Rule name can be max 256 characters."
-                    label={
-                      <EuiText
-                        size="s"
-                      >
-                        <strong>
-                          Rule name
-                        </strong>
-                      </EuiText>
-                    }
-                    labelType="label"
-                  >
-                    <div
-                      className="euiFormRow"
-                      id="some_html_id-row"
-                    >
-                      <div
-                        className="euiFormRow__labelWrapper"
-                      >
-                        <EuiFormLabel
-                          className="euiFormRow__label"
-                          htmlFor="some_html_id"
-                          isFocused={false}
-                          type="label"
-                        >
-                          <label
-                            className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
-                          >
-                            <EuiText
-                              size="s"
-                            >
-                              <div
-                                className="euiText euiText--small"
-                              >
-                                <strong>
-                                  Rule name
-                                </strong>
-                              </div>
-                            </EuiText>
-                          </label>
-                        </EuiFormLabel>
-                      </div>
-                      <div
-                        className="euiFormRow__fieldWrapper"
-                      >
-                        <EuiFieldText
-                          aria-describedby="some_html_id-help-0"
-                          data-test-subj="rule_name_field"
-                          id="some_html_id"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder="My custom rule"
-                          value=""
-                        >
-                          <EuiFormControlLayout
-                            fullWidth={false}
-                            inputId="some_html_id"
-                          >
-                            <div
-                              className="euiFormControlLayout"
-                            >
-                              <div
-                                className="euiFormControlLayout__childrenWrapper"
-                              >
-                                <EuiValidatableControl>
-                                  <input
-                                    aria-describedby="some_html_id-help-0"
-                                    className="euiFieldText"
-                                    data-test-subj="rule_name_field"
-                                    id="some_html_id"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    placeholder="My custom rule"
-                                    type="text"
-                                    value=""
-                                  />
-                                </EuiValidatableControl>
-                                <EuiFormControlLayoutIcons />
-                              </div>
-                            </div>
-                          </EuiFormControlLayout>
-                        </EuiFieldText>
-                        <EuiFormHelpText
-                          className="euiFormRow__text"
-                          id="some_html_id-help-0"
-                          key="Rule name can be max 256 characters."
-                        >
-                          <div
-                            className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
-                          >
-                            Rule name can be max 256 characters.
-                          </div>
-                        </EuiFormHelpText>
-                      </div>
-                    </div>
-                  </EuiFormRow>
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiFormRow
-                    describedByIds={Array []}
-                    display="row"
-                    fullWidth={false}
-                    hasChildLabel={true}
-                    hasEmptyLabelSpace={false}
-                    label={
-                      <EuiText
-                        size="s"
-                      >
-                        <strong>
-                          Description 
-                        </strong>
-                        <i>
-                          - optional
-                        </i>
-                      </EuiText>
-                    }
-                    labelType="label"
-                  >
-                    <div
-                      className="euiFormRow"
-                      id="some_html_id-row"
-                    >
-                      <div
-                        className="euiFormRow__labelWrapper"
-                      >
-                        <EuiFormLabel
-                          className="euiFormRow__label"
-                          htmlFor="some_html_id"
-                          isFocused={false}
-                          type="label"
-                        >
-                          <label
-                            className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
-                          >
-                            <EuiText
-                              size="s"
-                            >
-                              <div
-                                className="euiText euiText--small"
-                              >
-                                <strong>
-                                  Description 
-                                </strong>
-                                <i>
-                                  - optional
-                                </i>
-                              </div>
-                            </EuiText>
-                          </label>
-                        </EuiFormLabel>
-                      </div>
-                      <div
-                        className="euiFormRow__fieldWrapper"
-                      >
-                        <EuiFieldText
-                          data-test-subj="rule_description_field"
-                          id="some_html_id"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder="Detects ..."
-                          value=""
-                        >
-                          <EuiFormControlLayout
-                            fullWidth={false}
-                            inputId="some_html_id"
-                          >
-                            <div
-                              className="euiFormControlLayout"
-                            >
-                              <div
-                                className="euiFormControlLayout__childrenWrapper"
-                              >
-                                <EuiValidatableControl>
-                                  <input
-                                    className="euiFieldText"
-                                    data-test-subj="rule_description_field"
-                                    id="some_html_id"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    placeholder="Detects ..."
-                                    type="text"
-                                    value=""
-                                  />
-                                </EuiValidatableControl>
-                                <EuiFormControlLayoutIcons />
-                              </div>
-                            </div>
-                          </EuiFormControlLayout>
-                        </EuiFieldText>
-                      </div>
-                    </div>
-                  </EuiFormRow>
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiFormRow
-                    describedByIds={Array []}
-                    display="row"
-                    fullWidth={false}
-                    hasChildLabel={true}
-                    hasEmptyLabelSpace={false}
-                    helpText="Combine multiple authors separated with a comma"
-                    label={
-                      <EuiText
-                        size="s"
-                      >
-                        <strong>
-                          Author
-                        </strong>
-                      </EuiText>
-                    }
-                    labelType="label"
-                  >
-                    <div
-                      className="euiFormRow"
-                      id="some_html_id-row"
-                    >
-                      <div
-                        className="euiFormRow__labelWrapper"
-                      >
-                        <EuiFormLabel
-                          className="euiFormRow__label"
-                          htmlFor="some_html_id"
-                          isFocused={false}
-                          type="label"
-                        >
-                          <label
-                            className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
-                          >
-                            <EuiText
-                              size="s"
-                            >
-                              <div
-                                className="euiText euiText--small"
-                              >
-                                <strong>
-                                  Author
-                                </strong>
-                              </div>
-                            </EuiText>
-                          </label>
-                        </EuiFormLabel>
-                      </div>
-                      <div
-                        className="euiFormRow__fieldWrapper"
-                      >
-                        <EuiFieldText
-                          aria-describedby="some_html_id-help-0"
-                          data-test-subj="rule_author_field"
-                          id="some_html_id"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder="Enter author name"
-                          value=""
-                        >
-                          <EuiFormControlLayout
-                            fullWidth={false}
-                            inputId="some_html_id"
-                          >
-                            <div
-                              className="euiFormControlLayout"
-                            >
-                              <div
-                                className="euiFormControlLayout__childrenWrapper"
-                              >
-                                <EuiValidatableControl>
-                                  <input
-                                    aria-describedby="some_html_id-help-0"
-                                    className="euiFieldText"
-                                    data-test-subj="rule_author_field"
-                                    id="some_html_id"
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    placeholder="Enter author name"
-                                    type="text"
-                                    value=""
-                                  />
-                                </EuiValidatableControl>
-                                <EuiFormControlLayoutIcons />
-                              </div>
-                            </div>
-                          </EuiFormControlLayout>
-                        </EuiFieldText>
-                        <EuiFormHelpText
-                          className="euiFormRow__text"
-                          id="some_html_id-help-0"
-                          key="Combine multiple authors separated with a comma"
-                        >
-                          <div
-                            className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
-                          >
-                            Combine multiple authors separated with a comma
-                          </div>
-                        </EuiFormHelpText>
-                      </div>
-                    </div>
-                  </EuiFormRow>
-                  <EuiSpacer
-                    size="xl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
-                  <EuiTitle>
-                    <EuiText
-                      className="euiTitle euiTitle--medium"
-                    >
-                      <div
-                        className="euiText euiText--medium euiTitle euiTitle--medium"
-                      >
-                        <h2>
-                          Details
-                        </h2>
-                      </div>
-                    </EuiText>
-                  </EuiTitle>
-                  <EuiSpacer>
-                    <div
-                      className="euiSpacer euiSpacer--l"
-                    />
-                  </EuiSpacer>
-                  <EuiFlexGroup
-                    alignItems="flexStart"
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem
-                        style={
-                          Object {
-                            "maxWidth": 400,
-                          }
-                        }
-                      >
-                        <div
-                          className="euiFlexItem"
-                          style={
-                            Object {
-                              "maxWidth": 400,
-                            }
-                          }
-                        >
-                          <EuiFormRow
-                            describedByIds={Array []}
-                            display="row"
-                            fullWidth={false}
-                            hasChildLabel={true}
-                            hasEmptyLabelSpace={false}
-                            label={
-                              <EuiText
-                                size="s"
-                              >
-                                <strong>
-                                  Log type
-                                </strong>
-                              </EuiText>
-                            }
-                            labelType="label"
-                          >
-                            <div
-                              className="euiFormRow"
-                              id="some_html_id-row"
-                            >
-                              <div
-                                className="euiFormRow__labelWrapper"
-                              >
-                                <EuiFormLabel
-                                  className="euiFormRow__label"
-                                  htmlFor="some_html_id"
-                                  isFocused={false}
-                                  type="label"
-                                >
-                                  <label
-                                    className="euiFormLabel euiFormRow__label"
-                                    htmlFor="some_html_id"
-                                  >
-                                    <EuiText
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        <strong>
-                                          Log type
-                                        </strong>
-                                      </div>
-                                    </EuiText>
-                                  </label>
-                                </EuiFormLabel>
-                              </div>
-                              <div
-                                className="euiFormRow__fieldWrapper"
-                              >
-                                <EuiComboBox
-                                  async={false}
-                                  compressed={false}
-                                  data-test-subj="rule_type_dropdown"
-                                  fullWidth={false}
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="yaml"
+                                  disabled={false}
                                   id="some_html_id"
-                                  isClearable={true}
-                                  onBlur={[Function]}
+                                  name="some_html_id"
                                   onChange={[Function]}
-                                  onFocus={[Function]}
-                                  options={Array []}
-                                  placeholder="Select a log type"
-                                  selectedOptions={Array []}
-                                  singleSelection={
-                                    Object {
-                                      "asPlainText": true,
-                                    }
-                                  }
-                                  sortMatchesBy="none"
-                                >
-                                  <div
-                                    aria-expanded={false}
-                                    aria-haspopup="listbox"
-                                    className="euiComboBox"
-                                    data-test-subj="rule_type_dropdown"
-                                    onKeyDown={[Function]}
-                                    role="combobox"
-                                  >
-                                    <EuiComboBoxInput
-                                      autoSizeInputRef={[Function]}
-                                      compressed={false}
-                                      fullWidth={false}
-                                      hasSelectedOptions={false}
-                                      id="some_html_id"
-                                      inputRef={[Function]}
-                                      isListOpen={false}
-                                      noIcon={false}
-                                      onChange={[Function]}
-                                      onClear={[Function]}
-                                      onClick={[Function]}
-                                      onCloseListClick={[Function]}
-                                      onFocus={[Function]}
-                                      onOpenListClick={[Function]}
-                                      onRemoveOption={[Function]}
-                                      placeholder="Select a log type"
-                                      rootId={[Function]}
-                                      searchValue=""
-                                      selectedOptions={Array []}
-                                      singleSelection={
-                                        Object {
-                                          "asPlainText": true,
-                                        }
-                                      }
-                                      toggleButtonRef={[Function]}
-                                      updatePosition={[Function]}
-                                      value=""
-                                    >
-                                      <EuiFormControlLayout
-                                        compressed={false}
-                                        fullWidth={false}
-                                        icon={
-                                          Object {
-                                            "aria-label": "Open list of options",
-                                            "data-test-subj": "comboBoxToggleListButton",
-                                            "disabled": undefined,
-                                            "onClick": [Function],
-                                            "ref": [Function],
-                                            "side": "right",
-                                            "type": "arrowDown",
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          className="euiFormControlLayout"
-                                        >
-                                          <div
-                                            className="euiFormControlLayout__childrenWrapper"
-                                          >
-                                            <div
-                                              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                              data-test-subj="comboBoxInput"
-                                              onClick={[Function]}
-                                              tabIndex={-1}
-                                            >
-                                              <p
-                                                className="euiComboBoxPlaceholder"
-                                              >
-                                                Select a log type
-                                              </p>
-                                              <AutosizeInput
-                                                aria-controls=""
-                                                className="euiComboBox__input"
-                                                data-test-subj="comboBoxSearchInput"
-                                                id="some_html_id"
-                                                injectStyles={true}
-                                                inputRef={[Function]}
-                                                minWidth={1}
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                onFocus={[Function]}
-                                                role="textbox"
-                                                style={
-                                                  Object {
-                                                    "fontSize": 14,
-                                                  }
-                                                }
-                                                value=""
-                                              >
-                                                <div
-                                                  className="euiComboBox__input"
-                                                  style={
-                                                    Object {
-                                                      "display": "inline-block",
-                                                      "fontSize": 14,
-                                                    }
-                                                  }
-                                                >
-                                                  <input
-                                                    aria-controls=""
-                                                    data-test-subj="comboBoxSearchInput"
-                                                    id="some_html_id"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    onFocus={[Function]}
-                                                    role="textbox"
-                                                    style={
-                                                      Object {
-                                                        "boxSizing": "content-box",
-                                                        "width": "2px",
-                                                      }
-                                                    }
-                                                    value=""
-                                                  />
-                                                  <div
-                                                    style={
-                                                      Object {
-                                                        "height": 0,
-                                                        "left": 0,
-                                                        "overflow": "scroll",
-                                                        "position": "absolute",
-                                                        "top": 0,
-                                                        "visibility": "hidden",
-                                                        "whiteSpace": "pre",
-                                                      }
-                                                    }
-                                                  />
-                                                </div>
-                                              </AutosizeInput>
-                                            </div>
-                                            <EuiFormControlLayoutIcons
-                                              compressed={false}
-                                              icon={
-                                                Object {
-                                                  "aria-label": "Open list of options",
-                                                  "data-test-subj": "comboBoxToggleListButton",
-                                                  "disabled": undefined,
-                                                  "onClick": [Function],
-                                                  "ref": [Function],
-                                                  "side": "right",
-                                                  "type": "arrowDown",
-                                                }
-                                              }
-                                            >
-                                              <div
-                                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                              >
-                                                <EuiFormControlLayoutCustomIcon
-                                                  aria-label="Open list of options"
-                                                  data-test-subj="comboBoxToggleListButton"
-                                                  iconRef={[Function]}
-                                                  onClick={[Function]}
-                                                  size="m"
-                                                  type="arrowDown"
-                                                >
-                                                  <button
-                                                    aria-label="Open list of options"
-                                                    className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                                    data-test-subj="comboBoxToggleListButton"
-                                                    onClick={[Function]}
-                                                    type="button"
-                                                  >
-                                                    <EuiIcon
-                                                      aria-hidden="true"
-                                                      className="euiFormControlLayoutCustomIcon__icon"
-                                                      size="m"
-                                                      type="arrowDown"
-                                                    >
-                                                      EuiIconMock
-                                                    </EuiIcon>
-                                                  </button>
-                                                </EuiFormControlLayoutCustomIcon>
-                                              </div>
-                                            </EuiFormControlLayoutIcons>
-                                          </div>
-                                        </div>
-                                      </EuiFormControlLayout>
-                                    </EuiComboBoxInput>
-                                  </div>
-                                </EuiComboBox>
-                              </div>
-                            </div>
-                          </EuiFormRow>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                        style={
-                          Object {
-                            "marginTop": 36,
-                          }
-                        }
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                          style={
-                            Object {
-                              "marginTop": 36,
-                            }
-                          }
-                        >
-                          <EuiButton
-                            href="opensearch_security_analytics_dashboards#/log-types"
-                            target="_blank"
-                          >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
-                              element="a"
-                              href="opensearch_security_analytics_dashboards#/log-types"
-                              isDisabled={false}
-                              rel="noopener noreferrer"
-                              target="_blank"
-                            >
-                              <a
-                                className="euiButton euiButton--primary"
-                                disabled={false}
-                                href="opensearch_security_analytics_dashboards#/log-types"
-                                rel="noopener noreferrer"
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                  }
-                                }
-                                target="_blank"
-                              >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="left"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButton__text",
-                                    }
-                                  }
-                                >
-                                  <span
-                                    className="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      className="euiButton__text"
-                                    >
-                                      Manage 
-                                      <EuiIcon
-                                        type="popout"
-                                      >
-                                        EuiIconMock
-                                      </EuiIcon>
-                                    </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </a>
-                            </EuiButtonDisplay>
-                          </EuiButton>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                  <EuiSpacer>
-                    <div
-                      className="euiSpacer euiSpacer--l"
-                    />
-                  </EuiSpacer>
-                  <EuiFormRow
-                    describedByIds={Array []}
-                    display="row"
-                    fullWidth={false}
-                    hasChildLabel={true}
-                    hasEmptyLabelSpace={false}
-                    label={
-                      <EuiText
-                        size="s"
-                      >
-                        <strong>
-                          Rule level (severity)
-                        </strong>
-                      </EuiText>
-                    }
-                    labelType="label"
+                                  type="radio"
+                                />
+                                YAML Editor
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                  </div>
+                </fieldset>
+              </EuiButtonGroup>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <FormSubmissionErrorToastNotification
+                notifications={
+                  Object {
+                    "toasts": Object {
+                      "addDanger": [MockFunction],
+                      "addInfo": [MockFunction],
+                      "addSuccess": [MockFunction],
+                      "addWarning": [MockFunction],
+                    },
+                  }
+                }
+              />
+              <EuiTitle>
+                <EuiText
+                  className="euiTitle euiTitle--medium"
+                >
+                  <div
+                    className="euiText euiText--medium euiTitle euiTitle--medium"
                   >
-                    <div
-                      className="euiFormRow"
-                      id="some_html_id-row"
-                    >
-                      <div
-                        className="euiFormRow__labelWrapper"
-                      >
-                        <EuiFormLabel
-                          className="euiFormRow__label"
-                          htmlFor="some_html_id"
-                          isFocused={false}
-                          type="label"
-                        >
-                          <label
-                            className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
-                          >
-                            <EuiText
-                              size="s"
-                            >
-                              <div
-                                className="euiText euiText--small"
-                              >
-                                <strong>
-                                  Rule level (severity)
-                                </strong>
-                              </div>
-                            </EuiText>
-                          </label>
-                        </EuiFormLabel>
-                      </div>
-                      <div
-                        className="euiFormRow__fieldWrapper"
-                      >
-                        <EuiComboBox
-                          async={false}
-                          compressed={false}
-                          data-test-subj="rule_severity_dropdown"
-                          fullWidth={false}
-                          id="some_html_id"
-                          isClearable={true}
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          options={
-                            Array [
-                              Object {
-                                "label": "Critical",
-                                "value": "critical",
-                              },
-                              Object {
-                                "label": "High",
-                                "value": "high",
-                              },
-                              Object {
-                                "label": "Medium",
-                                "value": "medium",
-                              },
-                              Object {
-                                "label": "Low",
-                                "value": "low",
-                              },
-                              Object {
-                                "label": "Informational",
-                                "value": "informational",
-                              },
-                            ]
-                          }
-                          placeholder="Select a rule level"
-                          selectedOptions={Array []}
-                          singleSelection={
-                            Object {
-                              "asPlainText": true,
-                            }
-                          }
-                          sortMatchesBy="none"
-                        >
-                          <div
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
-                            className="euiComboBox"
-                            data-test-subj="rule_severity_dropdown"
-                            onKeyDown={[Function]}
-                            role="combobox"
-                          >
-                            <EuiComboBoxInput
-                              autoSizeInputRef={[Function]}
-                              compressed={false}
-                              fullWidth={false}
-                              hasSelectedOptions={false}
-                              id="some_html_id"
-                              inputRef={[Function]}
-                              isListOpen={false}
-                              noIcon={false}
-                              onChange={[Function]}
-                              onClear={[Function]}
-                              onClick={[Function]}
-                              onCloseListClick={[Function]}
-                              onFocus={[Function]}
-                              onOpenListClick={[Function]}
-                              onRemoveOption={[Function]}
-                              placeholder="Select a rule level"
-                              rootId={[Function]}
-                              searchValue=""
-                              selectedOptions={Array []}
-                              singleSelection={
-                                Object {
-                                  "asPlainText": true,
-                                }
-                              }
-                              toggleButtonRef={[Function]}
-                              updatePosition={[Function]}
-                              value=""
-                            >
-                              <EuiFormControlLayout
-                                compressed={false}
-                                fullWidth={false}
-                                icon={
-                                  Object {
-                                    "aria-label": "Open list of options",
-                                    "data-test-subj": "comboBoxToggleListButton",
-                                    "disabled": undefined,
-                                    "onClick": [Function],
-                                    "ref": [Function],
-                                    "side": "right",
-                                    "type": "arrowDown",
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiFormControlLayout"
-                                >
-                                  <div
-                                    className="euiFormControlLayout__childrenWrapper"
-                                  >
-                                    <div
-                                      className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                      data-test-subj="comboBoxInput"
-                                      onClick={[Function]}
-                                      tabIndex={-1}
-                                    >
-                                      <p
-                                        className="euiComboBoxPlaceholder"
-                                      >
-                                        Select a rule level
-                                      </p>
-                                      <AutosizeInput
-                                        aria-controls=""
-                                        className="euiComboBox__input"
-                                        data-test-subj="comboBoxSearchInput"
-                                        id="some_html_id"
-                                        injectStyles={true}
-                                        inputRef={[Function]}
-                                        minWidth={1}
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        role="textbox"
-                                        style={
-                                          Object {
-                                            "fontSize": 14,
-                                          }
-                                        }
-                                        value=""
-                                      >
-                                        <div
-                                          className="euiComboBox__input"
-                                          style={
-                                            Object {
-                                              "display": "inline-block",
-                                              "fontSize": 14,
-                                            }
-                                          }
-                                        >
-                                          <input
-                                            aria-controls=""
-                                            data-test-subj="comboBoxSearchInput"
-                                            id="some_html_id"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            role="textbox"
-                                            style={
-                                              Object {
-                                                "boxSizing": "content-box",
-                                                "width": "2px",
-                                              }
-                                            }
-                                            value=""
-                                          />
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": 0,
-                                                "left": 0,
-                                                "overflow": "scroll",
-                                                "position": "absolute",
-                                                "top": 0,
-                                                "visibility": "hidden",
-                                                "whiteSpace": "pre",
-                                              }
-                                            }
-                                          />
-                                        </div>
-                                      </AutosizeInput>
-                                    </div>
-                                    <EuiFormControlLayoutIcons
-                                      compressed={false}
-                                      icon={
-                                        Object {
-                                          "aria-label": "Open list of options",
-                                          "data-test-subj": "comboBoxToggleListButton",
-                                          "disabled": undefined,
-                                          "onClick": [Function],
-                                          "ref": [Function],
-                                          "side": "right",
-                                          "type": "arrowDown",
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                      >
-                                        <EuiFormControlLayoutCustomIcon
-                                          aria-label="Open list of options"
-                                          data-test-subj="comboBoxToggleListButton"
-                                          iconRef={[Function]}
-                                          onClick={[Function]}
-                                          size="m"
-                                          type="arrowDown"
-                                        >
-                                          <button
-                                            aria-label="Open list of options"
-                                            className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                            data-test-subj="comboBoxToggleListButton"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiIcon
-                                              aria-hidden="true"
-                                              className="euiFormControlLayoutCustomIcon__icon"
-                                              size="m"
-                                              type="arrowDown"
-                                            >
-                                              EuiIconMock
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiFormControlLayoutCustomIcon>
-                                      </div>
-                                    </EuiFormControlLayoutIcons>
-                                  </div>
-                                </div>
-                              </EuiFormControlLayout>
-                            </EuiComboBoxInput>
-                          </div>
-                        </EuiComboBox>
-                      </div>
-                    </div>
-                  </EuiFormRow>
-                  <EuiSpacer>
-                    <div
-                      className="euiSpacer euiSpacer--l"
-                    />
-                  </EuiSpacer>
-                  <EuiFormRow
-                    describedByIds={Array []}
-                    display="row"
-                    fullWidth={false}
-                    hasChildLabel={true}
-                    hasEmptyLabelSpace={false}
-                    label={
-                      <EuiText
-                        size="s"
-                      >
-                        <strong>
-                          Rule Status
-                        </strong>
-                      </EuiText>
-                    }
-                    labelType="label"
-                  >
-                    <div
-                      className="euiFormRow"
-                      id="some_html_id-row"
-                    >
-                      <div
-                        className="euiFormRow__labelWrapper"
-                      >
-                        <EuiFormLabel
-                          className="euiFormRow__label"
-                          htmlFor="some_html_id"
-                          isFocused={false}
-                          type="label"
-                        >
-                          <label
-                            className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
-                          >
-                            <EuiText
-                              size="s"
-                            >
-                              <div
-                                className="euiText euiText--small"
-                              >
-                                <strong>
-                                  Rule Status
-                                </strong>
-                              </div>
-                            </EuiText>
-                          </label>
-                        </EuiFormLabel>
-                      </div>
-                      <div
-                        className="euiFormRow__fieldWrapper"
-                      >
-                        <EuiComboBox
-                          async={false}
-                          compressed={false}
-                          data-test-subj="rule_status_dropdown"
-                          fullWidth={false}
-                          id="some_html_id"
-                          isClearable={true}
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          options={
-                            Array [
-                              Object {
-                                "label": "experimental",
-                                "value": "experimental",
-                              },
-                              Object {
-                                "label": "test",
-                                "value": "test",
-                              },
-                              Object {
-                                "label": "stable",
-                                "value": "stable",
-                              },
-                            ]
-                          }
-                          placeholder="Select a rule status"
-                          selectedOptions={
-                            Array [
-                              Object {
-                                "label": "experimental",
-                                "value": "experimental",
-                              },
-                            ]
-                          }
-                          singleSelection={
-                            Object {
-                              "asPlainText": true,
-                            }
-                          }
-                          sortMatchesBy="none"
-                        >
-                          <div
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
-                            className="euiComboBox"
-                            data-test-subj="rule_status_dropdown"
-                            onKeyDown={[Function]}
-                            role="combobox"
-                          >
-                            <EuiComboBoxInput
-                              autoSizeInputRef={[Function]}
-                              compressed={false}
-                              fullWidth={false}
-                              hasSelectedOptions={true}
-                              id="some_html_id"
-                              inputRef={[Function]}
-                              isListOpen={false}
-                              noIcon={false}
-                              onChange={[Function]}
-                              onClear={[Function]}
-                              onClick={[Function]}
-                              onCloseListClick={[Function]}
-                              onFocus={[Function]}
-                              onOpenListClick={[Function]}
-                              onRemoveOption={[Function]}
-                              placeholder="Select a rule status"
-                              rootId={[Function]}
-                              searchValue=""
-                              selectedOptions={
-                                Array [
-                                  Object {
-                                    "label": "experimental",
-                                    "value": "experimental",
-                                  },
-                                ]
-                              }
-                              singleSelection={
-                                Object {
-                                  "asPlainText": true,
-                                }
-                              }
-                              toggleButtonRef={[Function]}
-                              updatePosition={[Function]}
-                              value="experimental"
-                            >
-                              <EuiFormControlLayout
-                                clear={
-                                  Object {
-                                    "data-test-subj": "comboBoxClearButton",
-                                    "onClick": [Function],
-                                  }
-                                }
-                                compressed={false}
-                                fullWidth={false}
-                                icon={
-                                  Object {
-                                    "aria-label": "Open list of options",
-                                    "data-test-subj": "comboBoxToggleListButton",
-                                    "disabled": undefined,
-                                    "onClick": [Function],
-                                    "ref": [Function],
-                                    "side": "right",
-                                    "type": "arrowDown",
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiFormControlLayout"
-                                >
-                                  <div
-                                    className="euiFormControlLayout__childrenWrapper"
-                                  >
-                                    <div
-                                      className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                      data-test-subj="comboBoxInput"
-                                      onClick={[Function]}
-                                      tabIndex={-1}
-                                    >
-                                      <EuiComboBoxPill
-                                        asPlainText={true}
-                                        color="hollow"
-                                        key="experimental"
-                                        option={
-                                          Object {
-                                            "label": "experimental",
-                                            "value": "experimental",
-                                          }
-                                        }
-                                        value="experimental"
-                                      >
-                                        <span
-                                          className="euiComboBoxPill euiComboBoxPill--plainText"
-                                          value="experimental"
-                                        >
-                                          experimental
-                                        </span>
-                                      </EuiComboBoxPill>
-                                      <AutosizeInput
-                                        aria-controls=""
-                                        className="euiComboBox__input"
-                                        data-test-subj="comboBoxSearchInput"
-                                        id="some_html_id"
-                                        injectStyles={true}
-                                        inputRef={[Function]}
-                                        minWidth={1}
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        role="textbox"
-                                        style={
-                                          Object {
-                                            "fontSize": 14,
-                                          }
-                                        }
-                                        value=""
-                                      >
-                                        <div
-                                          className="euiComboBox__input"
-                                          style={
-                                            Object {
-                                              "display": "inline-block",
-                                              "fontSize": 14,
-                                            }
-                                          }
-                                        >
-                                          <input
-                                            aria-controls=""
-                                            data-test-subj="comboBoxSearchInput"
-                                            id="some_html_id"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            role="textbox"
-                                            style={
-                                              Object {
-                                                "boxSizing": "content-box",
-                                                "width": "2px",
-                                              }
-                                            }
-                                            value=""
-                                          />
-                                          <div
-                                            style={
-                                              Object {
-                                                "height": 0,
-                                                "left": 0,
-                                                "overflow": "scroll",
-                                                "position": "absolute",
-                                                "top": 0,
-                                                "visibility": "hidden",
-                                                "whiteSpace": "pre",
-                                              }
-                                            }
-                                          />
-                                        </div>
-                                      </AutosizeInput>
-                                    </div>
-                                    <EuiFormControlLayoutIcons
-                                      clear={
-                                        Object {
-                                          "data-test-subj": "comboBoxClearButton",
-                                          "onClick": [Function],
-                                        }
-                                      }
-                                      compressed={false}
-                                      icon={
-                                        Object {
-                                          "aria-label": "Open list of options",
-                                          "data-test-subj": "comboBoxToggleListButton",
-                                          "disabled": undefined,
-                                          "onClick": [Function],
-                                          "ref": [Function],
-                                          "side": "right",
-                                          "type": "arrowDown",
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                      >
-                                        <EuiFormControlLayoutClearButton
-                                          data-test-subj="comboBoxClearButton"
-                                          onClick={[Function]}
-                                          size="m"
-                                        >
-                                          <EuiI18n
-                                            default="Clear input"
-                                            token="euiFormControlLayoutClearButton.label"
-                                          >
-                                            <button
-                                              aria-label="Clear input"
-                                              className="euiFormControlLayoutClearButton"
-                                              data-test-subj="comboBoxClearButton"
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiIcon
-                                                className="euiFormControlLayoutClearButton__icon"
-                                                type="cross"
-                                              >
-                                                EuiIconMock
-                                              </EuiIcon>
-                                            </button>
-                                          </EuiI18n>
-                                        </EuiFormControlLayoutClearButton>
-                                        <EuiFormControlLayoutCustomIcon
-                                          aria-label="Open list of options"
-                                          data-test-subj="comboBoxToggleListButton"
-                                          iconRef={[Function]}
-                                          onClick={[Function]}
-                                          size="m"
-                                          type="arrowDown"
-                                        >
-                                          <button
-                                            aria-label="Open list of options"
-                                            className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                            data-test-subj="comboBoxToggleListButton"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiIcon
-                                              aria-hidden="true"
-                                              className="euiFormControlLayoutCustomIcon__icon"
-                                              size="m"
-                                              type="arrowDown"
-                                            >
-                                              EuiIconMock
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiFormControlLayoutCustomIcon>
-                                      </div>
-                                    </EuiFormControlLayoutIcons>
-                                  </div>
-                                </div>
-                              </EuiFormControlLayout>
-                            </EuiComboBoxInput>
-                          </div>
-                        </EuiComboBox>
-                      </div>
-                    </div>
-                  </EuiFormRow>
-                  <EuiSpacer
-                    size="xxl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xxl"
-                    />
-                  </EuiSpacer>
-                  <EuiTitle>
-                    <EuiText
-                      className="euiTitle euiTitle--medium"
-                    >
-                      <div
-                        className="euiText euiText--medium euiTitle euiTitle--medium"
-                      >
-                        <h2>
-                          Detection
-                        </h2>
-                      </div>
-                    </EuiText>
-                  </EuiTitle>
+                    <h2>
+                      Rule overview
+                    </h2>
+                  </div>
+                </EuiText>
+              </EuiTitle>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <EuiFormRow
+                describedByIds={Array []}
+                display="row"
+                fullWidth={false}
+                hasChildLabel={true}
+                hasEmptyLabelSpace={false}
+                helpText="Rule name can be max 256 characters."
+                label={
                   <EuiText
                     size="s"
                   >
-                    <div
-                      className="euiText euiText--small"
-                    >
-                      <p>
-                        Define the detection criteria for the rule
-                      </p>
-                    </div>
+                    <strong>
+                      Rule name
+                    </strong>
                   </EuiText>
-                  <EuiSpacer>
-                    <div
-                      className="euiSpacer euiSpacer--l"
-                    />
-                  </EuiSpacer>
-                  <DetectionVisualEditor
-                    detectionYml=""
-                    goToYamlEditor={[Function]}
-                    onChange={[Function]}
-                    setIsDetectionInvalid={[Function]}
+                }
+                labelType="label"
+              >
+                <div
+                  className="euiFormRow"
+                  id="some_html_id-row"
+                >
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
+                    <EuiFormLabel
+                      className="euiFormRow__label"
+                      htmlFor="some_html_id"
+                      isFocused={false}
+                      type="label"
+                    >
+                      <label
+                        className="euiFormLabel euiFormRow__label"
+                        htmlFor="some_html_id"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            <strong>
+                              Rule name
+                            </strong>
+                          </div>
+                        </EuiText>
+                      </label>
+                    </EuiFormLabel>
+                  </div>
+                  <div
+                    className="euiFormRow__fieldWrapper"
+                  >
+                    <EuiFieldText
+                      aria-describedby="some_html_id-help-0"
+                      data-test-subj="rule_name_field"
+                      id="some_html_id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder="My custom rule"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        fullWidth={false}
+                        inputId="some_html_id"
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                className="euiFieldText"
+                                data-test-subj="rule_name_field"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="My custom rule"
+                                type="text"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons />
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldText>
+                    <EuiFormHelpText
+                      className="euiFormRow__text"
+                      id="some_html_id-help-0"
+                      key="Rule name can be max 256 characters."
+                    >
+                      <div
+                        className="euiFormHelpText euiFormRow__text"
+                        id="some_html_id-help-0"
+                      >
+                        Rule name can be max 256 characters.
+                      </div>
+                    </EuiFormHelpText>
+                  </div>
+                </div>
+              </EuiFormRow>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiFormRow
+                describedByIds={Array []}
+                display="row"
+                fullWidth={false}
+                hasChildLabel={true}
+                hasEmptyLabelSpace={false}
+                label={
+                  <EuiText
+                    size="s"
+                  >
+                    <strong>
+                      Description 
+                    </strong>
+                    <i>
+                      - optional
+                    </i>
+                  </EuiText>
+                }
+                labelType="label"
+              >
+                <div
+                  className="euiFormRow"
+                  id="some_html_id-row"
+                >
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
+                    <EuiFormLabel
+                      className="euiFormRow__label"
+                      htmlFor="some_html_id"
+                      isFocused={false}
+                      type="label"
+                    >
+                      <label
+                        className="euiFormLabel euiFormRow__label"
+                        htmlFor="some_html_id"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            <strong>
+                              Description 
+                            </strong>
+                            <i>
+                              - optional
+                            </i>
+                          </div>
+                        </EuiText>
+                      </label>
+                    </EuiFormLabel>
+                  </div>
+                  <div
+                    className="euiFormRow__fieldWrapper"
+                  >
+                    <EuiFieldText
+                      data-test-subj="rule_description_field"
+                      id="some_html_id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder="Detects ..."
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        fullWidth={false}
+                        inputId="some_html_id"
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                className="euiFieldText"
+                                data-test-subj="rule_description_field"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Detects ..."
+                                type="text"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons />
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldText>
+                  </div>
+                </div>
+              </EuiFormRow>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiFormRow
+                describedByIds={Array []}
+                display="row"
+                fullWidth={false}
+                hasChildLabel={true}
+                hasEmptyLabelSpace={false}
+                helpText="Combine multiple authors separated with a comma"
+                label={
+                  <EuiText
+                    size="s"
+                  >
+                    <strong>
+                      Author
+                    </strong>
+                  </EuiText>
+                }
+                labelType="label"
+              >
+                <div
+                  className="euiFormRow"
+                  id="some_html_id-row"
+                >
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
+                    <EuiFormLabel
+                      className="euiFormRow__label"
+                      htmlFor="some_html_id"
+                      isFocused={false}
+                      type="label"
+                    >
+                      <label
+                        className="euiFormLabel euiFormRow__label"
+                        htmlFor="some_html_id"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            <strong>
+                              Author
+                            </strong>
+                          </div>
+                        </EuiText>
+                      </label>
+                    </EuiFormLabel>
+                  </div>
+                  <div
+                    className="euiFormRow__fieldWrapper"
+                  >
+                    <EuiFieldText
+                      aria-describedby="some_html_id-help-0"
+                      data-test-subj="rule_author_field"
+                      id="some_html_id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder="Enter author name"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        fullWidth={false}
+                        inputId="some_html_id"
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                className="euiFieldText"
+                                data-test-subj="rule_author_field"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Enter author name"
+                                type="text"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons />
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldText>
+                    <EuiFormHelpText
+                      className="euiFormRow__text"
+                      id="some_html_id-help-0"
+                      key="Combine multiple authors separated with a comma"
+                    >
+                      <div
+                        className="euiFormHelpText euiFormRow__text"
+                        id="some_html_id-help-0"
+                      >
+                        Combine multiple authors separated with a comma
+                      </div>
+                    </EuiFormHelpText>
+                  </div>
+                </div>
+              </EuiFormRow>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <EuiTitle>
+                <EuiText
+                  className="euiTitle euiTitle--medium"
+                >
+                  <div
+                    className="euiText euiText--medium euiTitle euiTitle--medium"
+                  >
+                    <h2>
+                      Details
+                    </h2>
+                  </div>
+                </EuiText>
+              </EuiTitle>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <EuiFlexGroup
+                alignItems="flexStart"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem
+                    style={
+                      Object {
+                        "maxWidth": 400,
+                      }
+                    }
                   >
                     <div
-                      className="detection-visual-editor"
+                      className="euiFlexItem"
                       style={
                         Object {
-                          "maxWidth": 1000,
+                          "maxWidth": 400,
                         }
                       }
                     >
-                      <div
-                        key="detection-visual-editor-selection-0"
-                      >
-                        <EuiPanel
-                          className="detection-visual-editor-selection"
-                          data-test-subj="detection-visual-editor-0"
-                          key="detection-visual-editor-0"
-                        >
-                          <div
-                            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow detection-visual-editor-selection"
-                            data-test-subj="detection-visual-editor-0"
-                          >
-                            <EuiFlexGroup
-                              alignItems="center"
-                            >
-                              <div
-                                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                              >
-                                <EuiFlexItem
-                                  grow={true}
-                                >
-                                  <div
-                                    className="euiFlexItem"
-                                  >
-                                    <EuiFormRow
-                                      describedByIds={Array []}
-                                      display="row"
-                                      fullWidth={false}
-                                      hasChildLabel={true}
-                                      hasEmptyLabelSpace={false}
-                                      labelType="label"
-                                    >
-                                      <div
-                                        className="euiFormRow"
-                                        id="some_html_id-row"
-                                      >
-                                        <div
-                                          className="euiFormRow__fieldWrapper"
-                                        >
-                                          <EuiFieldText
-                                            className="detection-visual-editor-name euiTitle--small"
-                                            data-test-subj="selection_name"
-                                            id="some_html_id"
-                                            onBlur={[Function]}
-                                            onChange={[Function]}
-                                            onFocus={[Function]}
-                                            placeholder="Enter selection name"
-                                            value="Selection_1"
-                                          >
-                                            <EuiFormControlLayout
-                                              fullWidth={false}
-                                              inputId="some_html_id"
-                                            >
-                                              <div
-                                                className="euiFormControlLayout"
-                                              >
-                                                <div
-                                                  className="euiFormControlLayout__childrenWrapper"
-                                                >
-                                                  <EuiValidatableControl>
-                                                    <input
-                                                      className="euiFieldText detection-visual-editor-name euiTitle--small"
-                                                      data-test-subj="selection_name"
-                                                      id="some_html_id"
-                                                      onBlur={[Function]}
-                                                      onChange={[Function]}
-                                                      onFocus={[Function]}
-                                                      placeholder="Enter selection name"
-                                                      type="text"
-                                                      value="Selection_1"
-                                                    />
-                                                  </EuiValidatableControl>
-                                                  <EuiFormControlLayoutIcons />
-                                                </div>
-                                              </div>
-                                            </EuiFormControlLayout>
-                                          </EuiFieldText>
-                                        </div>
-                                      </div>
-                                    </EuiFormRow>
-                                    <EuiText
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        <p>
-                                          Define the search identifier in your data the rule will be applied to.
-                                        </p>
-                                      </div>
-                                    </EuiText>
-                                  </div>
-                                </EuiFlexItem>
-                                <EuiFlexItem
-                                  className="detection-visual-editor-delete-selection"
-                                  grow={false}
-                                >
-                                  <div
-                                    className="euiFlexItem euiFlexItem--flexGrowZero detection-visual-editor-delete-selection"
-                                  />
-                                </EuiFlexItem>
-                              </div>
-                            </EuiFlexGroup>
-                            <EuiSpacer>
-                              <div
-                                className="euiSpacer euiSpacer--l"
-                              />
-                            </EuiSpacer>
-                            <div
-                              className="detection-visual-editor-accordion-wrapper"
-                              key="Map-0"
-                            >
-                              <EuiAccordion
-                                arrowDisplay="left"
-                                buttonClassName="euiAccordionForm__button"
-                                buttonContent={
-                                  <EuiText
-                                    size="m"
-                                  >
-                                    Map 
-                                    1
-                                  </EuiText>
-                                }
-                                className="euiAccordionForm detection-visual-editor-accordion"
-                                data-test-subj="Map-0"
-                                extraAction={null}
-                                id="Map-0"
-                                initialIsOpen={true}
-                                isLoading={false}
-                                isLoadingMessage={false}
-                                key="Map-0"
-                                paddingSize="none"
-                                style={
-                                  Object {
-                                    "maxWidth": "70%",
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiAccordion euiAccordion-isOpen euiAccordionForm detection-visual-editor-accordion"
-                                  data-test-subj="Map-0"
-                                  style={
-                                    Object {
-                                      "maxWidth": "70%",
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiAccordion__triggerWrapper"
-                                  >
-                                    <button
-                                      aria-controls="Map-0"
-                                      aria-expanded={true}
-                                      className="euiAccordion__button euiAccordionForm__button"
-                                      id="some_html_id"
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <span
-                                        className="euiAccordion__iconWrapper"
-                                      >
-                                        <EuiIcon
-                                          className="euiAccordion__icon euiAccordion__icon-isOpen"
-                                          size="m"
-                                          type="arrowRight"
-                                        >
-                                          EuiIconMock
-                                        </EuiIcon>
-                                      </span>
-                                      <span
-                                        className="euiIEFlexWrapFix"
-                                      >
-                                        <EuiText
-                                          size="m"
-                                        >
-                                          <div
-                                            className="euiText euiText--medium"
-                                          >
-                                            Map 
-                                            1
-                                          </div>
-                                        </EuiText>
-                                      </span>
-                                    </button>
-                                  </div>
-                                  <div
-                                    aria-labelledby="some_html_id"
-                                    className="euiAccordion__childWrapper"
-                                    id="Map-0"
-                                    role="region"
-                                    tabIndex={-1}
-                                  >
-                                    <EuiResizeObserver
-                                      onResize={[Function]}
-                                    >
-                                      <div>
-                                        <div
-                                          className=""
-                                        >
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                          <EuiFlexGroup>
-                                            <div
-                                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                            >
-                                              <EuiFlexItem
-                                                grow={false}
-                                                style={
-                                                  Object {
-                                                    "minWidth": 200,
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                                                  style={
-                                                    Object {
-                                                      "minWidth": 200,
-                                                    }
-                                                  }
-                                                >
-                                                  <EuiFormRow
-                                                    describedByIds={Array []}
-                                                    display="row"
-                                                    fullWidth={false}
-                                                    hasChildLabel={true}
-                                                    hasEmptyLabelSpace={false}
-                                                    label={
-                                                      <EuiText
-                                                        size="s"
-                                                      >
-                                                        Key
-                                                      </EuiText>
-                                                    }
-                                                    labelType="label"
-                                                  >
-                                                    <div
-                                                      className="euiFormRow"
-                                                      id="some_html_id-row"
-                                                    >
-                                                      <div
-                                                        className="euiFormRow__labelWrapper"
-                                                      >
-                                                        <EuiFormLabel
-                                                          className="euiFormRow__label"
-                                                          htmlFor="some_html_id"
-                                                          isFocused={false}
-                                                          type="label"
-                                                        >
-                                                          <label
-                                                            className="euiFormLabel euiFormRow__label"
-                                                            htmlFor="some_html_id"
-                                                          >
-                                                            <EuiText
-                                                              size="s"
-                                                            >
-                                                              <div
-                                                                className="euiText euiText--small"
-                                                              >
-                                                                Key
-                                                              </div>
-                                                            </EuiText>
-                                                          </label>
-                                                        </EuiFormLabel>
-                                                      </div>
-                                                      <div
-                                                        className="euiFormRow__fieldWrapper"
-                                                      >
-                                                        <EuiFieldText
-                                                          data-test-subj="selection_field_key_name"
-                                                          id="some_html_id"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          onFocus={[Function]}
-                                                          placeholder="Enter key name"
-                                                          value=""
-                                                        >
-                                                          <EuiFormControlLayout
-                                                            fullWidth={false}
-                                                            inputId="some_html_id"
-                                                          >
-                                                            <div
-                                                              className="euiFormControlLayout"
-                                                            >
-                                                              <div
-                                                                className="euiFormControlLayout__childrenWrapper"
-                                                              >
-                                                                <EuiValidatableControl>
-                                                                  <input
-                                                                    className="euiFieldText"
-                                                                    data-test-subj="selection_field_key_name"
-                                                                    id="some_html_id"
-                                                                    onBlur={[Function]}
-                                                                    onChange={[Function]}
-                                                                    onFocus={[Function]}
-                                                                    placeholder="Enter key name"
-                                                                    type="text"
-                                                                    value=""
-                                                                  />
-                                                                </EuiValidatableControl>
-                                                                <EuiFormControlLayoutIcons />
-                                                              </div>
-                                                            </div>
-                                                          </EuiFormControlLayout>
-                                                        </EuiFieldText>
-                                                      </div>
-                                                    </div>
-                                                  </EuiFormRow>
-                                                </div>
-                                              </EuiFlexItem>
-                                              <EuiFlexItem
-                                                grow={false}
-                                                style={
-                                                  Object {
-                                                    "minWidth": 200,
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                                                  style={
-                                                    Object {
-                                                      "minWidth": 200,
-                                                    }
-                                                  }
-                                                >
-                                                  <EuiFormRow
-                                                    describedByIds={Array []}
-                                                    display="row"
-                                                    fullWidth={false}
-                                                    hasChildLabel={true}
-                                                    hasEmptyLabelSpace={false}
-                                                    label={
-                                                      <EuiText
-                                                        size="s"
-                                                      >
-                                                        Modifier
-                                                      </EuiText>
-                                                    }
-                                                    labelType="label"
-                                                  >
-                                                    <div
-                                                      className="euiFormRow"
-                                                      id="some_html_id-row"
-                                                    >
-                                                      <div
-                                                        className="euiFormRow__labelWrapper"
-                                                      >
-                                                        <EuiFormLabel
-                                                          className="euiFormRow__label"
-                                                          htmlFor="some_html_id"
-                                                          isFocused={false}
-                                                          type="label"
-                                                        >
-                                                          <label
-                                                            className="euiFormLabel euiFormRow__label"
-                                                            htmlFor="some_html_id"
-                                                          >
-                                                            <EuiText
-                                                              size="s"
-                                                            >
-                                                              <div
-                                                                className="euiText euiText--small"
-                                                              >
-                                                                Modifier
-                                                              </div>
-                                                            </EuiText>
-                                                          </label>
-                                                        </EuiFormLabel>
-                                                      </div>
-                                                      <div
-                                                        className="euiFormRow__fieldWrapper"
-                                                      >
-                                                        <EuiComboBox
-                                                          async={false}
-                                                          compressed={false}
-                                                          data-test-subj="modifier_dropdown"
-                                                          fullWidth={false}
-                                                          id="some_html_id"
-                                                          isClearable={true}
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          onFocus={[Function]}
-                                                          options={
-                                                            Array [
-                                                              Object {
-                                                                "label": "all",
-                                                                "value": "all",
-                                                              },
-                                                              Object {
-                                                                "label": "contains",
-                                                                "value": "contains",
-                                                              },
-                                                              Object {
-                                                                "label": "base64",
-                                                                "value": "base64",
-                                                              },
-                                                              Object {
-                                                                "label": "endswith",
-                                                                "value": "endswith",
-                                                              },
-                                                              Object {
-                                                                "label": "startswith",
-                                                                "value": "startswith",
-                                                              },
-                                                              Object {
-                                                                "label": "cidr",
-                                                                "value": "cidr",
-                                                              },
-                                                            ]
-                                                          }
-                                                          selectedOptions={
-                                                            Array [
-                                                              Object {
-                                                                "label": "all",
-                                                                "value": "all",
-                                                              },
-                                                            ]
-                                                          }
-                                                          singleSelection={
-                                                            Object {
-                                                              "asPlainText": true,
-                                                            }
-                                                          }
-                                                          sortMatchesBy="none"
-                                                        >
-                                                          <div
-                                                            aria-expanded={false}
-                                                            aria-haspopup="listbox"
-                                                            className="euiComboBox"
-                                                            data-test-subj="modifier_dropdown"
-                                                            onKeyDown={[Function]}
-                                                            role="combobox"
-                                                          >
-                                                            <EuiComboBoxInput
-                                                              autoSizeInputRef={[Function]}
-                                                              compressed={false}
-                                                              fullWidth={false}
-                                                              hasSelectedOptions={true}
-                                                              id="some_html_id"
-                                                              inputRef={[Function]}
-                                                              isListOpen={false}
-                                                              noIcon={false}
-                                                              onChange={[Function]}
-                                                              onClear={[Function]}
-                                                              onClick={[Function]}
-                                                              onCloseListClick={[Function]}
-                                                              onFocus={[Function]}
-                                                              onOpenListClick={[Function]}
-                                                              onRemoveOption={[Function]}
-                                                              rootId={[Function]}
-                                                              searchValue=""
-                                                              selectedOptions={
-                                                                Array [
-                                                                  Object {
-                                                                    "label": "all",
-                                                                    "value": "all",
-                                                                  },
-                                                                ]
-                                                              }
-                                                              singleSelection={
-                                                                Object {
-                                                                  "asPlainText": true,
-                                                                }
-                                                              }
-                                                              toggleButtonRef={[Function]}
-                                                              updatePosition={[Function]}
-                                                              value="all"
-                                                            >
-                                                              <EuiFormControlLayout
-                                                                clear={
-                                                                  Object {
-                                                                    "data-test-subj": "comboBoxClearButton",
-                                                                    "onClick": [Function],
-                                                                  }
-                                                                }
-                                                                compressed={false}
-                                                                fullWidth={false}
-                                                                icon={
-                                                                  Object {
-                                                                    "aria-label": "Open list of options",
-                                                                    "data-test-subj": "comboBoxToggleListButton",
-                                                                    "disabled": undefined,
-                                                                    "onClick": [Function],
-                                                                    "ref": [Function],
-                                                                    "side": "right",
-                                                                    "type": "arrowDown",
-                                                                  }
-                                                                }
-                                                              >
-                                                                <div
-                                                                  className="euiFormControlLayout"
-                                                                >
-                                                                  <div
-                                                                    className="euiFormControlLayout__childrenWrapper"
-                                                                  >
-                                                                    <div
-                                                                      className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                                                      data-test-subj="comboBoxInput"
-                                                                      onClick={[Function]}
-                                                                      tabIndex={-1}
-                                                                    >
-                                                                      <EuiComboBoxPill
-                                                                        asPlainText={true}
-                                                                        color="hollow"
-                                                                        key="all"
-                                                                        option={
-                                                                          Object {
-                                                                            "label": "all",
-                                                                            "value": "all",
-                                                                          }
-                                                                        }
-                                                                        value="all"
-                                                                      >
-                                                                        <span
-                                                                          className="euiComboBoxPill euiComboBoxPill--plainText"
-                                                                          value="all"
-                                                                        >
-                                                                          all
-                                                                        </span>
-                                                                      </EuiComboBoxPill>
-                                                                      <AutosizeInput
-                                                                        aria-controls=""
-                                                                        className="euiComboBox__input"
-                                                                        data-test-subj="comboBoxSearchInput"
-                                                                        id="some_html_id"
-                                                                        injectStyles={true}
-                                                                        inputRef={[Function]}
-                                                                        minWidth={1}
-                                                                        onBlur={[Function]}
-                                                                        onChange={[Function]}
-                                                                        onFocus={[Function]}
-                                                                        role="textbox"
-                                                                        style={
-                                                                          Object {
-                                                                            "fontSize": 14,
-                                                                          }
-                                                                        }
-                                                                        value=""
-                                                                      >
-                                                                        <div
-                                                                          className="euiComboBox__input"
-                                                                          style={
-                                                                            Object {
-                                                                              "display": "inline-block",
-                                                                              "fontSize": 14,
-                                                                            }
-                                                                          }
-                                                                        >
-                                                                          <input
-                                                                            aria-controls=""
-                                                                            data-test-subj="comboBoxSearchInput"
-                                                                            id="some_html_id"
-                                                                            onBlur={[Function]}
-                                                                            onChange={[Function]}
-                                                                            onFocus={[Function]}
-                                                                            role="textbox"
-                                                                            style={
-                                                                              Object {
-                                                                                "boxSizing": "content-box",
-                                                                                "width": "2px",
-                                                                              }
-                                                                            }
-                                                                            value=""
-                                                                          />
-                                                                          <div
-                                                                            style={
-                                                                              Object {
-                                                                                "height": 0,
-                                                                                "left": 0,
-                                                                                "overflow": "scroll",
-                                                                                "position": "absolute",
-                                                                                "top": 0,
-                                                                                "visibility": "hidden",
-                                                                                "whiteSpace": "pre",
-                                                                              }
-                                                                            }
-                                                                          />
-                                                                        </div>
-                                                                      </AutosizeInput>
-                                                                    </div>
-                                                                    <EuiFormControlLayoutIcons
-                                                                      clear={
-                                                                        Object {
-                                                                          "data-test-subj": "comboBoxClearButton",
-                                                                          "onClick": [Function],
-                                                                        }
-                                                                      }
-                                                                      compressed={false}
-                                                                      icon={
-                                                                        Object {
-                                                                          "aria-label": "Open list of options",
-                                                                          "data-test-subj": "comboBoxToggleListButton",
-                                                                          "disabled": undefined,
-                                                                          "onClick": [Function],
-                                                                          "ref": [Function],
-                                                                          "side": "right",
-                                                                          "type": "arrowDown",
-                                                                        }
-                                                                      }
-                                                                    >
-                                                                      <div
-                                                                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                                                      >
-                                                                        <EuiFormControlLayoutClearButton
-                                                                          data-test-subj="comboBoxClearButton"
-                                                                          onClick={[Function]}
-                                                                          size="m"
-                                                                        >
-                                                                          <EuiI18n
-                                                                            default="Clear input"
-                                                                            token="euiFormControlLayoutClearButton.label"
-                                                                          >
-                                                                            <button
-                                                                              aria-label="Clear input"
-                                                                              className="euiFormControlLayoutClearButton"
-                                                                              data-test-subj="comboBoxClearButton"
-                                                                              onClick={[Function]}
-                                                                              type="button"
-                                                                            >
-                                                                              <EuiIcon
-                                                                                className="euiFormControlLayoutClearButton__icon"
-                                                                                type="cross"
-                                                                              >
-                                                                                EuiIconMock
-                                                                              </EuiIcon>
-                                                                            </button>
-                                                                          </EuiI18n>
-                                                                        </EuiFormControlLayoutClearButton>
-                                                                        <EuiFormControlLayoutCustomIcon
-                                                                          aria-label="Open list of options"
-                                                                          data-test-subj="comboBoxToggleListButton"
-                                                                          iconRef={[Function]}
-                                                                          onClick={[Function]}
-                                                                          size="m"
-                                                                          type="arrowDown"
-                                                                        >
-                                                                          <button
-                                                                            aria-label="Open list of options"
-                                                                            className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                                                            data-test-subj="comboBoxToggleListButton"
-                                                                            onClick={[Function]}
-                                                                            type="button"
-                                                                          >
-                                                                            <EuiIcon
-                                                                              aria-hidden="true"
-                                                                              className="euiFormControlLayoutCustomIcon__icon"
-                                                                              size="m"
-                                                                              type="arrowDown"
-                                                                            >
-                                                                              EuiIconMock
-                                                                            </EuiIcon>
-                                                                          </button>
-                                                                        </EuiFormControlLayoutCustomIcon>
-                                                                      </div>
-                                                                    </EuiFormControlLayoutIcons>
-                                                                  </div>
-                                                                </div>
-                                                              </EuiFormControlLayout>
-                                                            </EuiComboBoxInput>
-                                                          </div>
-                                                        </EuiComboBox>
-                                                      </div>
-                                                    </div>
-                                                  </EuiFormRow>
-                                                </div>
-                                              </EuiFlexItem>
-                                            </div>
-                                          </EuiFlexGroup>
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                          <EuiRadioGroup
-                                            idSelected="selection-map-value-0-0"
-                                            onChange={[Function]}
-                                            options={
-                                              Array [
-                                                Object {
-                                                  "id": "selection-map-value-0-0",
-                                                  "label": "Value",
-                                                },
-                                                Object {
-                                                  "id": "selection-map-list-0-0",
-                                                  "label": "List",
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            <div>
-                                              <EuiRadio
-                                                checked={true}
-                                                className="euiRadioGroup__item"
-                                                id="selection-map-value-0-0"
-                                                key="0"
-                                                label="Value"
-                                                onChange={[Function]}
-                                              >
-                                                <div
-                                                  className="euiRadio euiRadioGroup__item"
-                                                >
-                                                  <input
-                                                    checked={true}
-                                                    className="euiRadio__input"
-                                                    id="selection-map-value-0-0"
-                                                    onChange={[Function]}
-                                                    type="radio"
-                                                  />
-                                                  <div
-                                                    className="euiRadio__circle"
-                                                  />
-                                                  <label
-                                                    className="euiRadio__label"
-                                                    htmlFor="selection-map-value-0-0"
-                                                  >
-                                                    Value
-                                                  </label>
-                                                </div>
-                                              </EuiRadio>
-                                              <EuiRadio
-                                                checked={false}
-                                                className="euiRadioGroup__item"
-                                                id="selection-map-list-0-0"
-                                                key="1"
-                                                label="List"
-                                                onChange={[Function]}
-                                              >
-                                                <div
-                                                  className="euiRadio euiRadioGroup__item"
-                                                >
-                                                  <input
-                                                    checked={false}
-                                                    className="euiRadio__input"
-                                                    id="selection-map-list-0-0"
-                                                    onChange={[Function]}
-                                                    type="radio"
-                                                  />
-                                                  <div
-                                                    className="euiRadio__circle"
-                                                  />
-                                                  <label
-                                                    className="euiRadio__label"
-                                                    htmlFor="selection-map-list-0-0"
-                                                  >
-                                                    List
-                                                  </label>
-                                                </div>
-                                              </EuiRadio>
-                                            </div>
-                                          </EuiRadioGroup>
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                          <EuiFormRow
-                                            describedByIds={Array []}
-                                            display="row"
-                                            fullWidth={false}
-                                            hasChildLabel={true}
-                                            hasEmptyLabelSpace={false}
-                                            labelType="label"
-                                          >
-                                            <div
-                                              className="euiFormRow"
-                                              id="some_html_id-row"
-                                            >
-                                              <div
-                                                className="euiFormRow__fieldWrapper"
-                                              >
-                                                <EuiFieldText
-                                                  data-test-subj="selection_field_value"
-                                                  id="some_html_id"
-                                                  onBlur={[Function]}
-                                                  onChange={[Function]}
-                                                  onFocus={[Function]}
-                                                  placeholder="Value"
-                                                  value=""
-                                                >
-                                                  <EuiFormControlLayout
-                                                    fullWidth={false}
-                                                    inputId="some_html_id"
-                                                  >
-                                                    <div
-                                                      className="euiFormControlLayout"
-                                                    >
-                                                      <div
-                                                        className="euiFormControlLayout__childrenWrapper"
-                                                      >
-                                                        <EuiValidatableControl>
-                                                          <input
-                                                            className="euiFieldText"
-                                                            data-test-subj="selection_field_value"
-                                                            id="some_html_id"
-                                                            onBlur={[Function]}
-                                                            onChange={[Function]}
-                                                            onFocus={[Function]}
-                                                            placeholder="Value"
-                                                            type="text"
-                                                            value=""
-                                                          />
-                                                        </EuiValidatableControl>
-                                                        <EuiFormControlLayoutIcons />
-                                                      </div>
-                                                    </div>
-                                                  </EuiFormControlLayout>
-                                                </EuiFieldText>
-                                              </div>
-                                            </div>
-                                          </EuiFormRow>
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                        </div>
-                                      </div>
-                                    </EuiResizeObserver>
-                                  </div>
-                                </div>
-                              </EuiAccordion>
-                            </div>
-                            <EuiSpacer
-                              size="m"
-                            >
-                              <div
-                                className="euiSpacer euiSpacer--m"
-                              />
-                            </EuiSpacer>
-                            <EuiButton
-                              disabled={true}
-                              iconType="plusInCircle"
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "width": "70%",
-                                }
-                              }
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButton"
-                                disabled={true}
-                                element="button"
-                                iconType="plusInCircle"
-                                isDisabled={true}
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "width": "70%",
-                                  }
-                                }
-                                type="button"
-                              >
-                                <button
-                                  className="euiButton euiButton--primary euiButton-isDisabled"
-                                  disabled={true}
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                      "width": "70%",
-                                    }
-                                  }
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    iconType="plusInCircle"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <EuiIcon
-                                        className="euiButtonContent__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="plusInCircle"
-                                      >
-                                        EuiIconMock
-                                      </EuiIcon>
-                                      <span
-                                        className="euiButton__text"
-                                      >
-                                        Add map
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonDisplay>
-                            </EuiButton>
-                          </div>
-                        </EuiPanel>
-                      </div>
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiButton
-                        fullWidth={true}
-                        iconType="plusInCircle"
-                        onClick={[Function]}
-                      >
-                        <EuiButtonDisplay
-                          baseClassName="euiButton"
-                          disabled={false}
-                          element="button"
-                          fullWidth={true}
-                          iconType="plusInCircle"
-                          isDisabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <button
-                            className="euiButton euiButton--primary euiButton--fullWidth"
-                            disabled={false}
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "minWidth": undefined,
-                              }
-                            }
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButton__content"
-                              iconSide="left"
-                              iconType="plusInCircle"
-                              textProps={
-                                Object {
-                                  "className": "euiButton__text",
-                                }
-                              }
-                            >
-                              <span
-                                className="euiButtonContent euiButton__content"
-                              >
-                                <EuiIcon
-                                  className="euiButtonContent__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="plusInCircle"
-                                >
-                                  EuiIconMock
-                                </EuiIcon>
-                                <span
-                                  className="euiButton__text"
-                                >
-                                  Add selection
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonDisplay>
-                      </EuiButton>
-                      <EuiSpacer>
-                        <div
-                          className="euiSpacer euiSpacer--l"
-                        />
-                      </EuiSpacer>
                       <EuiFormRow
                         describedByIds={Array []}
                         display="row"
@@ -2735,48 +705,19 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                         hasChildLabel={true}
                         hasEmptyLabelSpace={false}
                         label={
-                          <React.Fragment>
-                            <EuiTitle
-                              size="s"
-                            >
-                              <p>
-                                Condition
-                              </p>
-                            </EuiTitle>
-                            <EuiText
-                              size="xs"
-                            >
-                              Define how each selection should be included in the final query. For more options use
-                               
-                              <EuiButtonEmpty
-                                className="empty-text-button"
-                                onClick={[Function]}
-                              >
-                                <EuiText
-                                  size="s"
-                                >
-                                  YAML editor
-                                </EuiText>
-                              </EuiButtonEmpty>
-                              .
-                            </EuiText>
-                          </React.Fragment>
+                          <EuiText
+                            size="s"
+                          >
+                            <strong>
+                              Log type
+                            </strong>
+                          </EuiText>
                         }
                         labelType="label"
-                        style={
-                          Object {
-                            "maxWidth": "100%",
-                          }
-                        }
                       >
                         <div
                           className="euiFormRow"
                           id="some_html_id-row"
-                          style={
-                            Object {
-                              "maxWidth": "100%",
-                            }
-                          }
                         >
                           <div
                             className="euiFormRow__labelWrapper"
@@ -2791,64 +732,15 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                 className="euiFormLabel euiFormRow__label"
                                 htmlFor="some_html_id"
                               >
-                                <EuiTitle
+                                <EuiText
                                   size="s"
                                 >
-                                  <p
-                                    className="euiTitle euiTitle--small"
-                                  >
-                                    Condition
-                                  </p>
-                                </EuiTitle>
-                                <EuiText
-                                  size="xs"
-                                >
                                   <div
-                                    className="euiText euiText--extraSmall"
+                                    className="euiText euiText--small"
                                   >
-                                    Define how each selection should be included in the final query. For more options use
-                                     
-                                    <EuiButtonEmpty
-                                      className="empty-text-button"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="left"
-                                          iconSize="m"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonEmpty__content"
-                                          >
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              <EuiText
-                                                size="s"
-                                              >
-                                                <div
-                                                  className="euiText euiText--small"
-                                                >
-                                                  YAML editor
-                                                </div>
-                                              </EuiText>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                    .
+                                    <strong>
+                                      Log type
+                                    </strong>
                                   </div>
                                 </EuiText>
                               </label>
@@ -2857,268 +749,2344 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                           <div
                             className="euiFormRow__fieldWrapper"
                           >
-                            <EuiCodeEditor
-                              data-test-subj="rule_detection_field"
-                              height="50px"
+                            <EuiComboBox
+                              async={false}
+                              compressed={false}
+                              data-test-subj="rule_type_dropdown"
+                              fullWidth={false}
                               id="some_html_id"
-                              mode="yaml"
+                              isClearable={true}
                               onBlur={[Function]}
                               onChange={[Function]}
                               onFocus={[Function]}
-                              setOptions={Object {}}
-                              value="Selection_1"
-                              width="600px"
+                              options={Array []}
+                              placeholder="Select a log type"
+                              selectedOptions={Array []}
+                              singleSelection={
+                                Object {
+                                  "asPlainText": true,
+                                }
+                              }
+                              sortMatchesBy="none"
                             >
                               <div
-                                className="euiCodeEditorWrapper"
-                                data-test-subj="rule_detection_field"
+                                aria-expanded={false}
+                                aria-haspopup="listbox"
+                                className="euiComboBox"
+                                data-test-subj="rule_type_dropdown"
+                                onKeyDown={[Function]}
+                                role="combobox"
+                              >
+                                <EuiComboBoxInput
+                                  autoSizeInputRef={[Function]}
+                                  compressed={false}
+                                  fullWidth={false}
+                                  hasSelectedOptions={false}
+                                  id="some_html_id"
+                                  inputRef={[Function]}
+                                  isListOpen={false}
+                                  noIcon={false}
+                                  onChange={[Function]}
+                                  onClear={[Function]}
+                                  onClick={[Function]}
+                                  onCloseListClick={[Function]}
+                                  onFocus={[Function]}
+                                  onOpenListClick={[Function]}
+                                  onRemoveOption={[Function]}
+                                  placeholder="Select a log type"
+                                  rootId={[Function]}
+                                  searchValue=""
+                                  selectedOptions={Array []}
+                                  singleSelection={
+                                    Object {
+                                      "asPlainText": true,
+                                    }
+                                  }
+                                  toggleButtonRef={[Function]}
+                                  updatePosition={[Function]}
+                                  value=""
+                                >
+                                  <EuiFormControlLayout
+                                    compressed={false}
+                                    fullWidth={false}
+                                    icon={
+                                      Object {
+                                        "aria-label": "Open list of options",
+                                        "data-test-subj": "comboBoxToggleListButton",
+                                        "disabled": undefined,
+                                        "onClick": [Function],
+                                        "ref": [Function],
+                                        "side": "right",
+                                        "type": "arrowDown",
+                                      }
+                                    }
+                                  >
+                                    <div
+                                      className="euiFormControlLayout"
+                                    >
+                                      <div
+                                        className="euiFormControlLayout__childrenWrapper"
+                                      >
+                                        <div
+                                          className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                          data-test-subj="comboBoxInput"
+                                          onClick={[Function]}
+                                          tabIndex={-1}
+                                        >
+                                          <p
+                                            className="euiComboBoxPlaceholder"
+                                          >
+                                            Select a log type
+                                          </p>
+                                          <AutosizeInput
+                                            aria-controls=""
+                                            className="euiComboBox__input"
+                                            data-test-subj="comboBoxSearchInput"
+                                            id="some_html_id"
+                                            injectStyles={true}
+                                            inputRef={[Function]}
+                                            minWidth={1}
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            role="textbox"
+                                            style={
+                                              Object {
+                                                "fontSize": 14,
+                                              }
+                                            }
+                                            value=""
+                                          >
+                                            <div
+                                              className="euiComboBox__input"
+                                              style={
+                                                Object {
+                                                  "display": "inline-block",
+                                                  "fontSize": 14,
+                                                }
+                                              }
+                                            >
+                                              <input
+                                                aria-controls=""
+                                                data-test-subj="comboBoxSearchInput"
+                                                id="some_html_id"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                role="textbox"
+                                                style={
+                                                  Object {
+                                                    "boxSizing": "content-box",
+                                                    "width": "2px",
+                                                  }
+                                                }
+                                                value=""
+                                              />
+                                              <div
+                                                style={
+                                                  Object {
+                                                    "height": 0,
+                                                    "left": 0,
+                                                    "overflow": "scroll",
+                                                    "position": "absolute",
+                                                    "top": 0,
+                                                    "visibility": "hidden",
+                                                    "whiteSpace": "pre",
+                                                  }
+                                                }
+                                              />
+                                            </div>
+                                          </AutosizeInput>
+                                        </div>
+                                        <EuiFormControlLayoutIcons
+                                          compressed={false}
+                                          icon={
+                                            Object {
+                                              "aria-label": "Open list of options",
+                                              "data-test-subj": "comboBoxToggleListButton",
+                                              "disabled": undefined,
+                                              "onClick": [Function],
+                                              "ref": [Function],
+                                              "side": "right",
+                                              "type": "arrowDown",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                          >
+                                            <EuiFormControlLayoutCustomIcon
+                                              aria-label="Open list of options"
+                                              data-test-subj="comboBoxToggleListButton"
+                                              iconRef={[Function]}
+                                              onClick={[Function]}
+                                              size="m"
+                                              type="arrowDown"
+                                            >
+                                              <button
+                                                aria-label="Open list of options"
+                                                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                                data-test-subj="comboBoxToggleListButton"
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiIcon
+                                                  aria-hidden="true"
+                                                  className="euiFormControlLayoutCustomIcon__icon"
+                                                  size="m"
+                                                  type="arrowDown"
+                                                >
+                                                  EuiIconMock
+                                                </EuiIcon>
+                                              </button>
+                                            </EuiFormControlLayoutCustomIcon>
+                                          </div>
+                                        </EuiFormControlLayoutIcons>
+                                      </div>
+                                    </div>
+                                  </EuiFormControlLayout>
+                                </EuiComboBoxInput>
+                              </div>
+                            </EuiComboBox>
+                          </div>
+                        </div>
+                      </EuiFormRow>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "marginTop": 36,
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "marginTop": 36,
+                        }
+                      }
+                    >
+                      <EuiButton
+                        href="opensearch_security_analytics_dashboards#/log-types"
+                        target="_blank"
+                      >
+                        <EuiButtonDisplay
+                          baseClassName="euiButton"
+                          element="a"
+                          href="opensearch_security_analytics_dashboards#/log-types"
+                          isDisabled={false}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="euiButton euiButton--primary"
+                            disabled={false}
+                            href="opensearch_security_analytics_dashboards#/log-types"
+                            rel="noopener noreferrer"
+                            style={
+                              Object {
+                                "minWidth": undefined,
+                              }
+                            }
+                            target="_blank"
+                          >
+                            <EuiButtonContent
+                              className="euiButton__content"
+                              iconSide="left"
+                              textProps={
+                                Object {
+                                  "className": "euiButton__text",
+                                }
+                              }
+                            >
+                              <span
+                                className="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  className="euiButton__text"
+                                >
+                                  Manage 
+                                  <EuiIcon
+                                    type="popout"
+                                  >
+                                    EuiIconMock
+                                  </EuiIcon>
+                                </span>
+                              </span>
+                            </EuiButtonContent>
+                          </a>
+                        </EuiButtonDisplay>
+                      </EuiButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <EuiFormRow
+                describedByIds={Array []}
+                display="row"
+                fullWidth={false}
+                hasChildLabel={true}
+                hasEmptyLabelSpace={false}
+                label={
+                  <EuiText
+                    size="s"
+                  >
+                    <strong>
+                      Rule level (severity)
+                    </strong>
+                  </EuiText>
+                }
+                labelType="label"
+              >
+                <div
+                  className="euiFormRow"
+                  id="some_html_id-row"
+                >
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
+                    <EuiFormLabel
+                      className="euiFormRow__label"
+                      htmlFor="some_html_id"
+                      isFocused={false}
+                      type="label"
+                    >
+                      <label
+                        className="euiFormLabel euiFormRow__label"
+                        htmlFor="some_html_id"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            <strong>
+                              Rule level (severity)
+                            </strong>
+                          </div>
+                        </EuiText>
+                      </label>
+                    </EuiFormLabel>
+                  </div>
+                  <div
+                    className="euiFormRow__fieldWrapper"
+                  >
+                    <EuiComboBox
+                      async={false}
+                      compressed={false}
+                      data-test-subj="rule_severity_dropdown"
+                      fullWidth={false}
+                      id="some_html_id"
+                      isClearable={true}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "Critical",
+                            "value": "critical",
+                          },
+                          Object {
+                            "label": "High",
+                            "value": "high",
+                          },
+                          Object {
+                            "label": "Medium",
+                            "value": "medium",
+                          },
+                          Object {
+                            "label": "Low",
+                            "value": "low",
+                          },
+                          Object {
+                            "label": "Informational",
+                            "value": "informational",
+                          },
+                        ]
+                      }
+                      placeholder="Select a rule level"
+                      selectedOptions={Array []}
+                      singleSelection={
+                        Object {
+                          "asPlainText": true,
+                        }
+                      }
+                      sortMatchesBy="none"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
+                        className="euiComboBox"
+                        data-test-subj="rule_severity_dropdown"
+                        onKeyDown={[Function]}
+                        role="combobox"
+                      >
+                        <EuiComboBoxInput
+                          autoSizeInputRef={[Function]}
+                          compressed={false}
+                          fullWidth={false}
+                          hasSelectedOptions={false}
+                          id="some_html_id"
+                          inputRef={[Function]}
+                          isListOpen={false}
+                          noIcon={false}
+                          onChange={[Function]}
+                          onClear={[Function]}
+                          onClick={[Function]}
+                          onCloseListClick={[Function]}
+                          onFocus={[Function]}
+                          onOpenListClick={[Function]}
+                          onRemoveOption={[Function]}
+                          placeholder="Select a rule level"
+                          rootId={[Function]}
+                          searchValue=""
+                          selectedOptions={Array []}
+                          singleSelection={
+                            Object {
+                              "asPlainText": true,
+                            }
+                          }
+                          toggleButtonRef={[Function]}
+                          updatePosition={[Function]}
+                          value=""
+                        >
+                          <EuiFormControlLayout
+                            compressed={false}
+                            fullWidth={false}
+                            icon={
+                              Object {
+                                "aria-label": "Open list of options",
+                                "data-test-subj": "comboBoxToggleListButton",
+                                "disabled": undefined,
+                                "onClick": [Function],
+                                "ref": [Function],
+                                "side": "right",
+                                "type": "arrowDown",
+                              }
+                            }
+                          >
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <div
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
+                                >
+                                  <p
+                                    className="euiComboBoxPlaceholder"
+                                  >
+                                    Select a rule level
+                                  </p>
+                                  <AutosizeInput
+                                    aria-controls=""
+                                    className="euiComboBox__input"
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="some_html_id"
+                                    injectStyles={true}
+                                    inputRef={[Function]}
+                                    minWidth={1}
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    role="textbox"
+                                    style={
+                                      Object {
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                    value=""
+                                  >
+                                    <div
+                                      className="euiComboBox__input"
+                                      style={
+                                        Object {
+                                          "display": "inline-block",
+                                          "fontSize": 14,
+                                        }
+                                      }
+                                    >
+                                      <input
+                                        aria-controls=""
+                                        data-test-subj="comboBoxSearchInput"
+                                        id="some_html_id"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        role="textbox"
+                                        style={
+                                          Object {
+                                            "boxSizing": "content-box",
+                                            "width": "2px",
+                                          }
+                                        }
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
+                                          }
+                                        }
+                                      />
+                                    </div>
+                                  </AutosizeInput>
+                                </div>
+                                <EuiFormControlLayoutIcons
+                                  compressed={false}
+                                  icon={
+                                    Object {
+                                      "aria-label": "Open list of options",
+                                      "data-test-subj": "comboBoxToggleListButton",
+                                      "disabled": undefined,
+                                      "onClick": [Function],
+                                      "ref": [Function],
+                                      "side": "right",
+                                      "type": "arrowDown",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                  >
+                                    <EuiFormControlLayoutCustomIcon
+                                      aria-label="Open list of options"
+                                      data-test-subj="comboBoxToggleListButton"
+                                      iconRef={[Function]}
+                                      onClick={[Function]}
+                                      size="m"
+                                      type="arrowDown"
+                                    >
+                                      <button
+                                        aria-label="Open list of options"
+                                        className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                        data-test-subj="comboBoxToggleListButton"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiFormControlLayoutCustomIcon__icon"
+                                          size="m"
+                                          type="arrowDown"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiFormControlLayoutCustomIcon>
+                                  </div>
+                                </EuiFormControlLayoutIcons>
+                              </div>
+                            </div>
+                          </EuiFormControlLayout>
+                        </EuiComboBoxInput>
+                      </div>
+                    </EuiComboBox>
+                  </div>
+                </div>
+              </EuiFormRow>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <EuiFormRow
+                describedByIds={Array []}
+                display="row"
+                fullWidth={false}
+                hasChildLabel={true}
+                hasEmptyLabelSpace={false}
+                label={
+                  <EuiText
+                    size="s"
+                  >
+                    <strong>
+                      Rule Status
+                    </strong>
+                  </EuiText>
+                }
+                labelType="label"
+              >
+                <div
+                  className="euiFormRow"
+                  id="some_html_id-row"
+                >
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
+                    <EuiFormLabel
+                      className="euiFormRow__label"
+                      htmlFor="some_html_id"
+                      isFocused={false}
+                      type="label"
+                    >
+                      <label
+                        className="euiFormLabel euiFormRow__label"
+                        htmlFor="some_html_id"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            <strong>
+                              Rule Status
+                            </strong>
+                          </div>
+                        </EuiText>
+                      </label>
+                    </EuiFormLabel>
+                  </div>
+                  <div
+                    className="euiFormRow__fieldWrapper"
+                  >
+                    <EuiComboBox
+                      async={false}
+                      compressed={false}
+                      data-test-subj="rule_status_dropdown"
+                      fullWidth={false}
+                      id="some_html_id"
+                      isClearable={true}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "experimental",
+                            "value": "experimental",
+                          },
+                          Object {
+                            "label": "test",
+                            "value": "test",
+                          },
+                          Object {
+                            "label": "stable",
+                            "value": "stable",
+                          },
+                        ]
+                      }
+                      placeholder="Select a rule status"
+                      selectedOptions={
+                        Array [
+                          Object {
+                            "label": "experimental",
+                            "value": "experimental",
+                          },
+                        ]
+                      }
+                      singleSelection={
+                        Object {
+                          "asPlainText": true,
+                        }
+                      }
+                      sortMatchesBy="none"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
+                        className="euiComboBox"
+                        data-test-subj="rule_status_dropdown"
+                        onKeyDown={[Function]}
+                        role="combobox"
+                      >
+                        <EuiComboBoxInput
+                          autoSizeInputRef={[Function]}
+                          compressed={false}
+                          fullWidth={false}
+                          hasSelectedOptions={true}
+                          id="some_html_id"
+                          inputRef={[Function]}
+                          isListOpen={false}
+                          noIcon={false}
+                          onChange={[Function]}
+                          onClear={[Function]}
+                          onClick={[Function]}
+                          onCloseListClick={[Function]}
+                          onFocus={[Function]}
+                          onOpenListClick={[Function]}
+                          onRemoveOption={[Function]}
+                          placeholder="Select a rule status"
+                          rootId={[Function]}
+                          searchValue=""
+                          selectedOptions={
+                            Array [
+                              Object {
+                                "label": "experimental",
+                                "value": "experimental",
+                              },
+                            ]
+                          }
+                          singleSelection={
+                            Object {
+                              "asPlainText": true,
+                            }
+                          }
+                          toggleButtonRef={[Function]}
+                          updatePosition={[Function]}
+                          value="experimental"
+                        >
+                          <EuiFormControlLayout
+                            clear={
+                              Object {
+                                "data-test-subj": "comboBoxClearButton",
+                                "onClick": [Function],
+                              }
+                            }
+                            compressed={false}
+                            fullWidth={false}
+                            icon={
+                              Object {
+                                "aria-label": "Open list of options",
+                                "data-test-subj": "comboBoxToggleListButton",
+                                "disabled": undefined,
+                                "onClick": [Function],
+                                "ref": [Function],
+                                "side": "right",
+                                "type": "arrowDown",
+                              }
+                            }
+                          >
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <div
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
+                                >
+                                  <EuiComboBoxPill
+                                    asPlainText={true}
+                                    color="hollow"
+                                    key="experimental"
+                                    option={
+                                      Object {
+                                        "label": "experimental",
+                                        "value": "experimental",
+                                      }
+                                    }
+                                    value="experimental"
+                                  >
+                                    <span
+                                      className="euiComboBoxPill euiComboBoxPill--plainText"
+                                      value="experimental"
+                                    >
+                                      experimental
+                                    </span>
+                                  </EuiComboBoxPill>
+                                  <AutosizeInput
+                                    aria-controls=""
+                                    className="euiComboBox__input"
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="some_html_id"
+                                    injectStyles={true}
+                                    inputRef={[Function]}
+                                    minWidth={1}
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    role="textbox"
+                                    style={
+                                      Object {
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                    value=""
+                                  >
+                                    <div
+                                      className="euiComboBox__input"
+                                      style={
+                                        Object {
+                                          "display": "inline-block",
+                                          "fontSize": 14,
+                                        }
+                                      }
+                                    >
+                                      <input
+                                        aria-controls=""
+                                        data-test-subj="comboBoxSearchInput"
+                                        id="some_html_id"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        role="textbox"
+                                        style={
+                                          Object {
+                                            "boxSizing": "content-box",
+                                            "width": "2px",
+                                          }
+                                        }
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
+                                          }
+                                        }
+                                      />
+                                    </div>
+                                  </AutosizeInput>
+                                </div>
+                                <EuiFormControlLayoutIcons
+                                  clear={
+                                    Object {
+                                      "data-test-subj": "comboBoxClearButton",
+                                      "onClick": [Function],
+                                    }
+                                  }
+                                  compressed={false}
+                                  icon={
+                                    Object {
+                                      "aria-label": "Open list of options",
+                                      "data-test-subj": "comboBoxToggleListButton",
+                                      "disabled": undefined,
+                                      "onClick": [Function],
+                                      "ref": [Function],
+                                      "side": "right",
+                                      "type": "arrowDown",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                  >
+                                    <EuiFormControlLayoutClearButton
+                                      data-test-subj="comboBoxClearButton"
+                                      onClick={[Function]}
+                                      size="m"
+                                    >
+                                      <EuiI18n
+                                        default="Clear input"
+                                        token="euiFormControlLayoutClearButton.label"
+                                      >
+                                        <button
+                                          aria-label="Clear input"
+                                          className="euiFormControlLayoutClearButton"
+                                          data-test-subj="comboBoxClearButton"
+                                          onClick={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            className="euiFormControlLayoutClearButton__icon"
+                                            type="cross"
+                                          >
+                                            EuiIconMock
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiI18n>
+                                    </EuiFormControlLayoutClearButton>
+                                    <EuiFormControlLayoutCustomIcon
+                                      aria-label="Open list of options"
+                                      data-test-subj="comboBoxToggleListButton"
+                                      iconRef={[Function]}
+                                      onClick={[Function]}
+                                      size="m"
+                                      type="arrowDown"
+                                    >
+                                      <button
+                                        aria-label="Open list of options"
+                                        className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                        data-test-subj="comboBoxToggleListButton"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiFormControlLayoutCustomIcon__icon"
+                                          size="m"
+                                          type="arrowDown"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiFormControlLayoutCustomIcon>
+                                  </div>
+                                </EuiFormControlLayoutIcons>
+                              </div>
+                            </div>
+                          </EuiFormControlLayout>
+                        </EuiComboBoxInput>
+                      </div>
+                    </EuiComboBox>
+                  </div>
+                </div>
+              </EuiFormRow>
+              <EuiSpacer
+                size="xxl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xxl"
+                />
+              </EuiSpacer>
+              <EuiTitle>
+                <EuiText
+                  className="euiTitle euiTitle--medium"
+                >
+                  <div
+                    className="euiText euiText--medium euiTitle euiTitle--medium"
+                  >
+                    <h2>
+                      Detection
+                    </h2>
+                  </div>
+                </EuiText>
+              </EuiTitle>
+              <EuiText
+                size="s"
+              >
+                <div
+                  className="euiText euiText--small"
+                >
+                  <p>
+                    Define the detection criteria for the rule
+                  </p>
+                </div>
+              </EuiText>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <DetectionVisualEditor
+                detectionYml=""
+                goToYamlEditor={[Function]}
+                onChange={[Function]}
+                setIsDetectionInvalid={[Function]}
+              >
+                <div
+                  className="detection-visual-editor"
+                  style={
+                    Object {
+                      "maxWidth": 1000,
+                    }
+                  }
+                >
+                  <div
+                    key="detection-visual-editor-selection-0"
+                  >
+                    <EuiPanel
+                      className="detection-visual-editor-selection"
+                      data-test-subj="detection-visual-editor-0"
+                      key="detection-visual-editor-0"
+                    >
+                      <div
+                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow detection-visual-editor-selection"
+                        data-test-subj="detection-visual-editor-0"
+                      >
+                        <EuiFlexGroup
+                          alignItems="center"
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <EuiFlexItem
+                              grow={true}
+                            >
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormRow
+                                  describedByIds={Array []}
+                                  display="row"
+                                  fullWidth={false}
+                                  hasChildLabel={true}
+                                  hasEmptyLabelSpace={false}
+                                  labelType="label"
+                                >
+                                  <div
+                                    className="euiFormRow"
+                                    id="some_html_id-row"
+                                  >
+                                    <div
+                                      className="euiFormRow__fieldWrapper"
+                                    >
+                                      <EuiFieldText
+                                        className="detection-visual-editor-name euiTitle--small"
+                                        data-test-subj="selection_name"
+                                        id="some_html_id"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        placeholder="Enter selection name"
+                                        value="Selection_1"
+                                      >
+                                        <EuiFormControlLayout
+                                          fullWidth={false}
+                                          inputId="some_html_id"
+                                        >
+                                          <div
+                                            className="euiFormControlLayout"
+                                          >
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiValidatableControl>
+                                                <input
+                                                  className="euiFieldText detection-visual-editor-name euiTitle--small"
+                                                  data-test-subj="selection_name"
+                                                  id="some_html_id"
+                                                  onBlur={[Function]}
+                                                  onChange={[Function]}
+                                                  onFocus={[Function]}
+                                                  placeholder="Enter selection name"
+                                                  type="text"
+                                                  value="Selection_1"
+                                                />
+                                              </EuiValidatableControl>
+                                              <EuiFormControlLayoutIcons />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </EuiFieldText>
+                                    </div>
+                                  </div>
+                                </EuiFormRow>
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    <p>
+                                      Define the search identifier in your data the rule will be applied to.
+                                    </p>
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiFlexItem>
+                            <EuiFlexItem
+                              className="detection-visual-editor-delete-selection"
+                              grow={false}
+                            >
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero detection-visual-editor-delete-selection"
+                              />
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                        <EuiSpacer>
+                          <div
+                            className="euiSpacer euiSpacer--l"
+                          />
+                        </EuiSpacer>
+                        <div
+                          className="detection-visual-editor-accordion-wrapper"
+                          key="Map-0"
+                        >
+                          <EuiAccordion
+                            arrowDisplay="left"
+                            buttonContent={
+                              <EuiText
+                                size="m"
+                              >
+                                Map 
+                                1
+                              </EuiText>
+                            }
+                            className="euiAccordionForm detection-visual-editor-accordion"
+                            data-test-subj="Map-0"
+                            extraAction={null}
+                            id="Map-0"
+                            initialIsOpen={true}
+                            isLoading={false}
+                            isLoadingMessage={false}
+                            key="Map-0"
+                            paddingSize="m"
+                            style={
+                              Object {
+                                "maxWidth": "70%",
+                              }
+                            }
+                          >
+                            <div
+                              className="euiAccordion euiAccordion-isOpen euiAccordionForm detection-visual-editor-accordion"
+                              data-test-subj="Map-0"
+                              style={
+                                Object {
+                                  "maxWidth": "70%",
+                                }
+                              }
+                            >
+                              <div
+                                className="euiAccordion__triggerWrapper"
+                              >
+                                <button
+                                  aria-controls="Map-0"
+                                  aria-expanded={true}
+                                  className="euiAccordion__button"
+                                  id="some_html_id"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="euiAccordion__iconWrapper"
+                                  >
+                                    <EuiIcon
+                                      className="euiAccordion__icon euiAccordion__icon-isOpen"
+                                      size="m"
+                                      type="arrowRight"
+                                    >
+                                      EuiIconMock
+                                    </EuiIcon>
+                                  </span>
+                                  <span
+                                    className="euiIEFlexWrapFix"
+                                  >
+                                    <EuiText
+                                      size="m"
+                                    >
+                                      <div
+                                        className="euiText euiText--medium"
+                                      >
+                                        Map 
+                                        1
+                                      </div>
+                                    </EuiText>
+                                  </span>
+                                </button>
+                              </div>
+                              <div
+                                aria-labelledby="some_html_id"
+                                className="euiAccordion__childWrapper"
+                                id="Map-0"
+                                role="region"
+                                tabIndex={-1}
+                              >
+                                <EuiResizeObserver
+                                  onResize={[Function]}
+                                >
+                                  <div>
+                                    <div
+                                      className="euiAccordion__padding--m"
+                                    >
+                                      <EuiFlexGroup>
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                            style={
+                                              Object {
+                                                "minWidth": 200,
+                                              }
+                                            }
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                              style={
+                                                Object {
+                                                  "minWidth": 200,
+                                                }
+                                              }
+                                            >
+                                              <EuiFormRow
+                                                describedByIds={Array []}
+                                                display="row"
+                                                fullWidth={false}
+                                                hasChildLabel={true}
+                                                hasEmptyLabelSpace={false}
+                                                label={
+                                                  <EuiText
+                                                    size="s"
+                                                  >
+                                                    Key
+                                                  </EuiText>
+                                                }
+                                                labelType="label"
+                                              >
+                                                <div
+                                                  className="euiFormRow"
+                                                  id="some_html_id-row"
+                                                >
+                                                  <div
+                                                    className="euiFormRow__labelWrapper"
+                                                  >
+                                                    <EuiFormLabel
+                                                      className="euiFormRow__label"
+                                                      htmlFor="some_html_id"
+                                                      isFocused={false}
+                                                      type="label"
+                                                    >
+                                                      <label
+                                                        className="euiFormLabel euiFormRow__label"
+                                                        htmlFor="some_html_id"
+                                                      >
+                                                        <EuiText
+                                                          size="s"
+                                                        >
+                                                          <div
+                                                            className="euiText euiText--small"
+                                                          >
+                                                            Key
+                                                          </div>
+                                                        </EuiText>
+                                                      </label>
+                                                    </EuiFormLabel>
+                                                  </div>
+                                                  <div
+                                                    className="euiFormRow__fieldWrapper"
+                                                  >
+                                                    <EuiFieldText
+                                                      data-test-subj="selection_field_key_name"
+                                                      id="some_html_id"
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      onFocus={[Function]}
+                                                      placeholder="Enter key name"
+                                                      value=""
+                                                    >
+                                                      <EuiFormControlLayout
+                                                        fullWidth={false}
+                                                        inputId="some_html_id"
+                                                      >
+                                                        <div
+                                                          className="euiFormControlLayout"
+                                                        >
+                                                          <div
+                                                            className="euiFormControlLayout__childrenWrapper"
+                                                          >
+                                                            <EuiValidatableControl>
+                                                              <input
+                                                                className="euiFieldText"
+                                                                data-test-subj="selection_field_key_name"
+                                                                id="some_html_id"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                onFocus={[Function]}
+                                                                placeholder="Enter key name"
+                                                                type="text"
+                                                                value=""
+                                                              />
+                                                            </EuiValidatableControl>
+                                                            <EuiFormControlLayoutIcons />
+                                                          </div>
+                                                        </div>
+                                                      </EuiFormControlLayout>
+                                                    </EuiFieldText>
+                                                  </div>
+                                                </div>
+                                              </EuiFormRow>
+                                            </div>
+                                          </EuiFlexItem>
+                                          <EuiFlexItem
+                                            grow={false}
+                                            style={
+                                              Object {
+                                                "minWidth": 200,
+                                              }
+                                            }
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                              style={
+                                                Object {
+                                                  "minWidth": 200,
+                                                }
+                                              }
+                                            >
+                                              <EuiFormRow
+                                                describedByIds={Array []}
+                                                display="row"
+                                                fullWidth={false}
+                                                hasChildLabel={true}
+                                                hasEmptyLabelSpace={false}
+                                                label={
+                                                  <EuiText
+                                                    size="s"
+                                                  >
+                                                    Modifier
+                                                  </EuiText>
+                                                }
+                                                labelType="label"
+                                              >
+                                                <div
+                                                  className="euiFormRow"
+                                                  id="some_html_id-row"
+                                                >
+                                                  <div
+                                                    className="euiFormRow__labelWrapper"
+                                                  >
+                                                    <EuiFormLabel
+                                                      className="euiFormRow__label"
+                                                      htmlFor="some_html_id"
+                                                      isFocused={false}
+                                                      type="label"
+                                                    >
+                                                      <label
+                                                        className="euiFormLabel euiFormRow__label"
+                                                        htmlFor="some_html_id"
+                                                      >
+                                                        <EuiText
+                                                          size="s"
+                                                        >
+                                                          <div
+                                                            className="euiText euiText--small"
+                                                          >
+                                                            Modifier
+                                                          </div>
+                                                        </EuiText>
+                                                      </label>
+                                                    </EuiFormLabel>
+                                                  </div>
+                                                  <div
+                                                    className="euiFormRow__fieldWrapper"
+                                                  >
+                                                    <EuiComboBox
+                                                      async={false}
+                                                      compressed={false}
+                                                      data-test-subj="modifier_dropdown"
+                                                      fullWidth={false}
+                                                      id="some_html_id"
+                                                      isClearable={true}
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      onFocus={[Function]}
+                                                      options={
+                                                        Array [
+                                                          Object {
+                                                            "label": "all",
+                                                            "value": "all",
+                                                          },
+                                                          Object {
+                                                            "label": "contains",
+                                                            "value": "contains",
+                                                          },
+                                                          Object {
+                                                            "label": "base64",
+                                                            "value": "base64",
+                                                          },
+                                                          Object {
+                                                            "label": "endswith",
+                                                            "value": "endswith",
+                                                          },
+                                                          Object {
+                                                            "label": "startswith",
+                                                            "value": "startswith",
+                                                          },
+                                                          Object {
+                                                            "label": "cidr",
+                                                            "value": "cidr",
+                                                          },
+                                                        ]
+                                                      }
+                                                      selectedOptions={
+                                                        Array [
+                                                          Object {
+                                                            "label": "all",
+                                                            "value": "all",
+                                                          },
+                                                        ]
+                                                      }
+                                                      singleSelection={
+                                                        Object {
+                                                          "asPlainText": true,
+                                                        }
+                                                      }
+                                                      sortMatchesBy="none"
+                                                    >
+                                                      <div
+                                                        aria-expanded={false}
+                                                        aria-haspopup="listbox"
+                                                        className="euiComboBox"
+                                                        data-test-subj="modifier_dropdown"
+                                                        onKeyDown={[Function]}
+                                                        role="combobox"
+                                                      >
+                                                        <EuiComboBoxInput
+                                                          autoSizeInputRef={[Function]}
+                                                          compressed={false}
+                                                          fullWidth={false}
+                                                          hasSelectedOptions={true}
+                                                          id="some_html_id"
+                                                          inputRef={[Function]}
+                                                          isListOpen={false}
+                                                          noIcon={false}
+                                                          onChange={[Function]}
+                                                          onClear={[Function]}
+                                                          onClick={[Function]}
+                                                          onCloseListClick={[Function]}
+                                                          onFocus={[Function]}
+                                                          onOpenListClick={[Function]}
+                                                          onRemoveOption={[Function]}
+                                                          rootId={[Function]}
+                                                          searchValue=""
+                                                          selectedOptions={
+                                                            Array [
+                                                              Object {
+                                                                "label": "all",
+                                                                "value": "all",
+                                                              },
+                                                            ]
+                                                          }
+                                                          singleSelection={
+                                                            Object {
+                                                              "asPlainText": true,
+                                                            }
+                                                          }
+                                                          toggleButtonRef={[Function]}
+                                                          updatePosition={[Function]}
+                                                          value="all"
+                                                        >
+                                                          <EuiFormControlLayout
+                                                            clear={
+                                                              Object {
+                                                                "data-test-subj": "comboBoxClearButton",
+                                                                "onClick": [Function],
+                                                              }
+                                                            }
+                                                            compressed={false}
+                                                            fullWidth={false}
+                                                            icon={
+                                                              Object {
+                                                                "aria-label": "Open list of options",
+                                                                "data-test-subj": "comboBoxToggleListButton",
+                                                                "disabled": undefined,
+                                                                "onClick": [Function],
+                                                                "ref": [Function],
+                                                                "side": "right",
+                                                                "type": "arrowDown",
+                                                              }
+                                                            }
+                                                          >
+                                                            <div
+                                                              className="euiFormControlLayout"
+                                                            >
+                                                              <div
+                                                                className="euiFormControlLayout__childrenWrapper"
+                                                              >
+                                                                <div
+                                                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                                                  data-test-subj="comboBoxInput"
+                                                                  onClick={[Function]}
+                                                                  tabIndex={-1}
+                                                                >
+                                                                  <EuiComboBoxPill
+                                                                    asPlainText={true}
+                                                                    color="hollow"
+                                                                    key="all"
+                                                                    option={
+                                                                      Object {
+                                                                        "label": "all",
+                                                                        "value": "all",
+                                                                      }
+                                                                    }
+                                                                    value="all"
+                                                                  >
+                                                                    <span
+                                                                      className="euiComboBoxPill euiComboBoxPill--plainText"
+                                                                      value="all"
+                                                                    >
+                                                                      all
+                                                                    </span>
+                                                                  </EuiComboBoxPill>
+                                                                  <AutosizeInput
+                                                                    aria-controls=""
+                                                                    className="euiComboBox__input"
+                                                                    data-test-subj="comboBoxSearchInput"
+                                                                    id="some_html_id"
+                                                                    injectStyles={true}
+                                                                    inputRef={[Function]}
+                                                                    minWidth={1}
+                                                                    onBlur={[Function]}
+                                                                    onChange={[Function]}
+                                                                    onFocus={[Function]}
+                                                                    role="textbox"
+                                                                    style={
+                                                                      Object {
+                                                                        "fontSize": 14,
+                                                                      }
+                                                                    }
+                                                                    value=""
+                                                                  >
+                                                                    <div
+                                                                      className="euiComboBox__input"
+                                                                      style={
+                                                                        Object {
+                                                                          "display": "inline-block",
+                                                                          "fontSize": 14,
+                                                                        }
+                                                                      }
+                                                                    >
+                                                                      <input
+                                                                        aria-controls=""
+                                                                        data-test-subj="comboBoxSearchInput"
+                                                                        id="some_html_id"
+                                                                        onBlur={[Function]}
+                                                                        onChange={[Function]}
+                                                                        onFocus={[Function]}
+                                                                        role="textbox"
+                                                                        style={
+                                                                          Object {
+                                                                            "boxSizing": "content-box",
+                                                                            "width": "2px",
+                                                                          }
+                                                                        }
+                                                                        value=""
+                                                                      />
+                                                                      <div
+                                                                        style={
+                                                                          Object {
+                                                                            "height": 0,
+                                                                            "left": 0,
+                                                                            "overflow": "scroll",
+                                                                            "position": "absolute",
+                                                                            "top": 0,
+                                                                            "visibility": "hidden",
+                                                                            "whiteSpace": "pre",
+                                                                          }
+                                                                        }
+                                                                      />
+                                                                    </div>
+                                                                  </AutosizeInput>
+                                                                </div>
+                                                                <EuiFormControlLayoutIcons
+                                                                  clear={
+                                                                    Object {
+                                                                      "data-test-subj": "comboBoxClearButton",
+                                                                      "onClick": [Function],
+                                                                    }
+                                                                  }
+                                                                  compressed={false}
+                                                                  icon={
+                                                                    Object {
+                                                                      "aria-label": "Open list of options",
+                                                                      "data-test-subj": "comboBoxToggleListButton",
+                                                                      "disabled": undefined,
+                                                                      "onClick": [Function],
+                                                                      "ref": [Function],
+                                                                      "side": "right",
+                                                                      "type": "arrowDown",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <div
+                                                                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                                                  >
+                                                                    <EuiFormControlLayoutClearButton
+                                                                      data-test-subj="comboBoxClearButton"
+                                                                      onClick={[Function]}
+                                                                      size="m"
+                                                                    >
+                                                                      <EuiI18n
+                                                                        default="Clear input"
+                                                                        token="euiFormControlLayoutClearButton.label"
+                                                                      >
+                                                                        <button
+                                                                          aria-label="Clear input"
+                                                                          className="euiFormControlLayoutClearButton"
+                                                                          data-test-subj="comboBoxClearButton"
+                                                                          onClick={[Function]}
+                                                                          type="button"
+                                                                        >
+                                                                          <EuiIcon
+                                                                            className="euiFormControlLayoutClearButton__icon"
+                                                                            type="cross"
+                                                                          >
+                                                                            EuiIconMock
+                                                                          </EuiIcon>
+                                                                        </button>
+                                                                      </EuiI18n>
+                                                                    </EuiFormControlLayoutClearButton>
+                                                                    <EuiFormControlLayoutCustomIcon
+                                                                      aria-label="Open list of options"
+                                                                      data-test-subj="comboBoxToggleListButton"
+                                                                      iconRef={[Function]}
+                                                                      onClick={[Function]}
+                                                                      size="m"
+                                                                      type="arrowDown"
+                                                                    >
+                                                                      <button
+                                                                        aria-label="Open list of options"
+                                                                        className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                                                        data-test-subj="comboBoxToggleListButton"
+                                                                        onClick={[Function]}
+                                                                        type="button"
+                                                                      >
+                                                                        <EuiIcon
+                                                                          aria-hidden="true"
+                                                                          className="euiFormControlLayoutCustomIcon__icon"
+                                                                          size="m"
+                                                                          type="arrowDown"
+                                                                        >
+                                                                          EuiIconMock
+                                                                        </EuiIcon>
+                                                                      </button>
+                                                                    </EuiFormControlLayoutCustomIcon>
+                                                                  </div>
+                                                                </EuiFormControlLayoutIcons>
+                                                              </div>
+                                                            </div>
+                                                          </EuiFormControlLayout>
+                                                        </EuiComboBoxInput>
+                                                      </div>
+                                                    </EuiComboBox>
+                                                  </div>
+                                                </div>
+                                              </EuiFormRow>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                      <EuiSpacer
+                                        size="m"
+                                      >
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiRadioGroup
+                                        idSelected="selection-map-value-0-0"
+                                        onChange={[Function]}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "id": "selection-map-value-0-0",
+                                              "label": "Value",
+                                            },
+                                            Object {
+                                              "id": "selection-map-list-0-0",
+                                              "label": "List",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <div>
+                                          <EuiRadio
+                                            checked={true}
+                                            className="euiRadioGroup__item"
+                                            id="selection-map-value-0-0"
+                                            key="0"
+                                            label="Value"
+                                            onChange={[Function]}
+                                          >
+                                            <div
+                                              className="euiRadio euiRadioGroup__item"
+                                            >
+                                              <input
+                                                checked={true}
+                                                className="euiRadio__input"
+                                                id="selection-map-value-0-0"
+                                                onChange={[Function]}
+                                                type="radio"
+                                              />
+                                              <div
+                                                className="euiRadio__circle"
+                                              />
+                                              <label
+                                                className="euiRadio__label"
+                                                htmlFor="selection-map-value-0-0"
+                                              >
+                                                Value
+                                              </label>
+                                            </div>
+                                          </EuiRadio>
+                                          <EuiRadio
+                                            checked={false}
+                                            className="euiRadioGroup__item"
+                                            id="selection-map-list-0-0"
+                                            key="1"
+                                            label="List"
+                                            onChange={[Function]}
+                                          >
+                                            <div
+                                              className="euiRadio euiRadioGroup__item"
+                                            >
+                                              <input
+                                                checked={false}
+                                                className="euiRadio__input"
+                                                id="selection-map-list-0-0"
+                                                onChange={[Function]}
+                                                type="radio"
+                                              />
+                                              <div
+                                                className="euiRadio__circle"
+                                              />
+                                              <label
+                                                className="euiRadio__label"
+                                                htmlFor="selection-map-list-0-0"
+                                              >
+                                                List
+                                              </label>
+                                            </div>
+                                          </EuiRadio>
+                                        </div>
+                                      </EuiRadioGroup>
+                                      <EuiSpacer
+                                        size="m"
+                                      >
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiFormRow
+                                        describedByIds={Array []}
+                                        display="row"
+                                        fullWidth={false}
+                                        hasChildLabel={true}
+                                        hasEmptyLabelSpace={false}
+                                        labelType="label"
+                                      >
+                                        <div
+                                          className="euiFormRow"
+                                          id="some_html_id-row"
+                                        >
+                                          <div
+                                            className="euiFormRow__fieldWrapper"
+                                          >
+                                            <EuiFieldText
+                                              data-test-subj="selection_field_value"
+                                              id="some_html_id"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              placeholder="Value"
+                                              value=""
+                                            >
+                                              <EuiFormControlLayout
+                                                fullWidth={false}
+                                                inputId="some_html_id"
+                                              >
+                                                <div
+                                                  className="euiFormControlLayout"
+                                                >
+                                                  <div
+                                                    className="euiFormControlLayout__childrenWrapper"
+                                                  >
+                                                    <EuiValidatableControl>
+                                                      <input
+                                                        className="euiFieldText"
+                                                        data-test-subj="selection_field_value"
+                                                        id="some_html_id"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onFocus={[Function]}
+                                                        placeholder="Value"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </EuiValidatableControl>
+                                                    <EuiFormControlLayoutIcons />
+                                                  </div>
+                                                </div>
+                                              </EuiFormControlLayout>
+                                            </EuiFieldText>
+                                          </div>
+                                        </div>
+                                      </EuiFormRow>
+                                      <EuiSpacer
+                                        size="m"
+                                      >
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                    </div>
+                                  </div>
+                                </EuiResizeObserver>
+                              </div>
+                            </div>
+                          </EuiAccordion>
+                        </div>
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiButton
+                          disabled={true}
+                          iconType="plusInCircle"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "width": "70%",
+                            }
+                          }
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButton"
+                            disabled={true}
+                            element="button"
+                            iconType="plusInCircle"
+                            isDisabled={true}
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "width": "70%",
+                              }
+                            }
+                            type="button"
+                          >
+                            <button
+                              className="euiButton euiButton--primary euiButton-isDisabled"
+                              disabled={true}
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                  "width": "70%",
+                                }
+                              }
+                              type="button"
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                iconType="plusInCircle"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <EuiIcon
+                                    className="euiButtonContent__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="plusInCircle"
+                                  >
+                                    EuiIconMock
+                                  </EuiIcon>
+                                  <span
+                                    className="euiButton__text"
+                                  >
+                                    Add map
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonDisplay>
+                        </EuiButton>
+                      </div>
+                    </EuiPanel>
+                  </div>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiButton
+                    fullWidth={true}
+                    iconType="plusInCircle"
+                    onClick={[Function]}
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButton"
+                      disabled={false}
+                      element="button"
+                      fullWidth={true}
+                      iconType="plusInCircle"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <button
+                        className="euiButton euiButton--primary euiButton--fullWidth"
+                        disabled={false}
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          iconType="plusInCircle"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="plusInCircle"
+                            >
+                              EuiIconMock
+                            </EuiIcon>
+                            <span
+                              className="euiButton__text"
+                            >
+                              Add selection
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonDisplay>
+                  </EuiButton>
+                  <EuiSpacer>
+                    <div
+                      className="euiSpacer euiSpacer--l"
+                    />
+                  </EuiSpacer>
+                  <EuiFormRow
+                    describedByIds={Array []}
+                    display="row"
+                    fullWidth={false}
+                    hasChildLabel={true}
+                    hasEmptyLabelSpace={false}
+                    label={
+                      <React.Fragment>
+                        <EuiTitle
+                          size="s"
+                        >
+                          <p>
+                            Condition
+                          </p>
+                        </EuiTitle>
+                        <EuiText
+                          size="xs"
+                        >
+                          Define how each selection should be included in the final query. For more options use
+                           
+                          <EuiButtonEmpty
+                            className="empty-text-button"
+                            onClick={[Function]}
+                          >
+                            <EuiText
+                              size="s"
+                            >
+                              YAML editor
+                            </EuiText>
+                          </EuiButtonEmpty>
+                          .
+                        </EuiText>
+                      </React.Fragment>
+                    }
+                    labelType="label"
+                    style={
+                      Object {
+                        "maxWidth": "100%",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFormRow"
+                      id="some_html_id-row"
+                      style={
+                        Object {
+                          "maxWidth": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="euiFormRow__labelWrapper"
+                      >
+                        <EuiFormLabel
+                          className="euiFormRow__label"
+                          htmlFor="some_html_id"
+                          isFocused={false}
+                          type="label"
+                        >
+                          <label
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            <EuiTitle
+                              size="s"
+                            >
+                              <p
+                                className="euiTitle euiTitle--small"
+                              >
+                                Condition
+                              </p>
+                            </EuiTitle>
+                            <EuiText
+                              size="xs"
+                            >
+                              <div
+                                className="euiText euiText--extraSmall"
+                              >
+                                Define how each selection should be included in the final query. For more options use
+                                 
+                                <EuiButtonEmpty
+                                  className="empty-text-button"
+                                  onClick={[Function]}
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="left"
+                                      iconSize="m"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButtonEmpty__content"
+                                      >
+                                        <span
+                                          className="euiButtonEmpty__text"
+                                        >
+                                          <EuiText
+                                            size="s"
+                                          >
+                                            <div
+                                              className="euiText euiText--small"
+                                            >
+                                              YAML editor
+                                            </div>
+                                          </EuiText>
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                                .
+                              </div>
+                            </EuiText>
+                          </label>
+                        </EuiFormLabel>
+                      </div>
+                      <div
+                        className="euiFormRow__fieldWrapper"
+                      >
+                        <EuiCodeEditor
+                          data-test-subj="rule_detection_field"
+                          height="50px"
+                          id="some_html_id"
+                          mode="yaml"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          setOptions={Object {}}
+                          value="Selection_1"
+                          width="600px"
+                        >
+                          <div
+                            className="euiCodeEditorWrapper"
+                            data-test-subj="rule_detection_field"
+                            style={
+                              Object {
+                                "height": "50px",
+                                "width": "600px",
+                              }
+                            }
+                          >
+                            <button
+                              className="euiCodeEditorKeyboardHint"
+                              data-test-subj="codeEditorHint"
+                              id="some_html_id"
+                              onClick={[Function]}
+                            >
+                              <p
+                                className="euiText"
+                              >
+                                <EuiI18n
+                                  default="Press Enter to start editing."
+                                  token="euiCodeEditor.startEditing"
+                                >
+                                  Press Enter to start editing.
+                                </EuiI18n>
+                              </p>
+                              <p
+                                className="euiText"
+                              >
+                                <EuiI18n
+                                  default="When you're done, press Escape to stop editing."
+                                  token="euiCodeEditor.stopEditing"
+                                >
+                                  When you're done, press Escape to stop editing.
+                                </EuiI18n>
+                              </p>
+                            </button>
+                            <ReactAce
+                              commands={
+                                Array [
+                                  Object {
+                                    "bindKey": Object {
+                                      "mac": "Esc",
+                                      "win": "Esc",
+                                    },
+                                    "exec": [Function],
+                                    "name": "stopEditingOnEsc",
+                                  },
+                                ]
+                              }
+                              cursorStart={1}
+                              editorProps={
+                                Object {
+                                  "$blockScrolling": Infinity,
+                                }
+                              }
+                              enableBasicAutocompletion={false}
+                              enableLiveAutocompletion={false}
+                              enableSnippets={false}
+                              focus={false}
+                              fontSize={12}
+                              height="50px"
+                              highlightActiveLine={true}
+                              id="some_html_id"
+                              maxLines={null}
+                              minLines={null}
+                              mode="yaml"
+                              name="some_html_id"
+                              navigateToFileEnd={true}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              onLoad={null}
+                              onPaste={null}
+                              onScroll={null}
+                              placeholder={null}
+                              readOnly={false}
+                              scrollMargin={
+                                Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ]
+                              }
+                              setOptions={Object {}}
+                              showGutter={true}
+                              showPrintMargin={true}
+                              style={Object {}}
+                              tabSize={4}
+                              theme="textmate"
+                              value="Selection_1"
+                              width="600px"
+                              wrapEnabled={false}
+                            >
+                              <div
+                                id="some_html_id"
                                 style={
                                   Object {
                                     "height": "50px",
                                     "width": "600px",
                                   }
                                 }
-                              >
-                                <button
-                                  className="euiCodeEditorKeyboardHint"
-                                  data-test-subj="codeEditorHint"
-                                  id="some_html_id"
-                                  onClick={[Function]}
-                                >
-                                  <p
-                                    className="euiText"
-                                  >
-                                    <EuiI18n
-                                      default="Press Enter to start editing."
-                                      token="euiCodeEditor.startEditing"
-                                    >
-                                      Press Enter to start editing.
-                                    </EuiI18n>
-                                  </p>
-                                  <p
-                                    className="euiText"
-                                  >
-                                    <EuiI18n
-                                      default="When you're done, press Escape to stop editing."
-                                      token="euiCodeEditor.stopEditing"
-                                    >
-                                      When you're done, press Escape to stop editing.
-                                    </EuiI18n>
-                                  </p>
-                                </button>
-                                <ReactAce
-                                  commands={
-                                    Array [
-                                      Object {
-                                        "bindKey": Object {
-                                          "mac": "Esc",
-                                          "win": "Esc",
-                                        },
-                                        "exec": [Function],
-                                        "name": "stopEditingOnEsc",
-                                      },
-                                    ]
-                                  }
-                                  cursorStart={1}
-                                  editorProps={
-                                    Object {
-                                      "$blockScrolling": Infinity,
-                                    }
-                                  }
-                                  enableBasicAutocompletion={false}
-                                  enableLiveAutocompletion={false}
-                                  enableSnippets={false}
-                                  focus={false}
-                                  fontSize={12}
-                                  height="50px"
-                                  highlightActiveLine={true}
-                                  id="some_html_id"
-                                  maxLines={null}
-                                  minLines={null}
-                                  mode="yaml"
-                                  name="some_html_id"
-                                  navigateToFileEnd={true}
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  onLoad={null}
-                                  onPaste={null}
-                                  onScroll={null}
-                                  placeholder={null}
-                                  readOnly={false}
-                                  scrollMargin={
-                                    Array [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                    ]
-                                  }
-                                  setOptions={Object {}}
-                                  showGutter={true}
-                                  showPrintMargin={true}
-                                  style={Object {}}
-                                  tabSize={4}
-                                  theme="textmate"
-                                  value="Selection_1"
-                                  width="600px"
-                                  wrapEnabled={false}
-                                >
-                                  <div
-                                    id="some_html_id"
-                                    style={
-                                      Object {
-                                        "height": "50px",
-                                        "width": "600px",
-                                      }
-                                    }
-                                  />
-                                </ReactAce>
-                              </div>
-                            </EuiCodeEditor>
+                              />
+                            </ReactAce>
                           </div>
-                        </div>
-                      </EuiFormRow>
+                        </EuiCodeEditor>
+                      </div>
                     </div>
-                  </DetectionVisualEditor>
-                  <EuiSpacer
-                    size="xl"
+                  </EuiFormRow>
+                </div>
+              </DetectionVisualEditor>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <div
+                style={
+                  Object {
+                    "maxWidth": 1000,
+                  }
+                }
+              >
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent={
+                    <React.Fragment>
+                      Additional details 
+                      <i>
+                        - optional
+                      </i>
+                    </React.Fragment>
+                  }
+                  id="additional-details"
+                  initialIsOpen={true}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  paddingSize="l"
+                >
+                  <div
+                    className="euiAccordion euiAccordion-isOpen"
                   >
                     <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
-                  <EuiPanel
-                    style={
-                      Object {
-                        "maxWidth": 1000,
-                      }
-                    }
-                  >
-                    <div
-                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                      style={
-                        Object {
-                          "maxWidth": 1000,
-                        }
-                      }
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiAccordion
-                        arrowDisplay="left"
-                        buttonContent={
-                          <React.Fragment>
-                            Additional details 
-                            <i>
-                              - optional
-                            </i>
-                          </React.Fragment>
-                        }
-                        id="additional-details"
-                        initialIsOpen={true}
-                        isLoading={false}
-                        isLoadingMessage={false}
-                        paddingSize="none"
+                      <button
+                        aria-controls="additional-details"
+                        aria-expanded={true}
+                        className="euiAccordion__button"
+                        id="some_html_id"
+                        onClick={[Function]}
+                        type="button"
                       >
-                        <div
-                          className="euiAccordion euiAccordion-isOpen"
+                        <span
+                          className="euiAccordion__iconWrapper"
                         >
-                          <div
-                            className="euiAccordion__triggerWrapper"
+                          <EuiIcon
+                            className="euiAccordion__icon euiAccordion__icon-isOpen"
+                            size="m"
+                            type="arrowRight"
                           >
-                            <button
-                              aria-controls="additional-details"
-                              aria-expanded={true}
-                              className="euiAccordion__button"
-                              id="some_html_id"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="euiAccordion__iconWrapper"
-                              >
-                                <EuiIcon
-                                  className="euiAccordion__icon euiAccordion__icon-isOpen"
-                                  size="m"
-                                  type="arrowRight"
-                                >
-                                  EuiIconMock
-                                </EuiIcon>
-                              </span>
-                              <span
-                                className="euiIEFlexWrapFix"
-                              >
-                                Additional details 
-                                <i>
-                                  - optional
-                                </i>
-                              </span>
-                            </button>
-                          </div>
+                            EuiIconMock
+                          </EuiIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          Additional details 
+                          <i>
+                            - optional
+                          </i>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      aria-labelledby="some_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="additional-details"
+                      role="region"
+                      tabIndex={-1}
+                    >
+                      <EuiResizeObserver
+                        onResize={[Function]}
+                      >
+                        <div>
                           <div
-                            aria-labelledby="some_html_id"
-                            className="euiAccordion__childWrapper"
-                            id="additional-details"
-                            role="region"
-                            tabIndex={-1}
+                            className="euiAccordion__padding--l"
                           >
-                            <EuiResizeObserver
-                              onResize={[Function]}
+                            <div
+                              className="rule-editor-form-additional-details-panel-body"
                             >
-                              <div>
-                                <div
-                                  className=""
+                              <FieldTextArray
+                                addButtonName="Add tag"
+                                data-test-subj="rule_tags_field"
+                                fields={Array []}
+                                label={
+                                  <React.Fragment>
+                                    <EuiText
+                                      size="m"
+                                    >
+                                      <strong>
+                                        Tags 
+                                      </strong>
+                                      <i>
+                                        - optional
+                                      </i>
+                                    </EuiText>
+                                    <EuiSpacer
+                                      size="m"
+                                    />
+                                    <EuiText
+                                      size="xs"
+                                    >
+                                      <strong>
+                                        Tag
+                                      </strong>
+                                    </EuiText>
+                                  </React.Fragment>
+                                }
+                                name="tags"
+                                onChange={[Function]}
+                                placeholder="tag"
+                              >
+                                <EuiFormRow
+                                  describedByIds={Array []}
+                                  display="row"
+                                  error=""
+                                  fullWidth={false}
+                                  hasChildLabel={true}
+                                  hasEmptyLabelSpace={false}
+                                  label={
+                                    <React.Fragment>
+                                      <EuiText
+                                        size="m"
+                                      >
+                                        <strong>
+                                          Tags 
+                                        </strong>
+                                        <i>
+                                          - optional
+                                        </i>
+                                      </EuiText>
+                                      <EuiSpacer
+                                        size="m"
+                                      />
+                                      <EuiText
+                                        size="xs"
+                                      >
+                                        <strong>
+                                          Tag
+                                        </strong>
+                                      </EuiText>
+                                    </React.Fragment>
+                                  }
+                                  labelType="label"
                                 >
                                   <div
-                                    className="rule-editor-form-additional-details-panel-body"
+                                    className="euiFormRow"
+                                    id="some_html_id-row"
                                   >
-                                    <EuiSpacer>
-                                      <div
-                                        className="euiSpacer euiSpacer--l"
-                                      />
-                                    </EuiSpacer>
-                                    <FieldTextArray
-                                      addButtonName="Add tag"
-                                      data-test-subj="rule_tags_field"
-                                      fields={Array []}
-                                      label={
-                                        <React.Fragment>
-                                          <EuiText
-                                            size="m"
-                                          >
-                                            <strong>
-                                              Tags 
-                                            </strong>
-                                            <i>
-                                              - optional
-                                            </i>
-                                          </EuiText>
-                                          <EuiSpacer
-                                            size="m"
-                                          />
-                                          <EuiText
-                                            size="xs"
-                                          >
-                                            <strong>
-                                              Tag
-                                            </strong>
-                                          </EuiText>
-                                        </React.Fragment>
-                                      }
-                                      name="tags"
-                                      onChange={[Function]}
-                                      placeholder="tag"
+                                    <div
+                                      className="euiFormRow__labelWrapper"
                                     >
-                                      <EuiFormRow
-                                        describedByIds={Array []}
-                                        display="row"
-                                        error=""
-                                        fullWidth={false}
-                                        hasChildLabel={true}
-                                        hasEmptyLabelSpace={false}
-                                        label={
-                                          <React.Fragment>
-                                            <EuiText
-                                              size="m"
+                                      <EuiFormLabel
+                                        className="euiFormRow__label"
+                                        htmlFor="some_html_id"
+                                        isFocused={false}
+                                        type="label"
+                                      >
+                                        <label
+                                          className="euiFormLabel euiFormRow__label"
+                                          htmlFor="some_html_id"
+                                        >
+                                          <EuiText
+                                            size="m"
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
                                             >
                                               <strong>
                                                 Tags 
@@ -3126,239 +3094,239 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                               <i>
                                                 - optional
                                               </i>
-                                            </EuiText>
-                                            <EuiSpacer
-                                              size="m"
+                                            </div>
+                                          </EuiText>
+                                          <EuiSpacer
+                                            size="m"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--m"
                                             />
-                                            <EuiText
-                                              size="xs"
+                                          </EuiSpacer>
+                                          <EuiText
+                                            size="xs"
+                                          >
+                                            <div
+                                              className="euiText euiText--extraSmall"
                                             >
                                               <strong>
                                                 Tag
                                               </strong>
-                                            </EuiText>
-                                          </React.Fragment>
-                                        }
-                                        labelType="label"
+                                            </div>
+                                          </EuiText>
+                                        </label>
+                                      </EuiFormLabel>
+                                    </div>
+                                    <div
+                                      className="euiFormRow__fieldWrapper"
+                                    >
+                                      <EuiFlexGroup
+                                        key="0"
                                       >
                                         <div
-                                          className="euiFormRow"
-                                          id="some_html_id-row"
+                                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                                         >
-                                          <div
-                                            className="euiFormRow__labelWrapper"
+                                          <EuiFlexItem
+                                            style={
+                                              Object {
+                                                "minWidth": "100%",
+                                              }
+                                            }
                                           >
-                                            <EuiFormLabel
-                                              className="euiFormRow__label"
-                                              htmlFor="some_html_id"
-                                              isFocused={false}
-                                              type="label"
+                                            <div
+                                              className="euiFlexItem"
+                                              style={
+                                                Object {
+                                                  "minWidth": "100%",
+                                                }
+                                              }
                                             >
-                                              <label
-                                                className="euiFormLabel euiFormRow__label"
-                                                htmlFor="some_html_id"
+                                              <EuiFieldText
+                                                data-test-subj="rule_tags_field_0"
+                                                name="tags"
+                                                onChange={[Function]}
+                                                placeholder="tag"
+                                                value=""
                                               >
-                                                <EuiText
-                                                  size="m"
+                                                <EuiFormControlLayout
+                                                  fullWidth={false}
                                                 >
                                                   <div
-                                                    className="euiText euiText--medium"
+                                                    className="euiFormControlLayout"
                                                   >
-                                                    <strong>
-                                                      Tags 
-                                                    </strong>
-                                                    <i>
-                                                      - optional
-                                                    </i>
-                                                  </div>
-                                                </EuiText>
-                                                <EuiSpacer
-                                                  size="m"
-                                                >
-                                                  <div
-                                                    className="euiSpacer euiSpacer--m"
-                                                  />
-                                                </EuiSpacer>
-                                                <EuiText
-                                                  size="xs"
-                                                >
-                                                  <div
-                                                    className="euiText euiText--extraSmall"
-                                                  >
-                                                    <strong>
-                                                      Tag
-                                                    </strong>
-                                                  </div>
-                                                </EuiText>
-                                              </label>
-                                            </EuiFormLabel>
-                                          </div>
-                                          <div
-                                            className="euiFormRow__fieldWrapper"
-                                          >
-                                            <EuiFlexGroup
-                                              key="0"
-                                            >
-                                              <div
-                                                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                              >
-                                                <EuiFlexItem
-                                                  style={
-                                                    Object {
-                                                      "minWidth": "100%",
-                                                    }
-                                                  }
-                                                >
-                                                  <div
-                                                    className="euiFlexItem"
-                                                    style={
-                                                      Object {
-                                                        "minWidth": "100%",
-                                                      }
-                                                    }
-                                                  >
-                                                    <EuiFieldText
-                                                      data-test-subj="rule_tags_field_0"
-                                                      name="tags"
-                                                      onChange={[Function]}
-                                                      placeholder="tag"
-                                                      value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
                                                     >
-                                                      <EuiFormControlLayout
-                                                        fullWidth={false}
-                                                      >
-                                                        <div
-                                                          className="euiFormControlLayout"
-                                                        >
-                                                          <div
-                                                            className="euiFormControlLayout__childrenWrapper"
-                                                          >
-                                                            <EuiValidatableControl>
-                                                              <input
-                                                                className="euiFieldText"
-                                                                data-test-subj="rule_tags_field_0"
-                                                                name="tags"
-                                                                onChange={[Function]}
-                                                                placeholder="tag"
-                                                                type="text"
-                                                                value=""
-                                                              />
-                                                            </EuiValidatableControl>
-                                                            <EuiFormControlLayoutIcons />
-                                                          </div>
-                                                        </div>
-                                                      </EuiFormControlLayout>
-                                                    </EuiFieldText>
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText"
+                                                          data-test-subj="rule_tags_field_0"
+                                                          name="tags"
+                                                          onChange={[Function]}
+                                                          placeholder="tag"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </EuiFlexItem>
-                                              </div>
-                                            </EuiFlexGroup>
-                                            <EuiSpacer
-                                              size="m"
-                                            >
-                                              <div
-                                                className="euiSpacer euiSpacer--m"
-                                              />
-                                            </EuiSpacer>
-                                            <EuiButton
-                                              className="secondary"
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonDisplay
-                                                baseClassName="euiButton"
-                                                className="secondary"
-                                                disabled={false}
-                                                element="button"
-                                                isDisabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <button
-                                                  className="euiButton euiButton--primary secondary"
-                                                  disabled={false}
-                                                  onClick={[Function]}
-                                                  style={
-                                                    Object {
-                                                      "minWidth": undefined,
-                                                    }
-                                                  }
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButton__content"
-                                                    iconSide="left"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButton__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButton__content"
-                                                    >
-                                                      <span
-                                                        className="euiButton__text"
-                                                      >
-                                                        Add tag
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonDisplay>
-                                            </EuiButton>
-                                          </div>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </div>
+                                          </EuiFlexItem>
                                         </div>
-                                      </EuiFormRow>
-                                      <EuiSpacer>
+                                      </EuiFlexGroup>
+                                      <EuiSpacer
+                                        size="m"
+                                      >
                                         <div
-                                          className="euiSpacer euiSpacer--l"
+                                          className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                    </FieldTextArray>
-                                    <FieldTextArray
-                                      addButtonName="Add URL"
-                                      data-test-subj="rule_references_field"
-                                      fields={Array []}
-                                      label={
-                                        <React.Fragment>
-                                          <EuiText
-                                            size="m"
+                                      <EuiButton
+                                        className="secondary"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="secondary"
+                                          disabled={false}
+                                          element="button"
+                                          isDisabled={false}
+                                          onClick={[Function]}
+                                          type="button"
+                                        >
+                                          <button
+                                            className="euiButton euiButton--primary secondary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            style={
+                                              Object {
+                                                "minWidth": undefined,
+                                              }
+                                            }
+                                            type="button"
                                           >
-                                            <strong>
-                                              References 
-                                            </strong>
-                                            <i>
-                                              - optional
-                                            </i>
-                                          </EuiText>
-                                          <EuiSpacer
-                                            size="m"
-                                          />
-                                          <EuiText
-                                            size="xs"
-                                          >
-                                            <strong>
-                                              URL
-                                            </strong>
-                                          </EuiText>
-                                        </React.Fragment>
-                                      }
-                                      name="references"
-                                      onChange={[Function]}
-                                      placeholder="http://"
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButton__content"
+                                              >
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Add tag
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </div>
+                                  </div>
+                                </EuiFormRow>
+                                <EuiSpacer>
+                                  <div
+                                    className="euiSpacer euiSpacer--l"
+                                  />
+                                </EuiSpacer>
+                              </FieldTextArray>
+                              <FieldTextArray
+                                addButtonName="Add URL"
+                                data-test-subj="rule_references_field"
+                                fields={Array []}
+                                label={
+                                  <React.Fragment>
+                                    <EuiText
+                                      size="m"
                                     >
-                                      <EuiFormRow
-                                        describedByIds={Array []}
-                                        display="row"
-                                        error=""
-                                        fullWidth={false}
-                                        hasChildLabel={true}
-                                        hasEmptyLabelSpace={false}
-                                        label={
-                                          <React.Fragment>
-                                            <EuiText
-                                              size="m"
+                                      <strong>
+                                        References 
+                                      </strong>
+                                      <i>
+                                        - optional
+                                      </i>
+                                    </EuiText>
+                                    <EuiSpacer
+                                      size="m"
+                                    />
+                                    <EuiText
+                                      size="xs"
+                                    >
+                                      <strong>
+                                        URL
+                                      </strong>
+                                    </EuiText>
+                                  </React.Fragment>
+                                }
+                                name="references"
+                                onChange={[Function]}
+                                placeholder="http://"
+                              >
+                                <EuiFormRow
+                                  describedByIds={Array []}
+                                  display="row"
+                                  error=""
+                                  fullWidth={false}
+                                  hasChildLabel={true}
+                                  hasEmptyLabelSpace={false}
+                                  label={
+                                    <React.Fragment>
+                                      <EuiText
+                                        size="m"
+                                      >
+                                        <strong>
+                                          References 
+                                        </strong>
+                                        <i>
+                                          - optional
+                                        </i>
+                                      </EuiText>
+                                      <EuiSpacer
+                                        size="m"
+                                      />
+                                      <EuiText
+                                        size="xs"
+                                      >
+                                        <strong>
+                                          URL
+                                        </strong>
+                                      </EuiText>
+                                    </React.Fragment>
+                                  }
+                                  labelType="label"
+                                >
+                                  <div
+                                    className="euiFormRow"
+                                    id="some_html_id-row"
+                                  >
+                                    <div
+                                      className="euiFormRow__labelWrapper"
+                                    >
+                                      <EuiFormLabel
+                                        className="euiFormRow__label"
+                                        htmlFor="some_html_id"
+                                        isFocused={false}
+                                        type="label"
+                                      >
+                                        <label
+                                          className="euiFormLabel euiFormRow__label"
+                                          htmlFor="some_html_id"
+                                        >
+                                          <EuiText
+                                            size="m"
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
                                             >
                                               <strong>
                                                 References 
@@ -3366,239 +3334,239 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                               <i>
                                                 - optional
                                               </i>
-                                            </EuiText>
-                                            <EuiSpacer
-                                              size="m"
+                                            </div>
+                                          </EuiText>
+                                          <EuiSpacer
+                                            size="m"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--m"
                                             />
-                                            <EuiText
-                                              size="xs"
+                                          </EuiSpacer>
+                                          <EuiText
+                                            size="xs"
+                                          >
+                                            <div
+                                              className="euiText euiText--extraSmall"
                                             >
                                               <strong>
                                                 URL
                                               </strong>
-                                            </EuiText>
-                                          </React.Fragment>
-                                        }
-                                        labelType="label"
+                                            </div>
+                                          </EuiText>
+                                        </label>
+                                      </EuiFormLabel>
+                                    </div>
+                                    <div
+                                      className="euiFormRow__fieldWrapper"
+                                    >
+                                      <EuiFlexGroup
+                                        key="0"
                                       >
                                         <div
-                                          className="euiFormRow"
-                                          id="some_html_id-row"
+                                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                                         >
-                                          <div
-                                            className="euiFormRow__labelWrapper"
+                                          <EuiFlexItem
+                                            style={
+                                              Object {
+                                                "minWidth": "100%",
+                                              }
+                                            }
                                           >
-                                            <EuiFormLabel
-                                              className="euiFormRow__label"
-                                              htmlFor="some_html_id"
-                                              isFocused={false}
-                                              type="label"
+                                            <div
+                                              className="euiFlexItem"
+                                              style={
+                                                Object {
+                                                  "minWidth": "100%",
+                                                }
+                                              }
                                             >
-                                              <label
-                                                className="euiFormLabel euiFormRow__label"
-                                                htmlFor="some_html_id"
+                                              <EuiFieldText
+                                                data-test-subj="rule_references_field_0"
+                                                name="references"
+                                                onChange={[Function]}
+                                                placeholder="http://"
+                                                value=""
                                               >
-                                                <EuiText
-                                                  size="m"
+                                                <EuiFormControlLayout
+                                                  fullWidth={false}
                                                 >
                                                   <div
-                                                    className="euiText euiText--medium"
+                                                    className="euiFormControlLayout"
                                                   >
-                                                    <strong>
-                                                      References 
-                                                    </strong>
-                                                    <i>
-                                                      - optional
-                                                    </i>
-                                                  </div>
-                                                </EuiText>
-                                                <EuiSpacer
-                                                  size="m"
-                                                >
-                                                  <div
-                                                    className="euiSpacer euiSpacer--m"
-                                                  />
-                                                </EuiSpacer>
-                                                <EuiText
-                                                  size="xs"
-                                                >
-                                                  <div
-                                                    className="euiText euiText--extraSmall"
-                                                  >
-                                                    <strong>
-                                                      URL
-                                                    </strong>
-                                                  </div>
-                                                </EuiText>
-                                              </label>
-                                            </EuiFormLabel>
-                                          </div>
-                                          <div
-                                            className="euiFormRow__fieldWrapper"
-                                          >
-                                            <EuiFlexGroup
-                                              key="0"
-                                            >
-                                              <div
-                                                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                              >
-                                                <EuiFlexItem
-                                                  style={
-                                                    Object {
-                                                      "minWidth": "100%",
-                                                    }
-                                                  }
-                                                >
-                                                  <div
-                                                    className="euiFlexItem"
-                                                    style={
-                                                      Object {
-                                                        "minWidth": "100%",
-                                                      }
-                                                    }
-                                                  >
-                                                    <EuiFieldText
-                                                      data-test-subj="rule_references_field_0"
-                                                      name="references"
-                                                      onChange={[Function]}
-                                                      placeholder="http://"
-                                                      value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
                                                     >
-                                                      <EuiFormControlLayout
-                                                        fullWidth={false}
-                                                      >
-                                                        <div
-                                                          className="euiFormControlLayout"
-                                                        >
-                                                          <div
-                                                            className="euiFormControlLayout__childrenWrapper"
-                                                          >
-                                                            <EuiValidatableControl>
-                                                              <input
-                                                                className="euiFieldText"
-                                                                data-test-subj="rule_references_field_0"
-                                                                name="references"
-                                                                onChange={[Function]}
-                                                                placeholder="http://"
-                                                                type="text"
-                                                                value=""
-                                                              />
-                                                            </EuiValidatableControl>
-                                                            <EuiFormControlLayoutIcons />
-                                                          </div>
-                                                        </div>
-                                                      </EuiFormControlLayout>
-                                                    </EuiFieldText>
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText"
+                                                          data-test-subj="rule_references_field_0"
+                                                          name="references"
+                                                          onChange={[Function]}
+                                                          placeholder="http://"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </EuiFlexItem>
-                                              </div>
-                                            </EuiFlexGroup>
-                                            <EuiSpacer
-                                              size="m"
-                                            >
-                                              <div
-                                                className="euiSpacer euiSpacer--m"
-                                              />
-                                            </EuiSpacer>
-                                            <EuiButton
-                                              className="secondary"
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonDisplay
-                                                baseClassName="euiButton"
-                                                className="secondary"
-                                                disabled={false}
-                                                element="button"
-                                                isDisabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <button
-                                                  className="euiButton euiButton--primary secondary"
-                                                  disabled={false}
-                                                  onClick={[Function]}
-                                                  style={
-                                                    Object {
-                                                      "minWidth": undefined,
-                                                    }
-                                                  }
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButton__content"
-                                                    iconSide="left"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButton__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButton__content"
-                                                    >
-                                                      <span
-                                                        className="euiButton__text"
-                                                      >
-                                                        Add URL
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonDisplay>
-                                            </EuiButton>
-                                          </div>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </div>
+                                          </EuiFlexItem>
                                         </div>
-                                      </EuiFormRow>
-                                      <EuiSpacer>
+                                      </EuiFlexGroup>
+                                      <EuiSpacer
+                                        size="m"
+                                      >
                                         <div
-                                          className="euiSpacer euiSpacer--l"
+                                          className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                    </FieldTextArray>
-                                    <FieldTextArray
-                                      addButtonName="Add false positive"
-                                      data-test-subj="rule_falsePositives_field"
-                                      fields={Array []}
-                                      label={
-                                        <React.Fragment>
-                                          <EuiText
-                                            size="m"
+                                      <EuiButton
+                                        className="secondary"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="secondary"
+                                          disabled={false}
+                                          element="button"
+                                          isDisabled={false}
+                                          onClick={[Function]}
+                                          type="button"
+                                        >
+                                          <button
+                                            className="euiButton euiButton--primary secondary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            style={
+                                              Object {
+                                                "minWidth": undefined,
+                                              }
+                                            }
+                                            type="button"
                                           >
-                                            <strong>
-                                              False positive cases 
-                                            </strong>
-                                            <i>
-                                              - optional
-                                            </i>
-                                          </EuiText>
-                                          <EuiSpacer
-                                            size="m"
-                                          />
-                                          <EuiText
-                                            size="xs"
-                                          >
-                                            <strong>
-                                              Description
-                                            </strong>
-                                          </EuiText>
-                                        </React.Fragment>
-                                      }
-                                      name="false_positives"
-                                      onChange={[Function]}
-                                      placeholder="format?"
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButton__content"
+                                              >
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Add URL
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </div>
+                                  </div>
+                                </EuiFormRow>
+                                <EuiSpacer>
+                                  <div
+                                    className="euiSpacer euiSpacer--l"
+                                  />
+                                </EuiSpacer>
+                              </FieldTextArray>
+                              <FieldTextArray
+                                addButtonName="Add false positive"
+                                data-test-subj="rule_falsePositives_field"
+                                fields={Array []}
+                                label={
+                                  <React.Fragment>
+                                    <EuiText
+                                      size="m"
                                     >
-                                      <EuiFormRow
-                                        describedByIds={Array []}
-                                        display="row"
-                                        error=""
-                                        fullWidth={false}
-                                        hasChildLabel={true}
-                                        hasEmptyLabelSpace={false}
-                                        label={
-                                          <React.Fragment>
-                                            <EuiText
-                                              size="m"
+                                      <strong>
+                                        False positive cases 
+                                      </strong>
+                                      <i>
+                                        - optional
+                                      </i>
+                                    </EuiText>
+                                    <EuiSpacer
+                                      size="m"
+                                    />
+                                    <EuiText
+                                      size="xs"
+                                    >
+                                      <strong>
+                                        Description
+                                      </strong>
+                                    </EuiText>
+                                  </React.Fragment>
+                                }
+                                name="false_positives"
+                                onChange={[Function]}
+                                placeholder="format?"
+                              >
+                                <EuiFormRow
+                                  describedByIds={Array []}
+                                  display="row"
+                                  error=""
+                                  fullWidth={false}
+                                  hasChildLabel={true}
+                                  hasEmptyLabelSpace={false}
+                                  label={
+                                    <React.Fragment>
+                                      <EuiText
+                                        size="m"
+                                      >
+                                        <strong>
+                                          False positive cases 
+                                        </strong>
+                                        <i>
+                                          - optional
+                                        </i>
+                                      </EuiText>
+                                      <EuiSpacer
+                                        size="m"
+                                      />
+                                      <EuiText
+                                        size="xs"
+                                      >
+                                        <strong>
+                                          Description
+                                        </strong>
+                                      </EuiText>
+                                    </React.Fragment>
+                                  }
+                                  labelType="label"
+                                >
+                                  <div
+                                    className="euiFormRow"
+                                    id="some_html_id-row"
+                                  >
+                                    <div
+                                      className="euiFormRow__labelWrapper"
+                                    >
+                                      <EuiFormLabel
+                                        className="euiFormRow__label"
+                                        htmlFor="some_html_id"
+                                        isFocused={false}
+                                        type="label"
+                                      >
+                                        <label
+                                          className="euiFormLabel euiFormRow__label"
+                                          htmlFor="some_html_id"
+                                        >
+                                          <EuiText
+                                            size="m"
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
                                             >
                                               <strong>
                                                 False positive cases 
@@ -3606,209 +3574,162 @@ exports[`<RuleEditorContainer /> spec renders the component 1`] = `
                                               <i>
                                                 - optional
                                               </i>
-                                            </EuiText>
-                                            <EuiSpacer
-                                              size="m"
+                                            </div>
+                                          </EuiText>
+                                          <EuiSpacer
+                                            size="m"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--m"
                                             />
-                                            <EuiText
-                                              size="xs"
+                                          </EuiSpacer>
+                                          <EuiText
+                                            size="xs"
+                                          >
+                                            <div
+                                              className="euiText euiText--extraSmall"
                                             >
                                               <strong>
                                                 Description
                                               </strong>
-                                            </EuiText>
-                                          </React.Fragment>
-                                        }
-                                        labelType="label"
+                                            </div>
+                                          </EuiText>
+                                        </label>
+                                      </EuiFormLabel>
+                                    </div>
+                                    <div
+                                      className="euiFormRow__fieldWrapper"
+                                    >
+                                      <EuiFlexGroup
+                                        key="0"
                                       >
                                         <div
-                                          className="euiFormRow"
-                                          id="some_html_id-row"
+                                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                                         >
-                                          <div
-                                            className="euiFormRow__labelWrapper"
+                                          <EuiFlexItem
+                                            style={
+                                              Object {
+                                                "minWidth": "100%",
+                                              }
+                                            }
                                           >
-                                            <EuiFormLabel
-                                              className="euiFormRow__label"
-                                              htmlFor="some_html_id"
-                                              isFocused={false}
-                                              type="label"
+                                            <div
+                                              className="euiFlexItem"
+                                              style={
+                                                Object {
+                                                  "minWidth": "100%",
+                                                }
+                                              }
                                             >
-                                              <label
-                                                className="euiFormLabel euiFormRow__label"
-                                                htmlFor="some_html_id"
+                                              <EuiFieldText
+                                                data-test-subj="rule_false_positives_field_0"
+                                                name="false_positives"
+                                                onChange={[Function]}
+                                                placeholder="format?"
+                                                value=""
                                               >
-                                                <EuiText
-                                                  size="m"
+                                                <EuiFormControlLayout
+                                                  fullWidth={false}
                                                 >
                                                   <div
-                                                    className="euiText euiText--medium"
+                                                    className="euiFormControlLayout"
                                                   >
-                                                    <strong>
-                                                      False positive cases 
-                                                    </strong>
-                                                    <i>
-                                                      - optional
-                                                    </i>
-                                                  </div>
-                                                </EuiText>
-                                                <EuiSpacer
-                                                  size="m"
-                                                >
-                                                  <div
-                                                    className="euiSpacer euiSpacer--m"
-                                                  />
-                                                </EuiSpacer>
-                                                <EuiText
-                                                  size="xs"
-                                                >
-                                                  <div
-                                                    className="euiText euiText--extraSmall"
-                                                  >
-                                                    <strong>
-                                                      Description
-                                                    </strong>
-                                                  </div>
-                                                </EuiText>
-                                              </label>
-                                            </EuiFormLabel>
-                                          </div>
-                                          <div
-                                            className="euiFormRow__fieldWrapper"
-                                          >
-                                            <EuiFlexGroup
-                                              key="0"
-                                            >
-                                              <div
-                                                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                              >
-                                                <EuiFlexItem
-                                                  style={
-                                                    Object {
-                                                      "minWidth": "100%",
-                                                    }
-                                                  }
-                                                >
-                                                  <div
-                                                    className="euiFlexItem"
-                                                    style={
-                                                      Object {
-                                                        "minWidth": "100%",
-                                                      }
-                                                    }
-                                                  >
-                                                    <EuiFieldText
-                                                      data-test-subj="rule_false_positives_field_0"
-                                                      name="false_positives"
-                                                      onChange={[Function]}
-                                                      placeholder="format?"
-                                                      value=""
+                                                    <div
+                                                      className="euiFormControlLayout__childrenWrapper"
                                                     >
-                                                      <EuiFormControlLayout
-                                                        fullWidth={false}
-                                                      >
-                                                        <div
-                                                          className="euiFormControlLayout"
-                                                        >
-                                                          <div
-                                                            className="euiFormControlLayout__childrenWrapper"
-                                                          >
-                                                            <EuiValidatableControl>
-                                                              <input
-                                                                className="euiFieldText"
-                                                                data-test-subj="rule_false_positives_field_0"
-                                                                name="false_positives"
-                                                                onChange={[Function]}
-                                                                placeholder="format?"
-                                                                type="text"
-                                                                value=""
-                                                              />
-                                                            </EuiValidatableControl>
-                                                            <EuiFormControlLayoutIcons />
-                                                          </div>
-                                                        </div>
-                                                      </EuiFormControlLayout>
-                                                    </EuiFieldText>
+                                                      <EuiValidatableControl>
+                                                        <input
+                                                          className="euiFieldText"
+                                                          data-test-subj="rule_false_positives_field_0"
+                                                          name="false_positives"
+                                                          onChange={[Function]}
+                                                          placeholder="format?"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                      </EuiValidatableControl>
+                                                      <EuiFormControlLayoutIcons />
+                                                    </div>
                                                   </div>
-                                                </EuiFlexItem>
-                                              </div>
-                                            </EuiFlexGroup>
-                                            <EuiSpacer
-                                              size="m"
-                                            >
-                                              <div
-                                                className="euiSpacer euiSpacer--m"
-                                              />
-                                            </EuiSpacer>
-                                            <EuiButton
-                                              className="secondary"
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonDisplay
-                                                baseClassName="euiButton"
-                                                className="secondary"
-                                                disabled={false}
-                                                element="button"
-                                                isDisabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <button
-                                                  className="euiButton euiButton--primary secondary"
-                                                  disabled={false}
-                                                  onClick={[Function]}
-                                                  style={
-                                                    Object {
-                                                      "minWidth": undefined,
-                                                    }
-                                                  }
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButton__content"
-                                                    iconSide="left"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButton__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButton__content"
-                                                    >
-                                                      <span
-                                                        className="euiButton__text"
-                                                      >
-                                                        Add false positive
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonDisplay>
-                                            </EuiButton>
-                                          </div>
+                                                </EuiFormControlLayout>
+                                              </EuiFieldText>
+                                            </div>
+                                          </EuiFlexItem>
                                         </div>
-                                      </EuiFormRow>
-                                      <EuiSpacer>
+                                      </EuiFlexGroup>
+                                      <EuiSpacer
+                                        size="m"
+                                      >
                                         <div
-                                          className="euiSpacer euiSpacer--l"
+                                          className="euiSpacer euiSpacer--m"
                                         />
                                       </EuiSpacer>
-                                    </FieldTextArray>
+                                      <EuiButton
+                                        className="secondary"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiButtonDisplay
+                                          baseClassName="euiButton"
+                                          className="secondary"
+                                          disabled={false}
+                                          element="button"
+                                          isDisabled={false}
+                                          onClick={[Function]}
+                                          type="button"
+                                        >
+                                          <button
+                                            className="euiButton euiButton--primary secondary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            style={
+                                              Object {
+                                                "minWidth": undefined,
+                                              }
+                                            }
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButton__content"
+                                              iconSide="left"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButton__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButton__content"
+                                              >
+                                                <span
+                                                  className="euiButton__text"
+                                                >
+                                                  Add false positive
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonDisplay>
+                                      </EuiButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </div>
-                            </EuiResizeObserver>
+                                </EuiFormRow>
+                                <EuiSpacer>
+                                  <div
+                                    className="euiSpacer euiSpacer--l"
+                                  />
+                                </EuiSpacer>
+                              </FieldTextArray>
+                            </div>
                           </div>
                         </div>
-                      </EuiAccordion>
+                      </EuiResizeObserver>
                     </div>
-                  </EuiPanel>
-                </div>
+                  </div>
+                </EuiAccordion>
               </div>
-            </EuiPanel>
-          </ContentPanel>
+            </div>
+          </EuiPanel>
           <EuiSpacer>
             <div
               className="euiSpacer euiSpacer--l"

--- a/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorForm.test.tsx.snap
+++ b/public/pages/Rules/components/RuleEditor/__snapshots__/RuleEditorForm.test.tsx.snap
@@ -57,2653 +57,623 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
       <form
         action="#"
       >
-        <ContentPanel
+        <EuiPanel
           className="rule-editor-form"
-          title="title"
         >
-          <EuiPanel
-            className="rule-editor-form"
-            style={
-              Object {
-                "paddingLeft": "0px",
-                "paddingRight": "0px",
-              }
-            }
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow rule-editor-form"
           >
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow rule-editor-form"
-              style={
-                Object {
-                  "paddingLeft": "0px",
-                  "paddingRight": "0px",
-                }
+            <PageHeader>
+              <EuiTitle>
+                <h3
+                  className="euiTitle euiTitle--medium"
+                >
+                  title
+                </h3>
+              </EuiTitle>
+            </PageHeader>
+            <EuiButtonGroup
+              data-test-subj="change-editor-type"
+              idSelected="visual"
+              legend="This is editor type selector"
+              onChange={[Function]}
+              options={
+                Array [
+                  Object {
+                    "id": "visual",
+                    "label": "Visual Editor",
+                  },
+                  Object {
+                    "id": "yaml",
+                    "label": "YAML Editor",
+                  },
+                ]
               }
             >
-              <EuiFlexGroup
-                alignItems="center"
-                justifyContent="spaceBetween"
-                style={
-                  Object {
-                    "padding": "0px 10px",
-                  }
-                }
+              <fieldset
+                className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                data-test-subj="change-editor-type"
+                disabled={false}
               >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-                  style={
-                    Object {
-                      "padding": "0px 10px",
-                    }
-                  }
-                >
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiTitle
-                        size="m"
-                      >
-                        <h3
-                          className="euiTitle euiTitle--medium"
-                        >
-                          title
-                        </h3>
-                      </EuiTitle>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiHorizontalRule
-                margin="xs"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-                />
-              </EuiHorizontalRule>
-              <div
-                style={
-                  Object {
-                    "padding": "0px 10px",
-                  }
-                }
-              >
-                <EuiButtonGroup
-                  data-test-subj="change-editor-type"
-                  idSelected="visual"
-                  legend="This is editor type selector"
-                  onChange={[Function]}
-                  options={
-                    Array [
-                      Object {
-                        "id": "visual",
-                        "label": "Visual Editor",
-                      },
-                      Object {
-                        "id": "yaml",
-                        "label": "YAML Editor",
-                      },
-                    ]
-                  }
-                >
-                  <fieldset
-                    className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                    data-test-subj="change-editor-type"
-                    disabled={false}
+                <EuiScreenReaderOnly>
+                  <legend
+                    className="euiScreenReaderOnly"
                   >
-                    <EuiScreenReaderOnly>
-                      <legend
-                        className="euiScreenReaderOnly"
-                      >
-                        This is editor type selector
-                      </legend>
-                    </EuiScreenReaderOnly>
-                    <div
-                      className="euiButtonGroup__buttons"
+                    This is editor type selector
+                  </legend>
+                </EuiScreenReaderOnly>
+                <div
+                  className="euiButtonGroup__buttons"
+                >
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="visual"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={true}
+                    key="0"
+                    label="Visual Editor"
+                    name="some_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className="euiButtonGroupButton-isSelected"
+                      color="text"
+                      element="label"
+                      fill={true}
+                      htmlFor="some_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Visual Editor",
+                          "ref": [Function],
+                          "title": "Visual Editor",
+                        }
+                      }
                     >
-                      <EuiButtonGroupButton
-                        color="text"
-                        element="label"
-                        id="visual"
-                        isDisabled={false}
-                        isIconOnly={false}
-                        isSelected={true}
-                        key="0"
-                        label="Visual Editor"
-                        name="some_html_id"
-                        onChange={[Function]}
-                        size="s"
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                        disabled={false}
+                        htmlFor="some_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
                       >
-                        <EuiButtonDisplay
-                          baseClassName="euiButtonGroupButton"
-                          className="euiButtonGroupButton-isSelected"
-                          color="text"
-                          element="label"
-                          fill={true}
-                          htmlFor="some_html_id"
-                          isDisabled={false}
-                          onClick={[Function]}
-                          size="s"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
                           textProps={
                             Object {
-                              "className": "euiButtonGroupButton__textShift",
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
                               "data-text": "Visual Editor",
                               "ref": [Function],
                               "title": "Visual Editor",
                             }
                           }
                         >
-                          <label
-                            className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                            disabled={false}
-                            htmlFor="some_html_id"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "minWidth": undefined,
-                              }
-                            }
+                          <span
+                            className="euiButtonContent euiButton__content"
                           >
-                            <EuiButtonContent
-                              className="euiButton__content"
-                              iconSide="left"
-                              textProps={
-                                Object {
-                                  "className": "euiButton__text euiButtonGroupButton__textShift",
-                                  "data-text": "Visual Editor",
-                                  "ref": [Function],
-                                  "title": "Visual Editor",
-                                }
-                              }
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Visual Editor"
+                              title="Visual Editor"
                             >
-                              <span
-                                className="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  className="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Visual Editor"
-                                  title="Visual Editor"
-                                >
-                                  <input
-                                    checked={true}
-                                    className="euiScreenReaderOnly"
-                                    data-test-subj="visual"
-                                    disabled={false}
-                                    id="some_html_id"
-                                    name="some_html_id"
-                                    onChange={[Function]}
-                                    type="radio"
-                                  />
-                                  Visual Editor
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </label>
-                        </EuiButtonDisplay>
-                      </EuiButtonGroupButton>
-                      <EuiButtonGroupButton
-                        color="text"
-                        element="label"
-                        id="yaml"
-                        isDisabled={false}
-                        isIconOnly={false}
-                        isSelected={false}
-                        key="1"
-                        label="YAML Editor"
-                        name="some_html_id"
-                        onChange={[Function]}
-                        size="s"
+                              <input
+                                checked={true}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="visual"
+                                disabled={false}
+                                id="some_html_id"
+                                name="some_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Visual Editor
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="yaml"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={false}
+                    key="1"
+                    label="YAML Editor"
+                    name="some_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className=""
+                      color="text"
+                      element="label"
+                      fill={false}
+                      htmlFor="some_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "YAML Editor",
+                          "ref": [Function],
+                          "title": "YAML Editor",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                        disabled={false}
+                        htmlFor="some_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
                       >
-                        <EuiButtonDisplay
-                          baseClassName="euiButtonGroupButton"
-                          className=""
-                          color="text"
-                          element="label"
-                          fill={false}
-                          htmlFor="some_html_id"
-                          isDisabled={false}
-                          onClick={[Function]}
-                          size="s"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
                           textProps={
                             Object {
-                              "className": "euiButtonGroupButton__textShift",
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
                               "data-text": "YAML Editor",
                               "ref": [Function],
                               "title": "YAML Editor",
                             }
                           }
                         >
-                          <label
-                            className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                            disabled={false}
-                            htmlFor="some_html_id"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "minWidth": undefined,
-                              }
-                            }
+                          <span
+                            className="euiButtonContent euiButton__content"
                           >
-                            <EuiButtonContent
-                              className="euiButton__content"
-                              iconSide="left"
-                              textProps={
-                                Object {
-                                  "className": "euiButton__text euiButtonGroupButton__textShift",
-                                  "data-text": "YAML Editor",
-                                  "ref": [Function],
-                                  "title": "YAML Editor",
-                                }
-                              }
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="YAML Editor"
+                              title="YAML Editor"
                             >
-                              <span
-                                className="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  className="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="YAML Editor"
-                                  title="YAML Editor"
-                                >
-                                  <input
-                                    checked={false}
-                                    className="euiScreenReaderOnly"
-                                    data-test-subj="yaml"
-                                    disabled={false}
-                                    id="some_html_id"
-                                    name="some_html_id"
-                                    onChange={[Function]}
-                                    type="radio"
-                                  />
-                                  YAML Editor
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </label>
-                        </EuiButtonDisplay>
-                      </EuiButtonGroupButton>
-                    </div>
-                  </fieldset>
-                </EuiButtonGroup>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <FormSubmissionErrorToastNotification
-                  notifications={
-                    Object {
-                      "toasts": Object {
-                        "addDanger": [MockFunction],
-                        "addInfo": [MockFunction],
-                        "addSuccess": [MockFunction],
-                        "addWarning": [MockFunction],
-                      },
-                    }
-                  }
-                />
-                <EuiTitle>
-                  <EuiText
-                    className="euiTitle euiTitle--medium"
-                  >
-                    <div
-                      className="euiText euiText--medium euiTitle euiTitle--medium"
-                    >
-                      <h2>
-                        Rule overview
-                      </h2>
-                    </div>
-                  </EuiText>
-                </EuiTitle>
-                <EuiSpacer>
-                  <div
-                    className="euiSpacer euiSpacer--l"
-                  />
-                </EuiSpacer>
-                <EuiFormRow
-                  describedByIds={Array []}
-                  display="row"
-                  fullWidth={false}
-                  hasChildLabel={true}
-                  hasEmptyLabelSpace={false}
-                  helpText="Rule name can be max 256 characters."
-                  label={
-                    <EuiText
-                      size="s"
-                    >
-                      <strong>
-                        Rule name
-                      </strong>
-                    </EuiText>
-                  }
-                  labelType="label"
-                >
-                  <div
-                    className="euiFormRow"
-                    id="some_html_id-row"
-                  >
-                    <div
-                      className="euiFormRow__labelWrapper"
-                    >
-                      <EuiFormLabel
-                        className="euiFormRow__label"
-                        htmlFor="some_html_id"
-                        isFocused={false}
-                        type="label"
-                      >
-                        <label
-                          className="euiFormLabel euiFormRow__label"
-                          htmlFor="some_html_id"
-                        >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              <strong>
-                                Rule name
-                              </strong>
-                            </div>
-                          </EuiText>
-                        </label>
-                      </EuiFormLabel>
-                    </div>
-                    <div
-                      className="euiFormRow__fieldWrapper"
-                    >
-                      <EuiFieldText
-                        aria-describedby="some_html_id-help-0"
-                        data-test-subj="rule_name_field"
-                        id="some_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="My custom rule"
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          fullWidth={false}
-                          inputId="some_html_id"
-                        >
-                          <div
-                            className="euiFormControlLayout"
-                          >
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl>
-                                <input
-                                  aria-describedby="some_html_id-help-0"
-                                  className="euiFieldText"
-                                  data-test-subj="rule_name_field"
-                                  id="some_html_id"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  placeholder="My custom rule"
-                                  type="text"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiFieldText>
-                      <EuiFormHelpText
-                        className="euiFormRow__text"
-                        id="some_html_id-help-0"
-                        key="Rule name can be max 256 characters."
-                      >
-                        <div
-                          className="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
-                        >
-                          Rule name can be max 256 characters.
-                        </div>
-                      </EuiFormHelpText>
-                    </div>
-                  </div>
-                </EuiFormRow>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiFormRow
-                  describedByIds={Array []}
-                  display="row"
-                  fullWidth={false}
-                  hasChildLabel={true}
-                  hasEmptyLabelSpace={false}
-                  label={
-                    <EuiText
-                      size="s"
-                    >
-                      <strong>
-                        Description 
-                      </strong>
-                      <i>
-                        - optional
-                      </i>
-                    </EuiText>
-                  }
-                  labelType="label"
-                >
-                  <div
-                    className="euiFormRow"
-                    id="some_html_id-row"
-                  >
-                    <div
-                      className="euiFormRow__labelWrapper"
-                    >
-                      <EuiFormLabel
-                        className="euiFormRow__label"
-                        htmlFor="some_html_id"
-                        isFocused={false}
-                        type="label"
-                      >
-                        <label
-                          className="euiFormLabel euiFormRow__label"
-                          htmlFor="some_html_id"
-                        >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              <strong>
-                                Description 
-                              </strong>
-                              <i>
-                                - optional
-                              </i>
-                            </div>
-                          </EuiText>
-                        </label>
-                      </EuiFormLabel>
-                    </div>
-                    <div
-                      className="euiFormRow__fieldWrapper"
-                    >
-                      <EuiFieldText
-                        data-test-subj="rule_description_field"
-                        id="some_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="Detects ..."
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          fullWidth={false}
-                          inputId="some_html_id"
-                        >
-                          <div
-                            className="euiFormControlLayout"
-                          >
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldText"
-                                  data-test-subj="rule_description_field"
-                                  id="some_html_id"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  placeholder="Detects ..."
-                                  type="text"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiFieldText>
-                    </div>
-                  </div>
-                </EuiFormRow>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiFormRow
-                  describedByIds={Array []}
-                  display="row"
-                  fullWidth={false}
-                  hasChildLabel={true}
-                  hasEmptyLabelSpace={false}
-                  helpText="Combine multiple authors separated with a comma"
-                  label={
-                    <EuiText
-                      size="s"
-                    >
-                      <strong>
-                        Author
-                      </strong>
-                    </EuiText>
-                  }
-                  labelType="label"
-                >
-                  <div
-                    className="euiFormRow"
-                    id="some_html_id-row"
-                  >
-                    <div
-                      className="euiFormRow__labelWrapper"
-                    >
-                      <EuiFormLabel
-                        className="euiFormRow__label"
-                        htmlFor="some_html_id"
-                        isFocused={false}
-                        type="label"
-                      >
-                        <label
-                          className="euiFormLabel euiFormRow__label"
-                          htmlFor="some_html_id"
-                        >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              <strong>
-                                Author
-                              </strong>
-                            </div>
-                          </EuiText>
-                        </label>
-                      </EuiFormLabel>
-                    </div>
-                    <div
-                      className="euiFormRow__fieldWrapper"
-                    >
-                      <EuiFieldText
-                        aria-describedby="some_html_id-help-0"
-                        data-test-subj="rule_author_field"
-                        id="some_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="Enter author name"
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          fullWidth={false}
-                          inputId="some_html_id"
-                        >
-                          <div
-                            className="euiFormControlLayout"
-                          >
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl>
-                                <input
-                                  aria-describedby="some_html_id-help-0"
-                                  className="euiFieldText"
-                                  data-test-subj="rule_author_field"
-                                  id="some_html_id"
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  placeholder="Enter author name"
-                                  type="text"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiFieldText>
-                      <EuiFormHelpText
-                        className="euiFormRow__text"
-                        id="some_html_id-help-0"
-                        key="Combine multiple authors separated with a comma"
-                      >
-                        <div
-                          className="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
-                        >
-                          Combine multiple authors separated with a comma
-                        </div>
-                      </EuiFormHelpText>
-                    </div>
-                  </div>
-                </EuiFormRow>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiTitle>
-                  <EuiText
-                    className="euiTitle euiTitle--medium"
-                  >
-                    <div
-                      className="euiText euiText--medium euiTitle euiTitle--medium"
-                    >
-                      <h2>
-                        Details
-                      </h2>
-                    </div>
-                  </EuiText>
-                </EuiTitle>
-                <EuiSpacer>
-                  <div
-                    className="euiSpacer euiSpacer--l"
-                  />
-                </EuiSpacer>
-                <EuiFlexGroup
-                  alignItems="flexStart"
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
-                  >
-                    <EuiFlexItem
-                      style={
-                        Object {
-                          "maxWidth": 400,
-                        }
-                      }
-                    >
-                      <div
-                        className="euiFlexItem"
-                        style={
-                          Object {
-                            "maxWidth": 400,
-                          }
-                        }
-                      >
-                        <EuiFormRow
-                          describedByIds={Array []}
-                          display="row"
-                          fullWidth={false}
-                          hasChildLabel={true}
-                          hasEmptyLabelSpace={false}
-                          label={
-                            <EuiText
-                              size="s"
-                            >
-                              <strong>
-                                Log type
-                              </strong>
-                            </EuiText>
-                          }
-                          labelType="label"
-                        >
-                          <div
-                            className="euiFormRow"
-                            id="some_html_id-row"
-                          >
-                            <div
-                              className="euiFormRow__labelWrapper"
-                            >
-                              <EuiFormLabel
-                                className="euiFormRow__label"
-                                htmlFor="some_html_id"
-                                isFocused={false}
-                                type="label"
-                              >
-                                <label
-                                  className="euiFormLabel euiFormRow__label"
-                                  htmlFor="some_html_id"
-                                >
-                                  <EuiText
-                                    size="s"
-                                  >
-                                    <div
-                                      className="euiText euiText--small"
-                                    >
-                                      <strong>
-                                        Log type
-                                      </strong>
-                                    </div>
-                                  </EuiText>
-                                </label>
-                              </EuiFormLabel>
-                            </div>
-                            <div
-                              className="euiFormRow__fieldWrapper"
-                            >
-                              <EuiComboBox
-                                async={false}
-                                compressed={false}
-                                data-test-subj="rule_type_dropdown"
-                                fullWidth={false}
+                              <input
+                                checked={false}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="yaml"
+                                disabled={false}
                                 id="some_html_id"
-                                isClearable={true}
-                                onBlur={[Function]}
+                                name="some_html_id"
                                 onChange={[Function]}
-                                onFocus={[Function]}
-                                options={Array []}
-                                placeholder="Select a log type"
-                                selectedOptions={Array []}
-                                singleSelection={
-                                  Object {
-                                    "asPlainText": true,
-                                  }
-                                }
-                                sortMatchesBy="none"
-                              >
-                                <div
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
-                                  className="euiComboBox"
-                                  data-test-subj="rule_type_dropdown"
-                                  onKeyDown={[Function]}
-                                  role="combobox"
-                                >
-                                  <EuiComboBoxInput
-                                    autoSizeInputRef={[Function]}
-                                    compressed={false}
-                                    fullWidth={false}
-                                    hasSelectedOptions={false}
-                                    id="some_html_id"
-                                    inputRef={[Function]}
-                                    isListOpen={false}
-                                    noIcon={false}
-                                    onChange={[Function]}
-                                    onClear={[Function]}
-                                    onClick={[Function]}
-                                    onCloseListClick={[Function]}
-                                    onFocus={[Function]}
-                                    onOpenListClick={[Function]}
-                                    onRemoveOption={[Function]}
-                                    placeholder="Select a log type"
-                                    rootId={[Function]}
-                                    searchValue=""
-                                    selectedOptions={Array []}
-                                    singleSelection={
-                                      Object {
-                                        "asPlainText": true,
-                                      }
-                                    }
-                                    toggleButtonRef={[Function]}
-                                    updatePosition={[Function]}
-                                    value=""
-                                  >
-                                    <EuiFormControlLayout
-                                      compressed={false}
-                                      fullWidth={false}
-                                      icon={
-                                        Object {
-                                          "aria-label": "Open list of options",
-                                          "data-test-subj": "comboBoxToggleListButton",
-                                          "disabled": undefined,
-                                          "onClick": [Function],
-                                          "ref": [Function],
-                                          "side": "right",
-                                          "type": "arrowDown",
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="euiFormControlLayout"
-                                      >
-                                        <div
-                                          className="euiFormControlLayout__childrenWrapper"
-                                        >
-                                          <div
-                                            className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                            data-test-subj="comboBoxInput"
-                                            onClick={[Function]}
-                                            tabIndex={-1}
-                                          >
-                                            <p
-                                              className="euiComboBoxPlaceholder"
-                                            >
-                                              Select a log type
-                                            </p>
-                                            <AutosizeInput
-                                              aria-controls=""
-                                              className="euiComboBox__input"
-                                              data-test-subj="comboBoxSearchInput"
-                                              id="some_html_id"
-                                              injectStyles={true}
-                                              inputRef={[Function]}
-                                              minWidth={1}
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              role="textbox"
-                                              style={
-                                                Object {
-                                                  "fontSize": 14,
-                                                }
-                                              }
-                                              value=""
-                                            >
-                                              <div
-                                                className="euiComboBox__input"
-                                                style={
-                                                  Object {
-                                                    "display": "inline-block",
-                                                    "fontSize": 14,
-                                                  }
-                                                }
-                                              >
-                                                <input
-                                                  aria-controls=""
-                                                  data-test-subj="comboBoxSearchInput"
-                                                  id="some_html_id"
-                                                  onBlur={[Function]}
-                                                  onChange={[Function]}
-                                                  onFocus={[Function]}
-                                                  role="textbox"
-                                                  style={
-                                                    Object {
-                                                      "boxSizing": "content-box",
-                                                      "width": "2px",
-                                                    }
-                                                  }
-                                                  value=""
-                                                />
-                                                <div
-                                                  style={
-                                                    Object {
-                                                      "height": 0,
-                                                      "left": 0,
-                                                      "overflow": "scroll",
-                                                      "position": "absolute",
-                                                      "top": 0,
-                                                      "visibility": "hidden",
-                                                      "whiteSpace": "pre",
-                                                    }
-                                                  }
-                                                />
-                                              </div>
-                                            </AutosizeInput>
-                                          </div>
-                                          <EuiFormControlLayoutIcons
-                                            compressed={false}
-                                            icon={
-                                              Object {
-                                                "aria-label": "Open list of options",
-                                                "data-test-subj": "comboBoxToggleListButton",
-                                                "disabled": undefined,
-                                                "onClick": [Function],
-                                                "ref": [Function],
-                                                "side": "right",
-                                                "type": "arrowDown",
-                                              }
-                                            }
-                                          >
-                                            <div
-                                              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                            >
-                                              <EuiFormControlLayoutCustomIcon
-                                                aria-label="Open list of options"
-                                                data-test-subj="comboBoxToggleListButton"
-                                                iconRef={[Function]}
-                                                onClick={[Function]}
-                                                size="m"
-                                                type="arrowDown"
-                                              >
-                                                <button
-                                                  aria-label="Open list of options"
-                                                  className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                                  data-test-subj="comboBoxToggleListButton"
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiFormControlLayoutCustomIcon__icon"
-                                                    size="m"
-                                                    type="arrowDown"
-                                                  >
-                                                    EuiIconMock
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiFormControlLayoutCustomIcon>
-                                            </div>
-                                          </EuiFormControlLayoutIcons>
-                                        </div>
-                                      </div>
-                                    </EuiFormControlLayout>
-                                  </EuiComboBoxInput>
-                                </div>
-                              </EuiComboBox>
-                            </div>
-                          </div>
-                        </EuiFormRow>
-                      </div>
-                    </EuiFlexItem>
-                    <EuiFlexItem
-                      grow={false}
-                      style={
-                        Object {
-                          "marginTop": 36,
-                        }
-                      }
-                    >
-                      <div
-                        className="euiFlexItem euiFlexItem--flexGrowZero"
-                        style={
-                          Object {
-                            "marginTop": 36,
-                          }
-                        }
-                      >
-                        <EuiButton
-                          href="opensearch_security_analytics_dashboards#/log-types"
-                          target="_blank"
-                        >
-                          <EuiButtonDisplay
-                            baseClassName="euiButton"
-                            element="a"
-                            href="opensearch_security_analytics_dashboards#/log-types"
-                            isDisabled={false}
-                            rel="noopener noreferrer"
-                            target="_blank"
-                          >
-                            <a
-                              className="euiButton euiButton--primary"
-                              disabled={false}
-                              href="opensearch_security_analytics_dashboards#/log-types"
-                              rel="noopener noreferrer"
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
-                              target="_blank"
-                            >
-                              <EuiButtonContent
-                                className="euiButton__content"
-                                iconSide="left"
-                                textProps={
-                                  Object {
-                                    "className": "euiButton__text",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    className="euiButton__text"
-                                  >
-                                    Manage 
-                                    <EuiIcon
-                                      type="popout"
-                                    >
-                                      EuiIconMock
-                                    </EuiIcon>
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </a>
-                          </EuiButtonDisplay>
-                        </EuiButton>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-                <EuiSpacer>
-                  <div
-                    className="euiSpacer euiSpacer--l"
-                  />
-                </EuiSpacer>
-                <EuiFormRow
-                  describedByIds={Array []}
-                  display="row"
-                  fullWidth={false}
-                  hasChildLabel={true}
-                  hasEmptyLabelSpace={false}
-                  label={
-                    <EuiText
-                      size="s"
-                    >
-                      <strong>
-                        Rule level (severity)
-                      </strong>
-                    </EuiText>
-                  }
-                  labelType="label"
+                                type="radio"
+                              />
+                              YAML Editor
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                </div>
+              </fieldset>
+            </EuiButtonGroup>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <FormSubmissionErrorToastNotification
+              notifications={
+                Object {
+                  "toasts": Object {
+                    "addDanger": [MockFunction],
+                    "addInfo": [MockFunction],
+                    "addSuccess": [MockFunction],
+                    "addWarning": [MockFunction],
+                  },
+                }
+              }
+            />
+            <EuiTitle>
+              <EuiText
+                className="euiTitle euiTitle--medium"
+              >
+                <div
+                  className="euiText euiText--medium euiTitle euiTitle--medium"
                 >
-                  <div
-                    className="euiFormRow"
-                    id="some_html_id-row"
-                  >
-                    <div
-                      className="euiFormRow__labelWrapper"
-                    >
-                      <EuiFormLabel
-                        className="euiFormRow__label"
-                        htmlFor="some_html_id"
-                        isFocused={false}
-                        type="label"
-                      >
-                        <label
-                          className="euiFormLabel euiFormRow__label"
-                          htmlFor="some_html_id"
-                        >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              <strong>
-                                Rule level (severity)
-                              </strong>
-                            </div>
-                          </EuiText>
-                        </label>
-                      </EuiFormLabel>
-                    </div>
-                    <div
-                      className="euiFormRow__fieldWrapper"
-                    >
-                      <EuiComboBox
-                        async={false}
-                        compressed={false}
-                        data-test-subj="rule_severity_dropdown"
-                        fullWidth={false}
-                        id="some_html_id"
-                        isClearable={true}
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "label": "Critical",
-                              "value": "critical",
-                            },
-                            Object {
-                              "label": "High",
-                              "value": "high",
-                            },
-                            Object {
-                              "label": "Medium",
-                              "value": "medium",
-                            },
-                            Object {
-                              "label": "Low",
-                              "value": "low",
-                            },
-                            Object {
-                              "label": "Informational",
-                              "value": "informational",
-                            },
-                          ]
-                        }
-                        placeholder="Select a rule level"
-                        selectedOptions={Array []}
-                        singleSelection={
-                          Object {
-                            "asPlainText": true,
-                          }
-                        }
-                        sortMatchesBy="none"
-                      >
-                        <div
-                          aria-expanded={false}
-                          aria-haspopup="listbox"
-                          className="euiComboBox"
-                          data-test-subj="rule_severity_dropdown"
-                          onKeyDown={[Function]}
-                          role="combobox"
-                        >
-                          <EuiComboBoxInput
-                            autoSizeInputRef={[Function]}
-                            compressed={false}
-                            fullWidth={false}
-                            hasSelectedOptions={false}
-                            id="some_html_id"
-                            inputRef={[Function]}
-                            isListOpen={false}
-                            noIcon={false}
-                            onChange={[Function]}
-                            onClear={[Function]}
-                            onClick={[Function]}
-                            onCloseListClick={[Function]}
-                            onFocus={[Function]}
-                            onOpenListClick={[Function]}
-                            onRemoveOption={[Function]}
-                            placeholder="Select a rule level"
-                            rootId={[Function]}
-                            searchValue=""
-                            selectedOptions={Array []}
-                            singleSelection={
-                              Object {
-                                "asPlainText": true,
-                              }
-                            }
-                            toggleButtonRef={[Function]}
-                            updatePosition={[Function]}
-                            value=""
-                          >
-                            <EuiFormControlLayout
-                              compressed={false}
-                              fullWidth={false}
-                              icon={
-                                Object {
-                                  "aria-label": "Open list of options",
-                                  "data-test-subj": "comboBoxToggleListButton",
-                                  "disabled": undefined,
-                                  "onClick": [Function],
-                                  "ref": [Function],
-                                  "side": "right",
-                                  "type": "arrowDown",
-                                }
-                              }
-                            >
-                              <div
-                                className="euiFormControlLayout"
-                              >
-                                <div
-                                  className="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <div
-                                    className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                    data-test-subj="comboBoxInput"
-                                    onClick={[Function]}
-                                    tabIndex={-1}
-                                  >
-                                    <p
-                                      className="euiComboBoxPlaceholder"
-                                    >
-                                      Select a rule level
-                                    </p>
-                                    <AutosizeInput
-                                      aria-controls=""
-                                      className="euiComboBox__input"
-                                      data-test-subj="comboBoxSearchInput"
-                                      id="some_html_id"
-                                      injectStyles={true}
-                                      inputRef={[Function]}
-                                      minWidth={1}
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      role="textbox"
-                                      style={
-                                        Object {
-                                          "fontSize": 14,
-                                        }
-                                      }
-                                      value=""
-                                    >
-                                      <div
-                                        className="euiComboBox__input"
-                                        style={
-                                          Object {
-                                            "display": "inline-block",
-                                            "fontSize": 14,
-                                          }
-                                        }
-                                      >
-                                        <input
-                                          aria-controls=""
-                                          data-test-subj="comboBoxSearchInput"
-                                          id="some_html_id"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          role="textbox"
-                                          style={
-                                            Object {
-                                              "boxSizing": "content-box",
-                                              "width": "2px",
-                                            }
-                                          }
-                                          value=""
-                                        />
-                                        <div
-                                          style={
-                                            Object {
-                                              "height": 0,
-                                              "left": 0,
-                                              "overflow": "scroll",
-                                              "position": "absolute",
-                                              "top": 0,
-                                              "visibility": "hidden",
-                                              "whiteSpace": "pre",
-                                            }
-                                          }
-                                        />
-                                      </div>
-                                    </AutosizeInput>
-                                  </div>
-                                  <EuiFormControlLayoutIcons
-                                    compressed={false}
-                                    icon={
-                                      Object {
-                                        "aria-label": "Open list of options",
-                                        "data-test-subj": "comboBoxToggleListButton",
-                                        "disabled": undefined,
-                                        "onClick": [Function],
-                                        "ref": [Function],
-                                        "side": "right",
-                                        "type": "arrowDown",
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                    >
-                                      <EuiFormControlLayoutCustomIcon
-                                        aria-label="Open list of options"
-                                        data-test-subj="comboBoxToggleListButton"
-                                        iconRef={[Function]}
-                                        onClick={[Function]}
-                                        size="m"
-                                        type="arrowDown"
-                                      >
-                                        <button
-                                          aria-label="Open list of options"
-                                          className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                          data-test-subj="comboBoxToggleListButton"
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiFormControlLayoutCustomIcon__icon"
-                                            size="m"
-                                            type="arrowDown"
-                                          >
-                                            EuiIconMock
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiFormControlLayoutCustomIcon>
-                                    </div>
-                                  </EuiFormControlLayoutIcons>
-                                </div>
-                              </div>
-                            </EuiFormControlLayout>
-                          </EuiComboBoxInput>
-                        </div>
-                      </EuiComboBox>
-                    </div>
-                  </div>
-                </EuiFormRow>
-                <EuiSpacer>
-                  <div
-                    className="euiSpacer euiSpacer--l"
-                  />
-                </EuiSpacer>
-                <EuiFormRow
-                  describedByIds={Array []}
-                  display="row"
-                  fullWidth={false}
-                  hasChildLabel={true}
-                  hasEmptyLabelSpace={false}
-                  label={
-                    <EuiText
-                      size="s"
-                    >
-                      <strong>
-                        Rule Status
-                      </strong>
-                    </EuiText>
-                  }
-                  labelType="label"
-                >
-                  <div
-                    className="euiFormRow"
-                    id="some_html_id-row"
-                  >
-                    <div
-                      className="euiFormRow__labelWrapper"
-                    >
-                      <EuiFormLabel
-                        className="euiFormRow__label"
-                        htmlFor="some_html_id"
-                        isFocused={false}
-                        type="label"
-                      >
-                        <label
-                          className="euiFormLabel euiFormRow__label"
-                          htmlFor="some_html_id"
-                        >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              <strong>
-                                Rule Status
-                              </strong>
-                            </div>
-                          </EuiText>
-                        </label>
-                      </EuiFormLabel>
-                    </div>
-                    <div
-                      className="euiFormRow__fieldWrapper"
-                    >
-                      <EuiComboBox
-                        async={false}
-                        compressed={false}
-                        data-test-subj="rule_status_dropdown"
-                        fullWidth={false}
-                        id="some_html_id"
-                        isClearable={true}
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "label": "experimental",
-                              "value": "experimental",
-                            },
-                            Object {
-                              "label": "test",
-                              "value": "test",
-                            },
-                            Object {
-                              "label": "stable",
-                              "value": "stable",
-                            },
-                          ]
-                        }
-                        placeholder="Select a rule status"
-                        selectedOptions={
-                          Array [
-                            Object {
-                              "label": "experimental",
-                              "value": "experimental",
-                            },
-                          ]
-                        }
-                        singleSelection={
-                          Object {
-                            "asPlainText": true,
-                          }
-                        }
-                        sortMatchesBy="none"
-                      >
-                        <div
-                          aria-expanded={false}
-                          aria-haspopup="listbox"
-                          className="euiComboBox"
-                          data-test-subj="rule_status_dropdown"
-                          onKeyDown={[Function]}
-                          role="combobox"
-                        >
-                          <EuiComboBoxInput
-                            autoSizeInputRef={[Function]}
-                            compressed={false}
-                            fullWidth={false}
-                            hasSelectedOptions={true}
-                            id="some_html_id"
-                            inputRef={[Function]}
-                            isListOpen={false}
-                            noIcon={false}
-                            onChange={[Function]}
-                            onClear={[Function]}
-                            onClick={[Function]}
-                            onCloseListClick={[Function]}
-                            onFocus={[Function]}
-                            onOpenListClick={[Function]}
-                            onRemoveOption={[Function]}
-                            placeholder="Select a rule status"
-                            rootId={[Function]}
-                            searchValue=""
-                            selectedOptions={
-                              Array [
-                                Object {
-                                  "label": "experimental",
-                                  "value": "experimental",
-                                },
-                              ]
-                            }
-                            singleSelection={
-                              Object {
-                                "asPlainText": true,
-                              }
-                            }
-                            toggleButtonRef={[Function]}
-                            updatePosition={[Function]}
-                            value="experimental"
-                          >
-                            <EuiFormControlLayout
-                              clear={
-                                Object {
-                                  "data-test-subj": "comboBoxClearButton",
-                                  "onClick": [Function],
-                                }
-                              }
-                              compressed={false}
-                              fullWidth={false}
-                              icon={
-                                Object {
-                                  "aria-label": "Open list of options",
-                                  "data-test-subj": "comboBoxToggleListButton",
-                                  "disabled": undefined,
-                                  "onClick": [Function],
-                                  "ref": [Function],
-                                  "side": "right",
-                                  "type": "arrowDown",
-                                }
-                              }
-                            >
-                              <div
-                                className="euiFormControlLayout"
-                              >
-                                <div
-                                  className="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <div
-                                    className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                    data-test-subj="comboBoxInput"
-                                    onClick={[Function]}
-                                    tabIndex={-1}
-                                  >
-                                    <EuiComboBoxPill
-                                      asPlainText={true}
-                                      color="hollow"
-                                      key="experimental"
-                                      option={
-                                        Object {
-                                          "label": "experimental",
-                                          "value": "experimental",
-                                        }
-                                      }
-                                      value="experimental"
-                                    >
-                                      <span
-                                        className="euiComboBoxPill euiComboBoxPill--plainText"
-                                        value="experimental"
-                                      >
-                                        experimental
-                                      </span>
-                                    </EuiComboBoxPill>
-                                    <AutosizeInput
-                                      aria-controls=""
-                                      className="euiComboBox__input"
-                                      data-test-subj="comboBoxSearchInput"
-                                      id="some_html_id"
-                                      injectStyles={true}
-                                      inputRef={[Function]}
-                                      minWidth={1}
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      role="textbox"
-                                      style={
-                                        Object {
-                                          "fontSize": 14,
-                                        }
-                                      }
-                                      value=""
-                                    >
-                                      <div
-                                        className="euiComboBox__input"
-                                        style={
-                                          Object {
-                                            "display": "inline-block",
-                                            "fontSize": 14,
-                                          }
-                                        }
-                                      >
-                                        <input
-                                          aria-controls=""
-                                          data-test-subj="comboBoxSearchInput"
-                                          id="some_html_id"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          role="textbox"
-                                          style={
-                                            Object {
-                                              "boxSizing": "content-box",
-                                              "width": "2px",
-                                            }
-                                          }
-                                          value=""
-                                        />
-                                        <div
-                                          style={
-                                            Object {
-                                              "height": 0,
-                                              "left": 0,
-                                              "overflow": "scroll",
-                                              "position": "absolute",
-                                              "top": 0,
-                                              "visibility": "hidden",
-                                              "whiteSpace": "pre",
-                                            }
-                                          }
-                                        />
-                                      </div>
-                                    </AutosizeInput>
-                                  </div>
-                                  <EuiFormControlLayoutIcons
-                                    clear={
-                                      Object {
-                                        "data-test-subj": "comboBoxClearButton",
-                                        "onClick": [Function],
-                                      }
-                                    }
-                                    compressed={false}
-                                    icon={
-                                      Object {
-                                        "aria-label": "Open list of options",
-                                        "data-test-subj": "comboBoxToggleListButton",
-                                        "disabled": undefined,
-                                        "onClick": [Function],
-                                        "ref": [Function],
-                                        "side": "right",
-                                        "type": "arrowDown",
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                    >
-                                      <EuiFormControlLayoutClearButton
-                                        data-test-subj="comboBoxClearButton"
-                                        onClick={[Function]}
-                                        size="m"
-                                      >
-                                        <EuiI18n
-                                          default="Clear input"
-                                          token="euiFormControlLayoutClearButton.label"
-                                        >
-                                          <button
-                                            aria-label="Clear input"
-                                            className="euiFormControlLayoutClearButton"
-                                            data-test-subj="comboBoxClearButton"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiIcon
-                                              className="euiFormControlLayoutClearButton__icon"
-                                              type="cross"
-                                            >
-                                              EuiIconMock
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiI18n>
-                                      </EuiFormControlLayoutClearButton>
-                                      <EuiFormControlLayoutCustomIcon
-                                        aria-label="Open list of options"
-                                        data-test-subj="comboBoxToggleListButton"
-                                        iconRef={[Function]}
-                                        onClick={[Function]}
-                                        size="m"
-                                        type="arrowDown"
-                                      >
-                                        <button
-                                          aria-label="Open list of options"
-                                          className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                          data-test-subj="comboBoxToggleListButton"
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiFormControlLayoutCustomIcon__icon"
-                                            size="m"
-                                            type="arrowDown"
-                                          >
-                                            EuiIconMock
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiFormControlLayoutCustomIcon>
-                                    </div>
-                                  </EuiFormControlLayoutIcons>
-                                </div>
-                              </div>
-                            </EuiFormControlLayout>
-                          </EuiComboBoxInput>
-                        </div>
-                      </EuiComboBox>
-                    </div>
-                  </div>
-                </EuiFormRow>
-                <EuiSpacer
-                  size="xxl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xxl"
-                  />
-                </EuiSpacer>
-                <EuiTitle>
-                  <EuiText
-                    className="euiTitle euiTitle--medium"
-                  >
-                    <div
-                      className="euiText euiText--medium euiTitle euiTitle--medium"
-                    >
-                      <h2>
-                        Detection
-                      </h2>
-                    </div>
-                  </EuiText>
-                </EuiTitle>
+                  <h2>
+                    Rule overview
+                  </h2>
+                </div>
+              </EuiText>
+            </EuiTitle>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <EuiFormRow
+              describedByIds={Array []}
+              display="row"
+              fullWidth={false}
+              hasChildLabel={true}
+              hasEmptyLabelSpace={false}
+              helpText="Rule name can be max 256 characters."
+              label={
                 <EuiText
                   size="s"
                 >
-                  <div
-                    className="euiText euiText--small"
-                  >
-                    <p>
-                      Define the detection criteria for the rule
-                    </p>
-                  </div>
+                  <strong>
+                    Rule name
+                  </strong>
                 </EuiText>
-                <EuiSpacer>
-                  <div
-                    className="euiSpacer euiSpacer--l"
-                  />
-                </EuiSpacer>
-                <DetectionVisualEditor
-                  detectionYml=""
-                  goToYamlEditor={[Function]}
-                  onChange={[Function]}
-                  setIsDetectionInvalid={[Function]}
+              }
+              labelType="label"
+            >
+              <div
+                className="euiFormRow"
+                id="some_html_id-row"
+              >
+                <div
+                  className="euiFormRow__labelWrapper"
+                >
+                  <EuiFormLabel
+                    className="euiFormRow__label"
+                    htmlFor="some_html_id"
+                    isFocused={false}
+                    type="label"
+                  >
+                    <label
+                      className="euiFormLabel euiFormRow__label"
+                      htmlFor="some_html_id"
+                    >
+                      <EuiText
+                        size="s"
+                      >
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <strong>
+                            Rule name
+                          </strong>
+                        </div>
+                      </EuiText>
+                    </label>
+                  </EuiFormLabel>
+                </div>
+                <div
+                  className="euiFormRow__fieldWrapper"
+                >
+                  <EuiFieldText
+                    aria-describedby="some_html_id-help-0"
+                    data-test-subj="rule_name_field"
+                    id="some_html_id"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="My custom rule"
+                    value=""
+                  >
+                    <EuiFormControlLayout
+                      fullWidth={false}
+                      inputId="some_html_id"
+                    >
+                      <div
+                        className="euiFormControlLayout"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <EuiValidatableControl>
+                            <input
+                              aria-describedby="some_html_id-help-0"
+                              className="euiFieldText"
+                              data-test-subj="rule_name_field"
+                              id="some_html_id"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="My custom rule"
+                              type="text"
+                              value=""
+                            />
+                          </EuiValidatableControl>
+                          <EuiFormControlLayoutIcons />
+                        </div>
+                      </div>
+                    </EuiFormControlLayout>
+                  </EuiFieldText>
+                  <EuiFormHelpText
+                    className="euiFormRow__text"
+                    id="some_html_id-help-0"
+                    key="Rule name can be max 256 characters."
+                  >
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="some_html_id-help-0"
+                    >
+                      Rule name can be max 256 characters.
+                    </div>
+                  </EuiFormHelpText>
+                </div>
+              </div>
+            </EuiFormRow>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiFormRow
+              describedByIds={Array []}
+              display="row"
+              fullWidth={false}
+              hasChildLabel={true}
+              hasEmptyLabelSpace={false}
+              label={
+                <EuiText
+                  size="s"
+                >
+                  <strong>
+                    Description 
+                  </strong>
+                  <i>
+                    - optional
+                  </i>
+                </EuiText>
+              }
+              labelType="label"
+            >
+              <div
+                className="euiFormRow"
+                id="some_html_id-row"
+              >
+                <div
+                  className="euiFormRow__labelWrapper"
+                >
+                  <EuiFormLabel
+                    className="euiFormRow__label"
+                    htmlFor="some_html_id"
+                    isFocused={false}
+                    type="label"
+                  >
+                    <label
+                      className="euiFormLabel euiFormRow__label"
+                      htmlFor="some_html_id"
+                    >
+                      <EuiText
+                        size="s"
+                      >
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <strong>
+                            Description 
+                          </strong>
+                          <i>
+                            - optional
+                          </i>
+                        </div>
+                      </EuiText>
+                    </label>
+                  </EuiFormLabel>
+                </div>
+                <div
+                  className="euiFormRow__fieldWrapper"
+                >
+                  <EuiFieldText
+                    data-test-subj="rule_description_field"
+                    id="some_html_id"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Detects ..."
+                    value=""
+                  >
+                    <EuiFormControlLayout
+                      fullWidth={false}
+                      inputId="some_html_id"
+                    >
+                      <div
+                        className="euiFormControlLayout"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <EuiValidatableControl>
+                            <input
+                              className="euiFieldText"
+                              data-test-subj="rule_description_field"
+                              id="some_html_id"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Detects ..."
+                              type="text"
+                              value=""
+                            />
+                          </EuiValidatableControl>
+                          <EuiFormControlLayoutIcons />
+                        </div>
+                      </div>
+                    </EuiFormControlLayout>
+                  </EuiFieldText>
+                </div>
+              </div>
+            </EuiFormRow>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiFormRow
+              describedByIds={Array []}
+              display="row"
+              fullWidth={false}
+              hasChildLabel={true}
+              hasEmptyLabelSpace={false}
+              helpText="Combine multiple authors separated with a comma"
+              label={
+                <EuiText
+                  size="s"
+                >
+                  <strong>
+                    Author
+                  </strong>
+                </EuiText>
+              }
+              labelType="label"
+            >
+              <div
+                className="euiFormRow"
+                id="some_html_id-row"
+              >
+                <div
+                  className="euiFormRow__labelWrapper"
+                >
+                  <EuiFormLabel
+                    className="euiFormRow__label"
+                    htmlFor="some_html_id"
+                    isFocused={false}
+                    type="label"
+                  >
+                    <label
+                      className="euiFormLabel euiFormRow__label"
+                      htmlFor="some_html_id"
+                    >
+                      <EuiText
+                        size="s"
+                      >
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <strong>
+                            Author
+                          </strong>
+                        </div>
+                      </EuiText>
+                    </label>
+                  </EuiFormLabel>
+                </div>
+                <div
+                  className="euiFormRow__fieldWrapper"
+                >
+                  <EuiFieldText
+                    aria-describedby="some_html_id-help-0"
+                    data-test-subj="rule_author_field"
+                    id="some_html_id"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Enter author name"
+                    value=""
+                  >
+                    <EuiFormControlLayout
+                      fullWidth={false}
+                      inputId="some_html_id"
+                    >
+                      <div
+                        className="euiFormControlLayout"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <EuiValidatableControl>
+                            <input
+                              aria-describedby="some_html_id-help-0"
+                              className="euiFieldText"
+                              data-test-subj="rule_author_field"
+                              id="some_html_id"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Enter author name"
+                              type="text"
+                              value=""
+                            />
+                          </EuiValidatableControl>
+                          <EuiFormControlLayoutIcons />
+                        </div>
+                      </div>
+                    </EuiFormControlLayout>
+                  </EuiFieldText>
+                  <EuiFormHelpText
+                    className="euiFormRow__text"
+                    id="some_html_id-help-0"
+                    key="Combine multiple authors separated with a comma"
+                  >
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="some_html_id-help-0"
+                    >
+                      Combine multiple authors separated with a comma
+                    </div>
+                  </EuiFormHelpText>
+                </div>
+              </div>
+            </EuiFormRow>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiTitle>
+              <EuiText
+                className="euiTitle euiTitle--medium"
+              >
+                <div
+                  className="euiText euiText--medium euiTitle euiTitle--medium"
+                >
+                  <h2>
+                    Details
+                  </h2>
+                </div>
+              </EuiText>
+            </EuiTitle>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <EuiFlexGroup
+              alignItems="flexStart"
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  style={
+                    Object {
+                      "maxWidth": 400,
+                    }
+                  }
                 >
                   <div
-                    className="detection-visual-editor"
+                    className="euiFlexItem"
                     style={
                       Object {
-                        "maxWidth": 1000,
+                        "maxWidth": 400,
                       }
                     }
                   >
-                    <div
-                      key="detection-visual-editor-selection-0"
-                    >
-                      <EuiPanel
-                        className="detection-visual-editor-selection"
-                        data-test-subj="detection-visual-editor-0"
-                        key="detection-visual-editor-0"
-                      >
-                        <div
-                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow detection-visual-editor-selection"
-                          data-test-subj="detection-visual-editor-0"
-                        >
-                          <EuiFlexGroup
-                            alignItems="center"
-                          >
-                            <div
-                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                            >
-                              <EuiFlexItem
-                                grow={true}
-                              >
-                                <div
-                                  className="euiFlexItem"
-                                >
-                                  <EuiFormRow
-                                    describedByIds={Array []}
-                                    display="row"
-                                    fullWidth={false}
-                                    hasChildLabel={true}
-                                    hasEmptyLabelSpace={false}
-                                    labelType="label"
-                                  >
-                                    <div
-                                      className="euiFormRow"
-                                      id="some_html_id-row"
-                                    >
-                                      <div
-                                        className="euiFormRow__fieldWrapper"
-                                      >
-                                        <EuiFieldText
-                                          className="detection-visual-editor-name euiTitle--small"
-                                          data-test-subj="selection_name"
-                                          id="some_html_id"
-                                          onBlur={[Function]}
-                                          onChange={[Function]}
-                                          onFocus={[Function]}
-                                          placeholder="Enter selection name"
-                                          value="Selection_1"
-                                        >
-                                          <EuiFormControlLayout
-                                            fullWidth={false}
-                                            inputId="some_html_id"
-                                          >
-                                            <div
-                                              className="euiFormControlLayout"
-                                            >
-                                              <div
-                                                className="euiFormControlLayout__childrenWrapper"
-                                              >
-                                                <EuiValidatableControl>
-                                                  <input
-                                                    className="euiFieldText detection-visual-editor-name euiTitle--small"
-                                                    data-test-subj="selection_name"
-                                                    id="some_html_id"
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    onFocus={[Function]}
-                                                    placeholder="Enter selection name"
-                                                    type="text"
-                                                    value="Selection_1"
-                                                  />
-                                                </EuiValidatableControl>
-                                                <EuiFormControlLayoutIcons />
-                                              </div>
-                                            </div>
-                                          </EuiFormControlLayout>
-                                        </EuiFieldText>
-                                      </div>
-                                    </div>
-                                  </EuiFormRow>
-                                  <EuiText
-                                    size="s"
-                                  >
-                                    <div
-                                      className="euiText euiText--small"
-                                    >
-                                      <p>
-                                        Define the search identifier in your data the rule will be applied to.
-                                      </p>
-                                    </div>
-                                  </EuiText>
-                                </div>
-                              </EuiFlexItem>
-                              <EuiFlexItem
-                                className="detection-visual-editor-delete-selection"
-                                grow={false}
-                              >
-                                <div
-                                  className="euiFlexItem euiFlexItem--flexGrowZero detection-visual-editor-delete-selection"
-                                />
-                              </EuiFlexItem>
-                            </div>
-                          </EuiFlexGroup>
-                          <EuiSpacer>
-                            <div
-                              className="euiSpacer euiSpacer--l"
-                            />
-                          </EuiSpacer>
-                          <div
-                            className="detection-visual-editor-accordion-wrapper"
-                            key="Map-0"
-                          >
-                            <EuiAccordion
-                              arrowDisplay="left"
-                              buttonClassName="euiAccordionForm__button"
-                              buttonContent={
-                                <EuiText
-                                  size="m"
-                                >
-                                  Map 
-                                  1
-                                </EuiText>
-                              }
-                              className="euiAccordionForm detection-visual-editor-accordion"
-                              data-test-subj="Map-0"
-                              extraAction={null}
-                              id="Map-0"
-                              initialIsOpen={true}
-                              isLoading={false}
-                              isLoadingMessage={false}
-                              key="Map-0"
-                              paddingSize="none"
-                              style={
-                                Object {
-                                  "maxWidth": "70%",
-                                }
-                              }
-                            >
-                              <div
-                                className="euiAccordion euiAccordion-isOpen euiAccordionForm detection-visual-editor-accordion"
-                                data-test-subj="Map-0"
-                                style={
-                                  Object {
-                                    "maxWidth": "70%",
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiAccordion__triggerWrapper"
-                                >
-                                  <button
-                                    aria-controls="Map-0"
-                                    aria-expanded={true}
-                                    className="euiAccordion__button euiAccordionForm__button"
-                                    id="some_html_id"
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <span
-                                      className="euiAccordion__iconWrapper"
-                                    >
-                                      <EuiIcon
-                                        className="euiAccordion__icon euiAccordion__icon-isOpen"
-                                        size="m"
-                                        type="arrowRight"
-                                      >
-                                        EuiIconMock
-                                      </EuiIcon>
-                                    </span>
-                                    <span
-                                      className="euiIEFlexWrapFix"
-                                    >
-                                      <EuiText
-                                        size="m"
-                                      >
-                                        <div
-                                          className="euiText euiText--medium"
-                                        >
-                                          Map 
-                                          1
-                                        </div>
-                                      </EuiText>
-                                    </span>
-                                  </button>
-                                </div>
-                                <div
-                                  aria-labelledby="some_html_id"
-                                  className="euiAccordion__childWrapper"
-                                  id="Map-0"
-                                  role="region"
-                                  tabIndex={-1}
-                                >
-                                  <EuiResizeObserver
-                                    onResize={[Function]}
-                                  >
-                                    <div>
-                                      <div
-                                        className=""
-                                      >
-                                        <EuiSpacer
-                                          size="m"
-                                        >
-                                          <div
-                                            className="euiSpacer euiSpacer--m"
-                                          />
-                                        </EuiSpacer>
-                                        <EuiFlexGroup>
-                                          <div
-                                            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                          >
-                                            <EuiFlexItem
-                                              grow={false}
-                                              style={
-                                                Object {
-                                                  "minWidth": 200,
-                                                }
-                                              }
-                                            >
-                                              <div
-                                                className="euiFlexItem euiFlexItem--flexGrowZero"
-                                                style={
-                                                  Object {
-                                                    "minWidth": 200,
-                                                  }
-                                                }
-                                              >
-                                                <EuiFormRow
-                                                  describedByIds={Array []}
-                                                  display="row"
-                                                  fullWidth={false}
-                                                  hasChildLabel={true}
-                                                  hasEmptyLabelSpace={false}
-                                                  label={
-                                                    <EuiText
-                                                      size="s"
-                                                    >
-                                                      Key
-                                                    </EuiText>
-                                                  }
-                                                  labelType="label"
-                                                >
-                                                  <div
-                                                    className="euiFormRow"
-                                                    id="some_html_id-row"
-                                                  >
-                                                    <div
-                                                      className="euiFormRow__labelWrapper"
-                                                    >
-                                                      <EuiFormLabel
-                                                        className="euiFormRow__label"
-                                                        htmlFor="some_html_id"
-                                                        isFocused={false}
-                                                        type="label"
-                                                      >
-                                                        <label
-                                                          className="euiFormLabel euiFormRow__label"
-                                                          htmlFor="some_html_id"
-                                                        >
-                                                          <EuiText
-                                                            size="s"
-                                                          >
-                                                            <div
-                                                              className="euiText euiText--small"
-                                                            >
-                                                              Key
-                                                            </div>
-                                                          </EuiText>
-                                                        </label>
-                                                      </EuiFormLabel>
-                                                    </div>
-                                                    <div
-                                                      className="euiFormRow__fieldWrapper"
-                                                    >
-                                                      <EuiFieldText
-                                                        data-test-subj="selection_field_key_name"
-                                                        id="some_html_id"
-                                                        onBlur={[Function]}
-                                                        onChange={[Function]}
-                                                        onFocus={[Function]}
-                                                        placeholder="Enter key name"
-                                                        value=""
-                                                      >
-                                                        <EuiFormControlLayout
-                                                          fullWidth={false}
-                                                          inputId="some_html_id"
-                                                        >
-                                                          <div
-                                                            className="euiFormControlLayout"
-                                                          >
-                                                            <div
-                                                              className="euiFormControlLayout__childrenWrapper"
-                                                            >
-                                                              <EuiValidatableControl>
-                                                                <input
-                                                                  className="euiFieldText"
-                                                                  data-test-subj="selection_field_key_name"
-                                                                  id="some_html_id"
-                                                                  onBlur={[Function]}
-                                                                  onChange={[Function]}
-                                                                  onFocus={[Function]}
-                                                                  placeholder="Enter key name"
-                                                                  type="text"
-                                                                  value=""
-                                                                />
-                                                              </EuiValidatableControl>
-                                                              <EuiFormControlLayoutIcons />
-                                                            </div>
-                                                          </div>
-                                                        </EuiFormControlLayout>
-                                                      </EuiFieldText>
-                                                    </div>
-                                                  </div>
-                                                </EuiFormRow>
-                                              </div>
-                                            </EuiFlexItem>
-                                            <EuiFlexItem
-                                              grow={false}
-                                              style={
-                                                Object {
-                                                  "minWidth": 200,
-                                                }
-                                              }
-                                            >
-                                              <div
-                                                className="euiFlexItem euiFlexItem--flexGrowZero"
-                                                style={
-                                                  Object {
-                                                    "minWidth": 200,
-                                                  }
-                                                }
-                                              >
-                                                <EuiFormRow
-                                                  describedByIds={Array []}
-                                                  display="row"
-                                                  fullWidth={false}
-                                                  hasChildLabel={true}
-                                                  hasEmptyLabelSpace={false}
-                                                  label={
-                                                    <EuiText
-                                                      size="s"
-                                                    >
-                                                      Modifier
-                                                    </EuiText>
-                                                  }
-                                                  labelType="label"
-                                                >
-                                                  <div
-                                                    className="euiFormRow"
-                                                    id="some_html_id-row"
-                                                  >
-                                                    <div
-                                                      className="euiFormRow__labelWrapper"
-                                                    >
-                                                      <EuiFormLabel
-                                                        className="euiFormRow__label"
-                                                        htmlFor="some_html_id"
-                                                        isFocused={false}
-                                                        type="label"
-                                                      >
-                                                        <label
-                                                          className="euiFormLabel euiFormRow__label"
-                                                          htmlFor="some_html_id"
-                                                        >
-                                                          <EuiText
-                                                            size="s"
-                                                          >
-                                                            <div
-                                                              className="euiText euiText--small"
-                                                            >
-                                                              Modifier
-                                                            </div>
-                                                          </EuiText>
-                                                        </label>
-                                                      </EuiFormLabel>
-                                                    </div>
-                                                    <div
-                                                      className="euiFormRow__fieldWrapper"
-                                                    >
-                                                      <EuiComboBox
-                                                        async={false}
-                                                        compressed={false}
-                                                        data-test-subj="modifier_dropdown"
-                                                        fullWidth={false}
-                                                        id="some_html_id"
-                                                        isClearable={true}
-                                                        onBlur={[Function]}
-                                                        onChange={[Function]}
-                                                        onFocus={[Function]}
-                                                        options={
-                                                          Array [
-                                                            Object {
-                                                              "label": "all",
-                                                              "value": "all",
-                                                            },
-                                                            Object {
-                                                              "label": "contains",
-                                                              "value": "contains",
-                                                            },
-                                                            Object {
-                                                              "label": "base64",
-                                                              "value": "base64",
-                                                            },
-                                                            Object {
-                                                              "label": "endswith",
-                                                              "value": "endswith",
-                                                            },
-                                                            Object {
-                                                              "label": "startswith",
-                                                              "value": "startswith",
-                                                            },
-                                                            Object {
-                                                              "label": "cidr",
-                                                              "value": "cidr",
-                                                            },
-                                                          ]
-                                                        }
-                                                        selectedOptions={
-                                                          Array [
-                                                            Object {
-                                                              "label": "all",
-                                                              "value": "all",
-                                                            },
-                                                          ]
-                                                        }
-                                                        singleSelection={
-                                                          Object {
-                                                            "asPlainText": true,
-                                                          }
-                                                        }
-                                                        sortMatchesBy="none"
-                                                      >
-                                                        <div
-                                                          aria-expanded={false}
-                                                          aria-haspopup="listbox"
-                                                          className="euiComboBox"
-                                                          data-test-subj="modifier_dropdown"
-                                                          onKeyDown={[Function]}
-                                                          role="combobox"
-                                                        >
-                                                          <EuiComboBoxInput
-                                                            autoSizeInputRef={[Function]}
-                                                            compressed={false}
-                                                            fullWidth={false}
-                                                            hasSelectedOptions={true}
-                                                            id="some_html_id"
-                                                            inputRef={[Function]}
-                                                            isListOpen={false}
-                                                            noIcon={false}
-                                                            onChange={[Function]}
-                                                            onClear={[Function]}
-                                                            onClick={[Function]}
-                                                            onCloseListClick={[Function]}
-                                                            onFocus={[Function]}
-                                                            onOpenListClick={[Function]}
-                                                            onRemoveOption={[Function]}
-                                                            rootId={[Function]}
-                                                            searchValue=""
-                                                            selectedOptions={
-                                                              Array [
-                                                                Object {
-                                                                  "label": "all",
-                                                                  "value": "all",
-                                                                },
-                                                              ]
-                                                            }
-                                                            singleSelection={
-                                                              Object {
-                                                                "asPlainText": true,
-                                                              }
-                                                            }
-                                                            toggleButtonRef={[Function]}
-                                                            updatePosition={[Function]}
-                                                            value="all"
-                                                          >
-                                                            <EuiFormControlLayout
-                                                              clear={
-                                                                Object {
-                                                                  "data-test-subj": "comboBoxClearButton",
-                                                                  "onClick": [Function],
-                                                                }
-                                                              }
-                                                              compressed={false}
-                                                              fullWidth={false}
-                                                              icon={
-                                                                Object {
-                                                                  "aria-label": "Open list of options",
-                                                                  "data-test-subj": "comboBoxToggleListButton",
-                                                                  "disabled": undefined,
-                                                                  "onClick": [Function],
-                                                                  "ref": [Function],
-                                                                  "side": "right",
-                                                                  "type": "arrowDown",
-                                                                }
-                                                              }
-                                                            >
-                                                              <div
-                                                                className="euiFormControlLayout"
-                                                              >
-                                                                <div
-                                                                  className="euiFormControlLayout__childrenWrapper"
-                                                                >
-                                                                  <div
-                                                                    className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                                                    data-test-subj="comboBoxInput"
-                                                                    onClick={[Function]}
-                                                                    tabIndex={-1}
-                                                                  >
-                                                                    <EuiComboBoxPill
-                                                                      asPlainText={true}
-                                                                      color="hollow"
-                                                                      key="all"
-                                                                      option={
-                                                                        Object {
-                                                                          "label": "all",
-                                                                          "value": "all",
-                                                                        }
-                                                                      }
-                                                                      value="all"
-                                                                    >
-                                                                      <span
-                                                                        className="euiComboBoxPill euiComboBoxPill--plainText"
-                                                                        value="all"
-                                                                      >
-                                                                        all
-                                                                      </span>
-                                                                    </EuiComboBoxPill>
-                                                                    <AutosizeInput
-                                                                      aria-controls=""
-                                                                      className="euiComboBox__input"
-                                                                      data-test-subj="comboBoxSearchInput"
-                                                                      id="some_html_id"
-                                                                      injectStyles={true}
-                                                                      inputRef={[Function]}
-                                                                      minWidth={1}
-                                                                      onBlur={[Function]}
-                                                                      onChange={[Function]}
-                                                                      onFocus={[Function]}
-                                                                      role="textbox"
-                                                                      style={
-                                                                        Object {
-                                                                          "fontSize": 14,
-                                                                        }
-                                                                      }
-                                                                      value=""
-                                                                    >
-                                                                      <div
-                                                                        className="euiComboBox__input"
-                                                                        style={
-                                                                          Object {
-                                                                            "display": "inline-block",
-                                                                            "fontSize": 14,
-                                                                          }
-                                                                        }
-                                                                      >
-                                                                        <input
-                                                                          aria-controls=""
-                                                                          data-test-subj="comboBoxSearchInput"
-                                                                          id="some_html_id"
-                                                                          onBlur={[Function]}
-                                                                          onChange={[Function]}
-                                                                          onFocus={[Function]}
-                                                                          role="textbox"
-                                                                          style={
-                                                                            Object {
-                                                                              "boxSizing": "content-box",
-                                                                              "width": "2px",
-                                                                            }
-                                                                          }
-                                                                          value=""
-                                                                        />
-                                                                        <div
-                                                                          style={
-                                                                            Object {
-                                                                              "height": 0,
-                                                                              "left": 0,
-                                                                              "overflow": "scroll",
-                                                                              "position": "absolute",
-                                                                              "top": 0,
-                                                                              "visibility": "hidden",
-                                                                              "whiteSpace": "pre",
-                                                                            }
-                                                                          }
-                                                                        />
-                                                                      </div>
-                                                                    </AutosizeInput>
-                                                                  </div>
-                                                                  <EuiFormControlLayoutIcons
-                                                                    clear={
-                                                                      Object {
-                                                                        "data-test-subj": "comboBoxClearButton",
-                                                                        "onClick": [Function],
-                                                                      }
-                                                                    }
-                                                                    compressed={false}
-                                                                    icon={
-                                                                      Object {
-                                                                        "aria-label": "Open list of options",
-                                                                        "data-test-subj": "comboBoxToggleListButton",
-                                                                        "disabled": undefined,
-                                                                        "onClick": [Function],
-                                                                        "ref": [Function],
-                                                                        "side": "right",
-                                                                        "type": "arrowDown",
-                                                                      }
-                                                                    }
-                                                                  >
-                                                                    <div
-                                                                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                                                    >
-                                                                      <EuiFormControlLayoutClearButton
-                                                                        data-test-subj="comboBoxClearButton"
-                                                                        onClick={[Function]}
-                                                                        size="m"
-                                                                      >
-                                                                        <EuiI18n
-                                                                          default="Clear input"
-                                                                          token="euiFormControlLayoutClearButton.label"
-                                                                        >
-                                                                          <button
-                                                                            aria-label="Clear input"
-                                                                            className="euiFormControlLayoutClearButton"
-                                                                            data-test-subj="comboBoxClearButton"
-                                                                            onClick={[Function]}
-                                                                            type="button"
-                                                                          >
-                                                                            <EuiIcon
-                                                                              className="euiFormControlLayoutClearButton__icon"
-                                                                              type="cross"
-                                                                            >
-                                                                              EuiIconMock
-                                                                            </EuiIcon>
-                                                                          </button>
-                                                                        </EuiI18n>
-                                                                      </EuiFormControlLayoutClearButton>
-                                                                      <EuiFormControlLayoutCustomIcon
-                                                                        aria-label="Open list of options"
-                                                                        data-test-subj="comboBoxToggleListButton"
-                                                                        iconRef={[Function]}
-                                                                        onClick={[Function]}
-                                                                        size="m"
-                                                                        type="arrowDown"
-                                                                      >
-                                                                        <button
-                                                                          aria-label="Open list of options"
-                                                                          className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                                                          data-test-subj="comboBoxToggleListButton"
-                                                                          onClick={[Function]}
-                                                                          type="button"
-                                                                        >
-                                                                          <EuiIcon
-                                                                            aria-hidden="true"
-                                                                            className="euiFormControlLayoutCustomIcon__icon"
-                                                                            size="m"
-                                                                            type="arrowDown"
-                                                                          >
-                                                                            EuiIconMock
-                                                                          </EuiIcon>
-                                                                        </button>
-                                                                      </EuiFormControlLayoutCustomIcon>
-                                                                    </div>
-                                                                  </EuiFormControlLayoutIcons>
-                                                                </div>
-                                                              </div>
-                                                            </EuiFormControlLayout>
-                                                          </EuiComboBoxInput>
-                                                        </div>
-                                                      </EuiComboBox>
-                                                    </div>
-                                                  </div>
-                                                </EuiFormRow>
-                                              </div>
-                                            </EuiFlexItem>
-                                          </div>
-                                        </EuiFlexGroup>
-                                        <EuiSpacer
-                                          size="m"
-                                        >
-                                          <div
-                                            className="euiSpacer euiSpacer--m"
-                                          />
-                                        </EuiSpacer>
-                                        <EuiRadioGroup
-                                          idSelected="selection-map-value-0-0"
-                                          onChange={[Function]}
-                                          options={
-                                            Array [
-                                              Object {
-                                                "id": "selection-map-value-0-0",
-                                                "label": "Value",
-                                              },
-                                              Object {
-                                                "id": "selection-map-list-0-0",
-                                                "label": "List",
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <div>
-                                            <EuiRadio
-                                              checked={true}
-                                              className="euiRadioGroup__item"
-                                              id="selection-map-value-0-0"
-                                              key="0"
-                                              label="Value"
-                                              onChange={[Function]}
-                                            >
-                                              <div
-                                                className="euiRadio euiRadioGroup__item"
-                                              >
-                                                <input
-                                                  checked={true}
-                                                  className="euiRadio__input"
-                                                  id="selection-map-value-0-0"
-                                                  onChange={[Function]}
-                                                  type="radio"
-                                                />
-                                                <div
-                                                  className="euiRadio__circle"
-                                                />
-                                                <label
-                                                  className="euiRadio__label"
-                                                  htmlFor="selection-map-value-0-0"
-                                                >
-                                                  Value
-                                                </label>
-                                              </div>
-                                            </EuiRadio>
-                                            <EuiRadio
-                                              checked={false}
-                                              className="euiRadioGroup__item"
-                                              id="selection-map-list-0-0"
-                                              key="1"
-                                              label="List"
-                                              onChange={[Function]}
-                                            >
-                                              <div
-                                                className="euiRadio euiRadioGroup__item"
-                                              >
-                                                <input
-                                                  checked={false}
-                                                  className="euiRadio__input"
-                                                  id="selection-map-list-0-0"
-                                                  onChange={[Function]}
-                                                  type="radio"
-                                                />
-                                                <div
-                                                  className="euiRadio__circle"
-                                                />
-                                                <label
-                                                  className="euiRadio__label"
-                                                  htmlFor="selection-map-list-0-0"
-                                                >
-                                                  List
-                                                </label>
-                                              </div>
-                                            </EuiRadio>
-                                          </div>
-                                        </EuiRadioGroup>
-                                        <EuiSpacer
-                                          size="m"
-                                        >
-                                          <div
-                                            className="euiSpacer euiSpacer--m"
-                                          />
-                                        </EuiSpacer>
-                                        <EuiFormRow
-                                          describedByIds={Array []}
-                                          display="row"
-                                          fullWidth={false}
-                                          hasChildLabel={true}
-                                          hasEmptyLabelSpace={false}
-                                          labelType="label"
-                                        >
-                                          <div
-                                            className="euiFormRow"
-                                            id="some_html_id-row"
-                                          >
-                                            <div
-                                              className="euiFormRow__fieldWrapper"
-                                            >
-                                              <EuiFieldText
-                                                data-test-subj="selection_field_value"
-                                                id="some_html_id"
-                                                onBlur={[Function]}
-                                                onChange={[Function]}
-                                                onFocus={[Function]}
-                                                placeholder="Value"
-                                                value=""
-                                              >
-                                                <EuiFormControlLayout
-                                                  fullWidth={false}
-                                                  inputId="some_html_id"
-                                                >
-                                                  <div
-                                                    className="euiFormControlLayout"
-                                                  >
-                                                    <div
-                                                      className="euiFormControlLayout__childrenWrapper"
-                                                    >
-                                                      <EuiValidatableControl>
-                                                        <input
-                                                          className="euiFieldText"
-                                                          data-test-subj="selection_field_value"
-                                                          id="some_html_id"
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          onFocus={[Function]}
-                                                          placeholder="Value"
-                                                          type="text"
-                                                          value=""
-                                                        />
-                                                      </EuiValidatableControl>
-                                                      <EuiFormControlLayoutIcons />
-                                                    </div>
-                                                  </div>
-                                                </EuiFormControlLayout>
-                                              </EuiFieldText>
-                                            </div>
-                                          </div>
-                                        </EuiFormRow>
-                                        <EuiSpacer
-                                          size="m"
-                                        >
-                                          <div
-                                            className="euiSpacer euiSpacer--m"
-                                          />
-                                        </EuiSpacer>
-                                      </div>
-                                    </div>
-                                  </EuiResizeObserver>
-                                </div>
-                              </div>
-                            </EuiAccordion>
-                          </div>
-                          <EuiSpacer
-                            size="m"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--m"
-                            />
-                          </EuiSpacer>
-                          <EuiButton
-                            disabled={true}
-                            iconType="plusInCircle"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "width": "70%",
-                              }
-                            }
-                          >
-                            <EuiButtonDisplay
-                              baseClassName="euiButton"
-                              disabled={true}
-                              element="button"
-                              iconType="plusInCircle"
-                              isDisabled={true}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "width": "70%",
-                                }
-                              }
-                              type="button"
-                            >
-                              <button
-                                className="euiButton euiButton--primary euiButton-isDisabled"
-                                disabled={true}
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "minWidth": undefined,
-                                    "width": "70%",
-                                  }
-                                }
-                                type="button"
-                              >
-                                <EuiButtonContent
-                                  className="euiButton__content"
-                                  iconSide="left"
-                                  iconType="plusInCircle"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButton__text",
-                                    }
-                                  }
-                                >
-                                  <span
-                                    className="euiButtonContent euiButton__content"
-                                  >
-                                    <EuiIcon
-                                      className="euiButtonContent__icon"
-                                      color="inherit"
-                                      size="m"
-                                      type="plusInCircle"
-                                    >
-                                      EuiIconMock
-                                    </EuiIcon>
-                                    <span
-                                      className="euiButton__text"
-                                    >
-                                      Add map
-                                    </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonDisplay>
-                          </EuiButton>
-                        </div>
-                      </EuiPanel>
-                    </div>
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiButton
-                      fullWidth={true}
-                      iconType="plusInCircle"
-                      onClick={[Function]}
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButton"
-                        disabled={false}
-                        element="button"
-                        fullWidth={true}
-                        iconType="plusInCircle"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <button
-                          className="euiButton euiButton--primary euiButton--fullWidth"
-                          disabled={false}
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
-                            iconType="plusInCircle"
-                            textProps={
-                              Object {
-                                "className": "euiButton__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButton__content"
-                            >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="plusInCircle"
-                              >
-                                EuiIconMock
-                              </EuiIcon>
-                              <span
-                                className="euiButton__text"
-                              >
-                                Add selection
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonDisplay>
-                    </EuiButton>
-                    <EuiSpacer>
-                      <div
-                        className="euiSpacer euiSpacer--l"
-                      />
-                    </EuiSpacer>
                     <EuiFormRow
                       describedByIds={Array []}
                       display="row"
@@ -2711,48 +681,19 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
                       label={
-                        <React.Fragment>
-                          <EuiTitle
-                            size="s"
-                          >
-                            <p>
-                              Condition
-                            </p>
-                          </EuiTitle>
-                          <EuiText
-                            size="xs"
-                          >
-                            Define how each selection should be included in the final query. For more options use
-                             
-                            <EuiButtonEmpty
-                              className="empty-text-button"
-                              onClick={[Function]}
-                            >
-                              <EuiText
-                                size="s"
-                              >
-                                YAML editor
-                              </EuiText>
-                            </EuiButtonEmpty>
-                            .
-                          </EuiText>
-                        </React.Fragment>
+                        <EuiText
+                          size="s"
+                        >
+                          <strong>
+                            Log type
+                          </strong>
+                        </EuiText>
                       }
                       labelType="label"
-                      style={
-                        Object {
-                          "maxWidth": "100%",
-                        }
-                      }
                     >
                       <div
                         className="euiFormRow"
                         id="some_html_id-row"
-                        style={
-                          Object {
-                            "maxWidth": "100%",
-                          }
-                        }
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -2767,64 +708,15 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                               className="euiFormLabel euiFormRow__label"
                               htmlFor="some_html_id"
                             >
-                              <EuiTitle
+                              <EuiText
                                 size="s"
                               >
-                                <p
-                                  className="euiTitle euiTitle--small"
-                                >
-                                  Condition
-                                </p>
-                              </EuiTitle>
-                              <EuiText
-                                size="xs"
-                              >
                                 <div
-                                  className="euiText euiText--extraSmall"
+                                  className="euiText euiText--small"
                                 >
-                                  Define how each selection should be included in the final query. For more options use
-                                   
-                                  <EuiButtonEmpty
-                                    className="empty-text-button"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="left"
-                                        iconSize="m"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiButtonContent euiButtonEmpty__content"
-                                        >
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            <EuiText
-                                              size="s"
-                                            >
-                                              <div
-                                                className="euiText euiText--small"
-                                              >
-                                                YAML editor
-                                              </div>
-                                            </EuiText>
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                  .
+                                  <strong>
+                                    Log type
+                                  </strong>
                                 </div>
                               </EuiText>
                             </label>
@@ -2833,268 +725,2344 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                         <div
                           className="euiFormRow__fieldWrapper"
                         >
-                          <EuiCodeEditor
-                            data-test-subj="rule_detection_field"
-                            height="50px"
+                          <EuiComboBox
+                            async={false}
+                            compressed={false}
+                            data-test-subj="rule_type_dropdown"
+                            fullWidth={false}
                             id="some_html_id"
-                            mode="yaml"
+                            isClearable={true}
                             onBlur={[Function]}
                             onChange={[Function]}
                             onFocus={[Function]}
-                            setOptions={Object {}}
-                            value="Selection_1"
-                            width="600px"
+                            options={Array []}
+                            placeholder="Select a log type"
+                            selectedOptions={Array []}
+                            singleSelection={
+                              Object {
+                                "asPlainText": true,
+                              }
+                            }
+                            sortMatchesBy="none"
                           >
                             <div
-                              className="euiCodeEditorWrapper"
-                              data-test-subj="rule_detection_field"
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
+                              className="euiComboBox"
+                              data-test-subj="rule_type_dropdown"
+                              onKeyDown={[Function]}
+                              role="combobox"
+                            >
+                              <EuiComboBoxInput
+                                autoSizeInputRef={[Function]}
+                                compressed={false}
+                                fullWidth={false}
+                                hasSelectedOptions={false}
+                                id="some_html_id"
+                                inputRef={[Function]}
+                                isListOpen={false}
+                                noIcon={false}
+                                onChange={[Function]}
+                                onClear={[Function]}
+                                onClick={[Function]}
+                                onCloseListClick={[Function]}
+                                onFocus={[Function]}
+                                onOpenListClick={[Function]}
+                                onRemoveOption={[Function]}
+                                placeholder="Select a log type"
+                                rootId={[Function]}
+                                searchValue=""
+                                selectedOptions={Array []}
+                                singleSelection={
+                                  Object {
+                                    "asPlainText": true,
+                                  }
+                                }
+                                toggleButtonRef={[Function]}
+                                updatePosition={[Function]}
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={false}
+                                  fullWidth={false}
+                                  icon={
+                                    Object {
+                                      "aria-label": "Open list of options",
+                                      "data-test-subj": "comboBoxToggleListButton",
+                                      "disabled": undefined,
+                                      "onClick": [Function],
+                                      "ref": [Function],
+                                      "side": "right",
+                                      "type": "arrowDown",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout"
+                                  >
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <div
+                                        className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                        data-test-subj="comboBoxInput"
+                                        onClick={[Function]}
+                                        tabIndex={-1}
+                                      >
+                                        <p
+                                          className="euiComboBoxPlaceholder"
+                                        >
+                                          Select a log type
+                                        </p>
+                                        <AutosizeInput
+                                          aria-controls=""
+                                          className="euiComboBox__input"
+                                          data-test-subj="comboBoxSearchInput"
+                                          id="some_html_id"
+                                          injectStyles={true}
+                                          inputRef={[Function]}
+                                          minWidth={1}
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          role="textbox"
+                                          style={
+                                            Object {
+                                              "fontSize": 14,
+                                            }
+                                          }
+                                          value=""
+                                        >
+                                          <div
+                                            className="euiComboBox__input"
+                                            style={
+                                              Object {
+                                                "display": "inline-block",
+                                                "fontSize": 14,
+                                              }
+                                            }
+                                          >
+                                            <input
+                                              aria-controls=""
+                                              data-test-subj="comboBoxSearchInput"
+                                              id="some_html_id"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              role="textbox"
+                                              style={
+                                                Object {
+                                                  "boxSizing": "content-box",
+                                                  "width": "2px",
+                                                }
+                                              }
+                                              value=""
+                                            />
+                                            <div
+                                              style={
+                                                Object {
+                                                  "height": 0,
+                                                  "left": 0,
+                                                  "overflow": "scroll",
+                                                  "position": "absolute",
+                                                  "top": 0,
+                                                  "visibility": "hidden",
+                                                  "whiteSpace": "pre",
+                                                }
+                                              }
+                                            />
+                                          </div>
+                                        </AutosizeInput>
+                                      </div>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={false}
+                                        icon={
+                                          Object {
+                                            "aria-label": "Open list of options",
+                                            "data-test-subj": "comboBoxToggleListButton",
+                                            "disabled": undefined,
+                                            "onClick": [Function],
+                                            "ref": [Function],
+                                            "side": "right",
+                                            "type": "arrowDown",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            aria-label="Open list of options"
+                                            data-test-subj="comboBoxToggleListButton"
+                                            iconRef={[Function]}
+                                            onClick={[Function]}
+                                            size="m"
+                                            type="arrowDown"
+                                          >
+                                            <button
+                                              aria-label="Open list of options"
+                                              className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                              data-test-subj="comboBoxToggleListButton"
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="m"
+                                                type="arrowDown"
+                                              >
+                                                EuiIconMock
+                                              </EuiIcon>
+                                            </button>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiComboBoxInput>
+                            </div>
+                          </EuiComboBox>
+                        </div>
+                      </div>
+                    </EuiFormRow>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  style={
+                    Object {
+                      "marginTop": 36,
+                    }
+                  }
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    style={
+                      Object {
+                        "marginTop": 36,
+                      }
+                    }
+                  >
+                    <EuiButton
+                      href="opensearch_security_analytics_dashboards#/log-types"
+                      target="_blank"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButton"
+                        element="a"
+                        href="opensearch_security_analytics_dashboards#/log-types"
+                        isDisabled={false}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="euiButton euiButton--primary"
+                          disabled={false}
+                          href="opensearch_security_analytics_dashboards#/log-types"
+                          rel="noopener noreferrer"
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                          target="_blank"
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text"
+                              >
+                                Manage 
+                                <EuiIcon
+                                  type="popout"
+                                >
+                                  EuiIconMock
+                                </EuiIcon>
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </a>
+                      </EuiButtonDisplay>
+                    </EuiButton>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <EuiFormRow
+              describedByIds={Array []}
+              display="row"
+              fullWidth={false}
+              hasChildLabel={true}
+              hasEmptyLabelSpace={false}
+              label={
+                <EuiText
+                  size="s"
+                >
+                  <strong>
+                    Rule level (severity)
+                  </strong>
+                </EuiText>
+              }
+              labelType="label"
+            >
+              <div
+                className="euiFormRow"
+                id="some_html_id-row"
+              >
+                <div
+                  className="euiFormRow__labelWrapper"
+                >
+                  <EuiFormLabel
+                    className="euiFormRow__label"
+                    htmlFor="some_html_id"
+                    isFocused={false}
+                    type="label"
+                  >
+                    <label
+                      className="euiFormLabel euiFormRow__label"
+                      htmlFor="some_html_id"
+                    >
+                      <EuiText
+                        size="s"
+                      >
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <strong>
+                            Rule level (severity)
+                          </strong>
+                        </div>
+                      </EuiText>
+                    </label>
+                  </EuiFormLabel>
+                </div>
+                <div
+                  className="euiFormRow__fieldWrapper"
+                >
+                  <EuiComboBox
+                    async={false}
+                    compressed={false}
+                    data-test-subj="rule_severity_dropdown"
+                    fullWidth={false}
+                    id="some_html_id"
+                    isClearable={true}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "label": "Critical",
+                          "value": "critical",
+                        },
+                        Object {
+                          "label": "High",
+                          "value": "high",
+                        },
+                        Object {
+                          "label": "Medium",
+                          "value": "medium",
+                        },
+                        Object {
+                          "label": "Low",
+                          "value": "low",
+                        },
+                        Object {
+                          "label": "Informational",
+                          "value": "informational",
+                        },
+                      ]
+                    }
+                    placeholder="Select a rule level"
+                    selectedOptions={Array []}
+                    singleSelection={
+                      Object {
+                        "asPlainText": true,
+                      }
+                    }
+                    sortMatchesBy="none"
+                  >
+                    <div
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
+                      className="euiComboBox"
+                      data-test-subj="rule_severity_dropdown"
+                      onKeyDown={[Function]}
+                      role="combobox"
+                    >
+                      <EuiComboBoxInput
+                        autoSizeInputRef={[Function]}
+                        compressed={false}
+                        fullWidth={false}
+                        hasSelectedOptions={false}
+                        id="some_html_id"
+                        inputRef={[Function]}
+                        isListOpen={false}
+                        noIcon={false}
+                        onChange={[Function]}
+                        onClear={[Function]}
+                        onClick={[Function]}
+                        onCloseListClick={[Function]}
+                        onFocus={[Function]}
+                        onOpenListClick={[Function]}
+                        onRemoveOption={[Function]}
+                        placeholder="Select a rule level"
+                        rootId={[Function]}
+                        searchValue=""
+                        selectedOptions={Array []}
+                        singleSelection={
+                          Object {
+                            "asPlainText": true,
+                          }
+                        }
+                        toggleButtonRef={[Function]}
+                        updatePosition={[Function]}
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={false}
+                          fullWidth={false}
+                          icon={
+                            Object {
+                              "aria-label": "Open list of options",
+                              "data-test-subj": "comboBoxToggleListButton",
+                              "disabled": undefined,
+                              "onClick": [Function],
+                              "ref": [Function],
+                              "side": "right",
+                              "type": "arrowDown",
+                            }
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                data-test-subj="comboBoxInput"
+                                onClick={[Function]}
+                                tabIndex={-1}
+                              >
+                                <p
+                                  className="euiComboBoxPlaceholder"
+                                >
+                                  Select a rule level
+                                </p>
+                                <AutosizeInput
+                                  aria-controls=""
+                                  className="euiComboBox__input"
+                                  data-test-subj="comboBoxSearchInput"
+                                  id="some_html_id"
+                                  injectStyles={true}
+                                  inputRef={[Function]}
+                                  minWidth={1}
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  role="textbox"
+                                  style={
+                                    Object {
+                                      "fontSize": 14,
+                                    }
+                                  }
+                                  value=""
+                                >
+                                  <div
+                                    className="euiComboBox__input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-controls=""
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "2px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </AutosizeInput>
+                              </div>
+                              <EuiFormControlLayoutIcons
+                                compressed={false}
+                                icon={
+                                  Object {
+                                    "aria-label": "Open list of options",
+                                    "data-test-subj": "comboBoxToggleListButton",
+                                    "disabled": undefined,
+                                    "onClick": [Function],
+                                    "ref": [Function],
+                                    "side": "right",
+                                    "type": "arrowDown",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    aria-label="Open list of options"
+                                    data-test-subj="comboBoxToggleListButton"
+                                    iconRef={[Function]}
+                                    onClick={[Function]}
+                                    size="m"
+                                    type="arrowDown"
+                                  >
+                                    <button
+                                      aria-label="Open list of options"
+                                      className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                      data-test-subj="comboBoxToggleListButton"
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        EuiIconMock
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiComboBoxInput>
+                    </div>
+                  </EuiComboBox>
+                </div>
+              </div>
+            </EuiFormRow>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <EuiFormRow
+              describedByIds={Array []}
+              display="row"
+              fullWidth={false}
+              hasChildLabel={true}
+              hasEmptyLabelSpace={false}
+              label={
+                <EuiText
+                  size="s"
+                >
+                  <strong>
+                    Rule Status
+                  </strong>
+                </EuiText>
+              }
+              labelType="label"
+            >
+              <div
+                className="euiFormRow"
+                id="some_html_id-row"
+              >
+                <div
+                  className="euiFormRow__labelWrapper"
+                >
+                  <EuiFormLabel
+                    className="euiFormRow__label"
+                    htmlFor="some_html_id"
+                    isFocused={false}
+                    type="label"
+                  >
+                    <label
+                      className="euiFormLabel euiFormRow__label"
+                      htmlFor="some_html_id"
+                    >
+                      <EuiText
+                        size="s"
+                      >
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <strong>
+                            Rule Status
+                          </strong>
+                        </div>
+                      </EuiText>
+                    </label>
+                  </EuiFormLabel>
+                </div>
+                <div
+                  className="euiFormRow__fieldWrapper"
+                >
+                  <EuiComboBox
+                    async={false}
+                    compressed={false}
+                    data-test-subj="rule_status_dropdown"
+                    fullWidth={false}
+                    id="some_html_id"
+                    isClearable={true}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "label": "experimental",
+                          "value": "experimental",
+                        },
+                        Object {
+                          "label": "test",
+                          "value": "test",
+                        },
+                        Object {
+                          "label": "stable",
+                          "value": "stable",
+                        },
+                      ]
+                    }
+                    placeholder="Select a rule status"
+                    selectedOptions={
+                      Array [
+                        Object {
+                          "label": "experimental",
+                          "value": "experimental",
+                        },
+                      ]
+                    }
+                    singleSelection={
+                      Object {
+                        "asPlainText": true,
+                      }
+                    }
+                    sortMatchesBy="none"
+                  >
+                    <div
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
+                      className="euiComboBox"
+                      data-test-subj="rule_status_dropdown"
+                      onKeyDown={[Function]}
+                      role="combobox"
+                    >
+                      <EuiComboBoxInput
+                        autoSizeInputRef={[Function]}
+                        compressed={false}
+                        fullWidth={false}
+                        hasSelectedOptions={true}
+                        id="some_html_id"
+                        inputRef={[Function]}
+                        isListOpen={false}
+                        noIcon={false}
+                        onChange={[Function]}
+                        onClear={[Function]}
+                        onClick={[Function]}
+                        onCloseListClick={[Function]}
+                        onFocus={[Function]}
+                        onOpenListClick={[Function]}
+                        onRemoveOption={[Function]}
+                        placeholder="Select a rule status"
+                        rootId={[Function]}
+                        searchValue=""
+                        selectedOptions={
+                          Array [
+                            Object {
+                              "label": "experimental",
+                              "value": "experimental",
+                            },
+                          ]
+                        }
+                        singleSelection={
+                          Object {
+                            "asPlainText": true,
+                          }
+                        }
+                        toggleButtonRef={[Function]}
+                        updatePosition={[Function]}
+                        value="experimental"
+                      >
+                        <EuiFormControlLayout
+                          clear={
+                            Object {
+                              "data-test-subj": "comboBoxClearButton",
+                              "onClick": [Function],
+                            }
+                          }
+                          compressed={false}
+                          fullWidth={false}
+                          icon={
+                            Object {
+                              "aria-label": "Open list of options",
+                              "data-test-subj": "comboBoxToggleListButton",
+                              "disabled": undefined,
+                              "onClick": [Function],
+                              "ref": [Function],
+                              "side": "right",
+                              "type": "arrowDown",
+                            }
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                data-test-subj="comboBoxInput"
+                                onClick={[Function]}
+                                tabIndex={-1}
+                              >
+                                <EuiComboBoxPill
+                                  asPlainText={true}
+                                  color="hollow"
+                                  key="experimental"
+                                  option={
+                                    Object {
+                                      "label": "experimental",
+                                      "value": "experimental",
+                                    }
+                                  }
+                                  value="experimental"
+                                >
+                                  <span
+                                    className="euiComboBoxPill euiComboBoxPill--plainText"
+                                    value="experimental"
+                                  >
+                                    experimental
+                                  </span>
+                                </EuiComboBoxPill>
+                                <AutosizeInput
+                                  aria-controls=""
+                                  className="euiComboBox__input"
+                                  data-test-subj="comboBoxSearchInput"
+                                  id="some_html_id"
+                                  injectStyles={true}
+                                  inputRef={[Function]}
+                                  minWidth={1}
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  role="textbox"
+                                  style={
+                                    Object {
+                                      "fontSize": 14,
+                                    }
+                                  }
+                                  value=""
+                                >
+                                  <div
+                                    className="euiComboBox__input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-controls=""
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "2px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </AutosizeInput>
+                              </div>
+                              <EuiFormControlLayoutIcons
+                                clear={
+                                  Object {
+                                    "data-test-subj": "comboBoxClearButton",
+                                    "onClick": [Function],
+                                  }
+                                }
+                                compressed={false}
+                                icon={
+                                  Object {
+                                    "aria-label": "Open list of options",
+                                    "data-test-subj": "comboBoxToggleListButton",
+                                    "disabled": undefined,
+                                    "onClick": [Function],
+                                    "ref": [Function],
+                                    "side": "right",
+                                    "type": "arrowDown",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <EuiFormControlLayoutClearButton
+                                    data-test-subj="comboBoxClearButton"
+                                    onClick={[Function]}
+                                    size="m"
+                                  >
+                                    <EuiI18n
+                                      default="Clear input"
+                                      token="euiFormControlLayoutClearButton.label"
+                                    >
+                                      <button
+                                        aria-label="Clear input"
+                                        className="euiFormControlLayoutClearButton"
+                                        data-test-subj="comboBoxClearButton"
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          className="euiFormControlLayoutClearButton__icon"
+                                          type="cross"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiI18n>
+                                  </EuiFormControlLayoutClearButton>
+                                  <EuiFormControlLayoutCustomIcon
+                                    aria-label="Open list of options"
+                                    data-test-subj="comboBoxToggleListButton"
+                                    iconRef={[Function]}
+                                    onClick={[Function]}
+                                    size="m"
+                                    type="arrowDown"
+                                  >
+                                    <button
+                                      aria-label="Open list of options"
+                                      className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                      data-test-subj="comboBoxToggleListButton"
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        EuiIconMock
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiComboBoxInput>
+                    </div>
+                  </EuiComboBox>
+                </div>
+              </div>
+            </EuiFormRow>
+            <EuiSpacer
+              size="xxl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xxl"
+              />
+            </EuiSpacer>
+            <EuiTitle>
+              <EuiText
+                className="euiTitle euiTitle--medium"
+              >
+                <div
+                  className="euiText euiText--medium euiTitle euiTitle--medium"
+                >
+                  <h2>
+                    Detection
+                  </h2>
+                </div>
+              </EuiText>
+            </EuiTitle>
+            <EuiText
+              size="s"
+            >
+              <div
+                className="euiText euiText--small"
+              >
+                <p>
+                  Define the detection criteria for the rule
+                </p>
+              </div>
+            </EuiText>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <DetectionVisualEditor
+              detectionYml=""
+              goToYamlEditor={[Function]}
+              onChange={[Function]}
+              setIsDetectionInvalid={[Function]}
+            >
+              <div
+                className="detection-visual-editor"
+                style={
+                  Object {
+                    "maxWidth": 1000,
+                  }
+                }
+              >
+                <div
+                  key="detection-visual-editor-selection-0"
+                >
+                  <EuiPanel
+                    className="detection-visual-editor-selection"
+                    data-test-subj="detection-visual-editor-0"
+                    key="detection-visual-editor-0"
+                  >
+                    <div
+                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow detection-visual-editor-selection"
+                      data-test-subj="detection-visual-editor-0"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem
+                            grow={true}
+                          >
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiFormRow
+                                describedByIds={Array []}
+                                display="row"
+                                fullWidth={false}
+                                hasChildLabel={true}
+                                hasEmptyLabelSpace={false}
+                                labelType="label"
+                              >
+                                <div
+                                  className="euiFormRow"
+                                  id="some_html_id-row"
+                                >
+                                  <div
+                                    className="euiFormRow__fieldWrapper"
+                                  >
+                                    <EuiFieldText
+                                      className="detection-visual-editor-name euiTitle--small"
+                                      data-test-subj="selection_name"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      placeholder="Enter selection name"
+                                      value="Selection_1"
+                                    >
+                                      <EuiFormControlLayout
+                                        fullWidth={false}
+                                        inputId="some_html_id"
+                                      >
+                                        <div
+                                          className="euiFormControlLayout"
+                                        >
+                                          <div
+                                            className="euiFormControlLayout__childrenWrapper"
+                                          >
+                                            <EuiValidatableControl>
+                                              <input
+                                                className="euiFieldText detection-visual-editor-name euiTitle--small"
+                                                data-test-subj="selection_name"
+                                                id="some_html_id"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                placeholder="Enter selection name"
+                                                type="text"
+                                                value="Selection_1"
+                                              />
+                                            </EuiValidatableControl>
+                                            <EuiFormControlLayoutIcons />
+                                          </div>
+                                        </div>
+                                      </EuiFormControlLayout>
+                                    </EuiFieldText>
+                                  </div>
+                                </div>
+                              </EuiFormRow>
+                              <EuiText
+                                size="s"
+                              >
+                                <div
+                                  className="euiText euiText--small"
+                                >
+                                  <p>
+                                    Define the search identifier in your data the rule will be applied to.
+                                  </p>
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            className="detection-visual-editor-delete-selection"
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero detection-visual-editor-delete-selection"
+                            />
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                      <EuiSpacer>
+                        <div
+                          className="euiSpacer euiSpacer--l"
+                        />
+                      </EuiSpacer>
+                      <div
+                        className="detection-visual-editor-accordion-wrapper"
+                        key="Map-0"
+                      >
+                        <EuiAccordion
+                          arrowDisplay="left"
+                          buttonContent={
+                            <EuiText
+                              size="m"
+                            >
+                              Map 
+                              1
+                            </EuiText>
+                          }
+                          className="euiAccordionForm detection-visual-editor-accordion"
+                          data-test-subj="Map-0"
+                          extraAction={null}
+                          id="Map-0"
+                          initialIsOpen={true}
+                          isLoading={false}
+                          isLoadingMessage={false}
+                          key="Map-0"
+                          paddingSize="m"
+                          style={
+                            Object {
+                              "maxWidth": "70%",
+                            }
+                          }
+                        >
+                          <div
+                            className="euiAccordion euiAccordion-isOpen euiAccordionForm detection-visual-editor-accordion"
+                            data-test-subj="Map-0"
+                            style={
+                              Object {
+                                "maxWidth": "70%",
+                              }
+                            }
+                          >
+                            <div
+                              className="euiAccordion__triggerWrapper"
+                            >
+                              <button
+                                aria-controls="Map-0"
+                                aria-expanded={true}
+                                className="euiAccordion__button"
+                                id="some_html_id"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiAccordion__iconWrapper"
+                                >
+                                  <EuiIcon
+                                    className="euiAccordion__icon euiAccordion__icon-isOpen"
+                                    size="m"
+                                    type="arrowRight"
+                                  >
+                                    EuiIconMock
+                                  </EuiIcon>
+                                </span>
+                                <span
+                                  className="euiIEFlexWrapFix"
+                                >
+                                  <EuiText
+                                    size="m"
+                                  >
+                                    <div
+                                      className="euiText euiText--medium"
+                                    >
+                                      Map 
+                                      1
+                                    </div>
+                                  </EuiText>
+                                </span>
+                              </button>
+                            </div>
+                            <div
+                              aria-labelledby="some_html_id"
+                              className="euiAccordion__childWrapper"
+                              id="Map-0"
+                              role="region"
+                              tabIndex={-1}
+                            >
+                              <EuiResizeObserver
+                                onResize={[Function]}
+                              >
+                                <div>
+                                  <div
+                                    className="euiAccordion__padding--m"
+                                  >
+                                    <EuiFlexGroup>
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                          style={
+                                            Object {
+                                              "minWidth": 200,
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            style={
+                                              Object {
+                                                "minWidth": 200,
+                                              }
+                                            }
+                                          >
+                                            <EuiFormRow
+                                              describedByIds={Array []}
+                                              display="row"
+                                              fullWidth={false}
+                                              hasChildLabel={true}
+                                              hasEmptyLabelSpace={false}
+                                              label={
+                                                <EuiText
+                                                  size="s"
+                                                >
+                                                  Key
+                                                </EuiText>
+                                              }
+                                              labelType="label"
+                                            >
+                                              <div
+                                                className="euiFormRow"
+                                                id="some_html_id-row"
+                                              >
+                                                <div
+                                                  className="euiFormRow__labelWrapper"
+                                                >
+                                                  <EuiFormLabel
+                                                    className="euiFormRow__label"
+                                                    htmlFor="some_html_id"
+                                                    isFocused={false}
+                                                    type="label"
+                                                  >
+                                                    <label
+                                                      className="euiFormLabel euiFormRow__label"
+                                                      htmlFor="some_html_id"
+                                                    >
+                                                      <EuiText
+                                                        size="s"
+                                                      >
+                                                        <div
+                                                          className="euiText euiText--small"
+                                                        >
+                                                          Key
+                                                        </div>
+                                                      </EuiText>
+                                                    </label>
+                                                  </EuiFormLabel>
+                                                </div>
+                                                <div
+                                                  className="euiFormRow__fieldWrapper"
+                                                >
+                                                  <EuiFieldText
+                                                    data-test-subj="selection_field_key_name"
+                                                    id="some_html_id"
+                                                    onBlur={[Function]}
+                                                    onChange={[Function]}
+                                                    onFocus={[Function]}
+                                                    placeholder="Enter key name"
+                                                    value=""
+                                                  >
+                                                    <EuiFormControlLayout
+                                                      fullWidth={false}
+                                                      inputId="some_html_id"
+                                                    >
+                                                      <div
+                                                        className="euiFormControlLayout"
+                                                      >
+                                                        <div
+                                                          className="euiFormControlLayout__childrenWrapper"
+                                                        >
+                                                          <EuiValidatableControl>
+                                                            <input
+                                                              className="euiFieldText"
+                                                              data-test-subj="selection_field_key_name"
+                                                              id="some_html_id"
+                                                              onBlur={[Function]}
+                                                              onChange={[Function]}
+                                                              onFocus={[Function]}
+                                                              placeholder="Enter key name"
+                                                              type="text"
+                                                              value=""
+                                                            />
+                                                          </EuiValidatableControl>
+                                                          <EuiFormControlLayoutIcons />
+                                                        </div>
+                                                      </div>
+                                                    </EuiFormControlLayout>
+                                                  </EuiFieldText>
+                                                </div>
+                                              </div>
+                                            </EuiFormRow>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={false}
+                                          style={
+                                            Object {
+                                              "minWidth": 200,
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            style={
+                                              Object {
+                                                "minWidth": 200,
+                                              }
+                                            }
+                                          >
+                                            <EuiFormRow
+                                              describedByIds={Array []}
+                                              display="row"
+                                              fullWidth={false}
+                                              hasChildLabel={true}
+                                              hasEmptyLabelSpace={false}
+                                              label={
+                                                <EuiText
+                                                  size="s"
+                                                >
+                                                  Modifier
+                                                </EuiText>
+                                              }
+                                              labelType="label"
+                                            >
+                                              <div
+                                                className="euiFormRow"
+                                                id="some_html_id-row"
+                                              >
+                                                <div
+                                                  className="euiFormRow__labelWrapper"
+                                                >
+                                                  <EuiFormLabel
+                                                    className="euiFormRow__label"
+                                                    htmlFor="some_html_id"
+                                                    isFocused={false}
+                                                    type="label"
+                                                  >
+                                                    <label
+                                                      className="euiFormLabel euiFormRow__label"
+                                                      htmlFor="some_html_id"
+                                                    >
+                                                      <EuiText
+                                                        size="s"
+                                                      >
+                                                        <div
+                                                          className="euiText euiText--small"
+                                                        >
+                                                          Modifier
+                                                        </div>
+                                                      </EuiText>
+                                                    </label>
+                                                  </EuiFormLabel>
+                                                </div>
+                                                <div
+                                                  className="euiFormRow__fieldWrapper"
+                                                >
+                                                  <EuiComboBox
+                                                    async={false}
+                                                    compressed={false}
+                                                    data-test-subj="modifier_dropdown"
+                                                    fullWidth={false}
+                                                    id="some_html_id"
+                                                    isClearable={true}
+                                                    onBlur={[Function]}
+                                                    onChange={[Function]}
+                                                    onFocus={[Function]}
+                                                    options={
+                                                      Array [
+                                                        Object {
+                                                          "label": "all",
+                                                          "value": "all",
+                                                        },
+                                                        Object {
+                                                          "label": "contains",
+                                                          "value": "contains",
+                                                        },
+                                                        Object {
+                                                          "label": "base64",
+                                                          "value": "base64",
+                                                        },
+                                                        Object {
+                                                          "label": "endswith",
+                                                          "value": "endswith",
+                                                        },
+                                                        Object {
+                                                          "label": "startswith",
+                                                          "value": "startswith",
+                                                        },
+                                                        Object {
+                                                          "label": "cidr",
+                                                          "value": "cidr",
+                                                        },
+                                                      ]
+                                                    }
+                                                    selectedOptions={
+                                                      Array [
+                                                        Object {
+                                                          "label": "all",
+                                                          "value": "all",
+                                                        },
+                                                      ]
+                                                    }
+                                                    singleSelection={
+                                                      Object {
+                                                        "asPlainText": true,
+                                                      }
+                                                    }
+                                                    sortMatchesBy="none"
+                                                  >
+                                                    <div
+                                                      aria-expanded={false}
+                                                      aria-haspopup="listbox"
+                                                      className="euiComboBox"
+                                                      data-test-subj="modifier_dropdown"
+                                                      onKeyDown={[Function]}
+                                                      role="combobox"
+                                                    >
+                                                      <EuiComboBoxInput
+                                                        autoSizeInputRef={[Function]}
+                                                        compressed={false}
+                                                        fullWidth={false}
+                                                        hasSelectedOptions={true}
+                                                        id="some_html_id"
+                                                        inputRef={[Function]}
+                                                        isListOpen={false}
+                                                        noIcon={false}
+                                                        onChange={[Function]}
+                                                        onClear={[Function]}
+                                                        onClick={[Function]}
+                                                        onCloseListClick={[Function]}
+                                                        onFocus={[Function]}
+                                                        onOpenListClick={[Function]}
+                                                        onRemoveOption={[Function]}
+                                                        rootId={[Function]}
+                                                        searchValue=""
+                                                        selectedOptions={
+                                                          Array [
+                                                            Object {
+                                                              "label": "all",
+                                                              "value": "all",
+                                                            },
+                                                          ]
+                                                        }
+                                                        singleSelection={
+                                                          Object {
+                                                            "asPlainText": true,
+                                                          }
+                                                        }
+                                                        toggleButtonRef={[Function]}
+                                                        updatePosition={[Function]}
+                                                        value="all"
+                                                      >
+                                                        <EuiFormControlLayout
+                                                          clear={
+                                                            Object {
+                                                              "data-test-subj": "comboBoxClearButton",
+                                                              "onClick": [Function],
+                                                            }
+                                                          }
+                                                          compressed={false}
+                                                          fullWidth={false}
+                                                          icon={
+                                                            Object {
+                                                              "aria-label": "Open list of options",
+                                                              "data-test-subj": "comboBoxToggleListButton",
+                                                              "disabled": undefined,
+                                                              "onClick": [Function],
+                                                              "ref": [Function],
+                                                              "side": "right",
+                                                              "type": "arrowDown",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="euiFormControlLayout"
+                                                          >
+                                                            <div
+                                                              className="euiFormControlLayout__childrenWrapper"
+                                                            >
+                                                              <div
+                                                                className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                                                data-test-subj="comboBoxInput"
+                                                                onClick={[Function]}
+                                                                tabIndex={-1}
+                                                              >
+                                                                <EuiComboBoxPill
+                                                                  asPlainText={true}
+                                                                  color="hollow"
+                                                                  key="all"
+                                                                  option={
+                                                                    Object {
+                                                                      "label": "all",
+                                                                      "value": "all",
+                                                                    }
+                                                                  }
+                                                                  value="all"
+                                                                >
+                                                                  <span
+                                                                    className="euiComboBoxPill euiComboBoxPill--plainText"
+                                                                    value="all"
+                                                                  >
+                                                                    all
+                                                                  </span>
+                                                                </EuiComboBoxPill>
+                                                                <AutosizeInput
+                                                                  aria-controls=""
+                                                                  className="euiComboBox__input"
+                                                                  data-test-subj="comboBoxSearchInput"
+                                                                  id="some_html_id"
+                                                                  injectStyles={true}
+                                                                  inputRef={[Function]}
+                                                                  minWidth={1}
+                                                                  onBlur={[Function]}
+                                                                  onChange={[Function]}
+                                                                  onFocus={[Function]}
+                                                                  role="textbox"
+                                                                  style={
+                                                                    Object {
+                                                                      "fontSize": 14,
+                                                                    }
+                                                                  }
+                                                                  value=""
+                                                                >
+                                                                  <div
+                                                                    className="euiComboBox__input"
+                                                                    style={
+                                                                      Object {
+                                                                        "display": "inline-block",
+                                                                        "fontSize": 14,
+                                                                      }
+                                                                    }
+                                                                  >
+                                                                    <input
+                                                                      aria-controls=""
+                                                                      data-test-subj="comboBoxSearchInput"
+                                                                      id="some_html_id"
+                                                                      onBlur={[Function]}
+                                                                      onChange={[Function]}
+                                                                      onFocus={[Function]}
+                                                                      role="textbox"
+                                                                      style={
+                                                                        Object {
+                                                                          "boxSizing": "content-box",
+                                                                          "width": "2px",
+                                                                        }
+                                                                      }
+                                                                      value=""
+                                                                    />
+                                                                    <div
+                                                                      style={
+                                                                        Object {
+                                                                          "height": 0,
+                                                                          "left": 0,
+                                                                          "overflow": "scroll",
+                                                                          "position": "absolute",
+                                                                          "top": 0,
+                                                                          "visibility": "hidden",
+                                                                          "whiteSpace": "pre",
+                                                                        }
+                                                                      }
+                                                                    />
+                                                                  </div>
+                                                                </AutosizeInput>
+                                                              </div>
+                                                              <EuiFormControlLayoutIcons
+                                                                clear={
+                                                                  Object {
+                                                                    "data-test-subj": "comboBoxClearButton",
+                                                                    "onClick": [Function],
+                                                                  }
+                                                                }
+                                                                compressed={false}
+                                                                icon={
+                                                                  Object {
+                                                                    "aria-label": "Open list of options",
+                                                                    "data-test-subj": "comboBoxToggleListButton",
+                                                                    "disabled": undefined,
+                                                                    "onClick": [Function],
+                                                                    "ref": [Function],
+                                                                    "side": "right",
+                                                                    "type": "arrowDown",
+                                                                  }
+                                                                }
+                                                              >
+                                                                <div
+                                                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                                                >
+                                                                  <EuiFormControlLayoutClearButton
+                                                                    data-test-subj="comboBoxClearButton"
+                                                                    onClick={[Function]}
+                                                                    size="m"
+                                                                  >
+                                                                    <EuiI18n
+                                                                      default="Clear input"
+                                                                      token="euiFormControlLayoutClearButton.label"
+                                                                    >
+                                                                      <button
+                                                                        aria-label="Clear input"
+                                                                        className="euiFormControlLayoutClearButton"
+                                                                        data-test-subj="comboBoxClearButton"
+                                                                        onClick={[Function]}
+                                                                        type="button"
+                                                                      >
+                                                                        <EuiIcon
+                                                                          className="euiFormControlLayoutClearButton__icon"
+                                                                          type="cross"
+                                                                        >
+                                                                          EuiIconMock
+                                                                        </EuiIcon>
+                                                                      </button>
+                                                                    </EuiI18n>
+                                                                  </EuiFormControlLayoutClearButton>
+                                                                  <EuiFormControlLayoutCustomIcon
+                                                                    aria-label="Open list of options"
+                                                                    data-test-subj="comboBoxToggleListButton"
+                                                                    iconRef={[Function]}
+                                                                    onClick={[Function]}
+                                                                    size="m"
+                                                                    type="arrowDown"
+                                                                  >
+                                                                    <button
+                                                                      aria-label="Open list of options"
+                                                                      className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                                                      data-test-subj="comboBoxToggleListButton"
+                                                                      onClick={[Function]}
+                                                                      type="button"
+                                                                    >
+                                                                      <EuiIcon
+                                                                        aria-hidden="true"
+                                                                        className="euiFormControlLayoutCustomIcon__icon"
+                                                                        size="m"
+                                                                        type="arrowDown"
+                                                                      >
+                                                                        EuiIconMock
+                                                                      </EuiIcon>
+                                                                    </button>
+                                                                  </EuiFormControlLayoutCustomIcon>
+                                                                </div>
+                                                              </EuiFormControlLayoutIcons>
+                                                            </div>
+                                                          </div>
+                                                        </EuiFormControlLayout>
+                                                      </EuiComboBoxInput>
+                                                    </div>
+                                                  </EuiComboBox>
+                                                </div>
+                                              </div>
+                                            </EuiFormRow>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                    <EuiSpacer
+                                      size="m"
+                                    >
+                                      <div
+                                        className="euiSpacer euiSpacer--m"
+                                      />
+                                    </EuiSpacer>
+                                    <EuiRadioGroup
+                                      idSelected="selection-map-value-0-0"
+                                      onChange={[Function]}
+                                      options={
+                                        Array [
+                                          Object {
+                                            "id": "selection-map-value-0-0",
+                                            "label": "Value",
+                                          },
+                                          Object {
+                                            "id": "selection-map-list-0-0",
+                                            "label": "List",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <div>
+                                        <EuiRadio
+                                          checked={true}
+                                          className="euiRadioGroup__item"
+                                          id="selection-map-value-0-0"
+                                          key="0"
+                                          label="Value"
+                                          onChange={[Function]}
+                                        >
+                                          <div
+                                            className="euiRadio euiRadioGroup__item"
+                                          >
+                                            <input
+                                              checked={true}
+                                              className="euiRadio__input"
+                                              id="selection-map-value-0-0"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            <div
+                                              className="euiRadio__circle"
+                                            />
+                                            <label
+                                              className="euiRadio__label"
+                                              htmlFor="selection-map-value-0-0"
+                                            >
+                                              Value
+                                            </label>
+                                          </div>
+                                        </EuiRadio>
+                                        <EuiRadio
+                                          checked={false}
+                                          className="euiRadioGroup__item"
+                                          id="selection-map-list-0-0"
+                                          key="1"
+                                          label="List"
+                                          onChange={[Function]}
+                                        >
+                                          <div
+                                            className="euiRadio euiRadioGroup__item"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiRadio__input"
+                                              id="selection-map-list-0-0"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            <div
+                                              className="euiRadio__circle"
+                                            />
+                                            <label
+                                              className="euiRadio__label"
+                                              htmlFor="selection-map-list-0-0"
+                                            >
+                                              List
+                                            </label>
+                                          </div>
+                                        </EuiRadio>
+                                      </div>
+                                    </EuiRadioGroup>
+                                    <EuiSpacer
+                                      size="m"
+                                    >
+                                      <div
+                                        className="euiSpacer euiSpacer--m"
+                                      />
+                                    </EuiSpacer>
+                                    <EuiFormRow
+                                      describedByIds={Array []}
+                                      display="row"
+                                      fullWidth={false}
+                                      hasChildLabel={true}
+                                      hasEmptyLabelSpace={false}
+                                      labelType="label"
+                                    >
+                                      <div
+                                        className="euiFormRow"
+                                        id="some_html_id-row"
+                                      >
+                                        <div
+                                          className="euiFormRow__fieldWrapper"
+                                        >
+                                          <EuiFieldText
+                                            data-test-subj="selection_field_value"
+                                            id="some_html_id"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            placeholder="Value"
+                                            value=""
+                                          >
+                                            <EuiFormControlLayout
+                                              fullWidth={false}
+                                              inputId="some_html_id"
+                                            >
+                                              <div
+                                                className="euiFormControlLayout"
+                                              >
+                                                <div
+                                                  className="euiFormControlLayout__childrenWrapper"
+                                                >
+                                                  <EuiValidatableControl>
+                                                    <input
+                                                      className="euiFieldText"
+                                                      data-test-subj="selection_field_value"
+                                                      id="some_html_id"
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      onFocus={[Function]}
+                                                      placeholder="Value"
+                                                      type="text"
+                                                      value=""
+                                                    />
+                                                  </EuiValidatableControl>
+                                                  <EuiFormControlLayoutIcons />
+                                                </div>
+                                              </div>
+                                            </EuiFormControlLayout>
+                                          </EuiFieldText>
+                                        </div>
+                                      </div>
+                                    </EuiFormRow>
+                                    <EuiSpacer
+                                      size="m"
+                                    >
+                                      <div
+                                        className="euiSpacer euiSpacer--m"
+                                      />
+                                    </EuiSpacer>
+                                  </div>
+                                </div>
+                              </EuiResizeObserver>
+                            </div>
+                          </div>
+                        </EuiAccordion>
+                      </div>
+                      <EuiSpacer
+                        size="m"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiButton
+                        disabled={true}
+                        iconType="plusInCircle"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": "70%",
+                          }
+                        }
+                      >
+                        <EuiButtonDisplay
+                          baseClassName="euiButton"
+                          disabled={true}
+                          element="button"
+                          iconType="plusInCircle"
+                          isDisabled={true}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "width": "70%",
+                            }
+                          }
+                          type="button"
+                        >
+                          <button
+                            className="euiButton euiButton--primary euiButton-isDisabled"
+                            disabled={true}
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "minWidth": undefined,
+                                "width": "70%",
+                              }
+                            }
+                            type="button"
+                          >
+                            <EuiButtonContent
+                              className="euiButton__content"
+                              iconSide="left"
+                              iconType="plusInCircle"
+                              textProps={
+                                Object {
+                                  "className": "euiButton__text",
+                                }
+                              }
+                            >
+                              <span
+                                className="euiButtonContent euiButton__content"
+                              >
+                                <EuiIcon
+                                  className="euiButtonContent__icon"
+                                  color="inherit"
+                                  size="m"
+                                  type="plusInCircle"
+                                >
+                                  EuiIconMock
+                                </EuiIcon>
+                                <span
+                                  className="euiButton__text"
+                                >
+                                  Add map
+                                </span>
+                              </span>
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonDisplay>
+                      </EuiButton>
+                    </div>
+                  </EuiPanel>
+                </div>
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiButton
+                  fullWidth={true}
+                  iconType="plusInCircle"
+                  onClick={[Function]}
+                >
+                  <EuiButtonDisplay
+                    baseClassName="euiButton"
+                    disabled={false}
+                    element="button"
+                    fullWidth={true}
+                    iconType="plusInCircle"
+                    isDisabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="euiButton euiButton--primary euiButton--fullWidth"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "minWidth": undefined,
+                        }
+                      }
+                      type="button"
+                    >
+                      <EuiButtonContent
+                        className="euiButton__content"
+                        iconSide="left"
+                        iconType="plusInCircle"
+                        textProps={
+                          Object {
+                            "className": "euiButton__text",
+                          }
+                        }
+                      >
+                        <span
+                          className="euiButtonContent euiButton__content"
+                        >
+                          <EuiIcon
+                            className="euiButtonContent__icon"
+                            color="inherit"
+                            size="m"
+                            type="plusInCircle"
+                          >
+                            EuiIconMock
+                          </EuiIcon>
+                          <span
+                            className="euiButton__text"
+                          >
+                            Add selection
+                          </span>
+                        </span>
+                      </EuiButtonContent>
+                    </button>
+                  </EuiButtonDisplay>
+                </EuiButton>
+                <EuiSpacer>
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                </EuiSpacer>
+                <EuiFormRow
+                  describedByIds={Array []}
+                  display="row"
+                  fullWidth={false}
+                  hasChildLabel={true}
+                  hasEmptyLabelSpace={false}
+                  label={
+                    <React.Fragment>
+                      <EuiTitle
+                        size="s"
+                      >
+                        <p>
+                          Condition
+                        </p>
+                      </EuiTitle>
+                      <EuiText
+                        size="xs"
+                      >
+                        Define how each selection should be included in the final query. For more options use
+                         
+                        <EuiButtonEmpty
+                          className="empty-text-button"
+                          onClick={[Function]}
+                        >
+                          <EuiText
+                            size="s"
+                          >
+                            YAML editor
+                          </EuiText>
+                        </EuiButtonEmpty>
+                        .
+                      </EuiText>
+                    </React.Fragment>
+                  }
+                  labelType="label"
+                  style={
+                    Object {
+                      "maxWidth": "100%",
+                    }
+                  }
+                >
+                  <div
+                    className="euiFormRow"
+                    id="some_html_id-row"
+                    style={
+                      Object {
+                        "maxWidth": "100%",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFormRow__labelWrapper"
+                    >
+                      <EuiFormLabel
+                        className="euiFormRow__label"
+                        htmlFor="some_html_id"
+                        isFocused={false}
+                        type="label"
+                      >
+                        <label
+                          className="euiFormLabel euiFormRow__label"
+                          htmlFor="some_html_id"
+                        >
+                          <EuiTitle
+                            size="s"
+                          >
+                            <p
+                              className="euiTitle euiTitle--small"
+                            >
+                              Condition
+                            </p>
+                          </EuiTitle>
+                          <EuiText
+                            size="xs"
+                          >
+                            <div
+                              className="euiText euiText--extraSmall"
+                            >
+                              Define how each selection should be included in the final query. For more options use
+                               
+                              <EuiButtonEmpty
+                                className="empty-text-button"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary empty-text-button"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="m"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        <EuiText
+                                          size="s"
+                                        >
+                                          <div
+                                            className="euiText euiText--small"
+                                          >
+                                            YAML editor
+                                          </div>
+                                        </EuiText>
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                              .
+                            </div>
+                          </EuiText>
+                        </label>
+                      </EuiFormLabel>
+                    </div>
+                    <div
+                      className="euiFormRow__fieldWrapper"
+                    >
+                      <EuiCodeEditor
+                        data-test-subj="rule_detection_field"
+                        height="50px"
+                        id="some_html_id"
+                        mode="yaml"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        setOptions={Object {}}
+                        value="Selection_1"
+                        width="600px"
+                      >
+                        <div
+                          className="euiCodeEditorWrapper"
+                          data-test-subj="rule_detection_field"
+                          style={
+                            Object {
+                              "height": "50px",
+                              "width": "600px",
+                            }
+                          }
+                        >
+                          <button
+                            className="euiCodeEditorKeyboardHint"
+                            data-test-subj="codeEditorHint"
+                            id="some_html_id"
+                            onClick={[Function]}
+                          >
+                            <p
+                              className="euiText"
+                            >
+                              <EuiI18n
+                                default="Press Enter to start editing."
+                                token="euiCodeEditor.startEditing"
+                              >
+                                Press Enter to start editing.
+                              </EuiI18n>
+                            </p>
+                            <p
+                              className="euiText"
+                            >
+                              <EuiI18n
+                                default="When you're done, press Escape to stop editing."
+                                token="euiCodeEditor.stopEditing"
+                              >
+                                When you're done, press Escape to stop editing.
+                              </EuiI18n>
+                            </p>
+                          </button>
+                          <ReactAce
+                            commands={
+                              Array [
+                                Object {
+                                  "bindKey": Object {
+                                    "mac": "Esc",
+                                    "win": "Esc",
+                                  },
+                                  "exec": [Function],
+                                  "name": "stopEditingOnEsc",
+                                },
+                              ]
+                            }
+                            cursorStart={1}
+                            editorProps={
+                              Object {
+                                "$blockScrolling": Infinity,
+                              }
+                            }
+                            enableBasicAutocompletion={false}
+                            enableLiveAutocompletion={false}
+                            enableSnippets={false}
+                            focus={false}
+                            fontSize={12}
+                            height="50px"
+                            highlightActiveLine={true}
+                            id="some_html_id"
+                            maxLines={null}
+                            minLines={null}
+                            mode="yaml"
+                            name="some_html_id"
+                            navigateToFileEnd={true}
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            onLoad={null}
+                            onPaste={null}
+                            onScroll={null}
+                            placeholder={null}
+                            readOnly={false}
+                            scrollMargin={
+                              Array [
+                                0,
+                                0,
+                                0,
+                                0,
+                              ]
+                            }
+                            setOptions={Object {}}
+                            showGutter={true}
+                            showPrintMargin={true}
+                            style={Object {}}
+                            tabSize={4}
+                            theme="textmate"
+                            value="Selection_1"
+                            width="600px"
+                            wrapEnabled={false}
+                          >
+                            <div
+                              id="some_html_id"
                               style={
                                 Object {
                                   "height": "50px",
                                   "width": "600px",
                                 }
                               }
-                            >
-                              <button
-                                className="euiCodeEditorKeyboardHint"
-                                data-test-subj="codeEditorHint"
-                                id="some_html_id"
-                                onClick={[Function]}
-                              >
-                                <p
-                                  className="euiText"
-                                >
-                                  <EuiI18n
-                                    default="Press Enter to start editing."
-                                    token="euiCodeEditor.startEditing"
-                                  >
-                                    Press Enter to start editing.
-                                  </EuiI18n>
-                                </p>
-                                <p
-                                  className="euiText"
-                                >
-                                  <EuiI18n
-                                    default="When you're done, press Escape to stop editing."
-                                    token="euiCodeEditor.stopEditing"
-                                  >
-                                    When you're done, press Escape to stop editing.
-                                  </EuiI18n>
-                                </p>
-                              </button>
-                              <ReactAce
-                                commands={
-                                  Array [
-                                    Object {
-                                      "bindKey": Object {
-                                        "mac": "Esc",
-                                        "win": "Esc",
-                                      },
-                                      "exec": [Function],
-                                      "name": "stopEditingOnEsc",
-                                    },
-                                  ]
-                                }
-                                cursorStart={1}
-                                editorProps={
-                                  Object {
-                                    "$blockScrolling": Infinity,
-                                  }
-                                }
-                                enableBasicAutocompletion={false}
-                                enableLiveAutocompletion={false}
-                                enableSnippets={false}
-                                focus={false}
-                                fontSize={12}
-                                height="50px"
-                                highlightActiveLine={true}
-                                id="some_html_id"
-                                maxLines={null}
-                                minLines={null}
-                                mode="yaml"
-                                name="some_html_id"
-                                navigateToFileEnd={true}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                onLoad={null}
-                                onPaste={null}
-                                onScroll={null}
-                                placeholder={null}
-                                readOnly={false}
-                                scrollMargin={
-                                  Array [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                setOptions={Object {}}
-                                showGutter={true}
-                                showPrintMargin={true}
-                                style={Object {}}
-                                tabSize={4}
-                                theme="textmate"
-                                value="Selection_1"
-                                width="600px"
-                                wrapEnabled={false}
-                              >
-                                <div
-                                  id="some_html_id"
-                                  style={
-                                    Object {
-                                      "height": "50px",
-                                      "width": "600px",
-                                    }
-                                  }
-                                />
-                              </ReactAce>
-                            </div>
-                          </EuiCodeEditor>
+                            />
+                          </ReactAce>
                         </div>
-                      </div>
-                    </EuiFormRow>
+                      </EuiCodeEditor>
+                    </div>
                   </div>
-                </DetectionVisualEditor>
-                <EuiSpacer
-                  size="xl"
+                </EuiFormRow>
+              </div>
+            </DetectionVisualEditor>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <div
+              style={
+                Object {
+                  "maxWidth": 1000,
+                }
+              }
+            >
+              <EuiAccordion
+                arrowDisplay="left"
+                buttonContent={
+                  <React.Fragment>
+                    Additional details 
+                    <i>
+                      - optional
+                    </i>
+                  </React.Fragment>
+                }
+                id="additional-details"
+                initialIsOpen={true}
+                isLoading={false}
+                isLoadingMessage={false}
+                paddingSize="l"
+              >
+                <div
+                  className="euiAccordion euiAccordion-isOpen"
                 >
                   <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiPanel
-                  style={
-                    Object {
-                      "maxWidth": 1000,
-                    }
-                  }
-                >
-                  <div
-                    className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                    style={
-                      Object {
-                        "maxWidth": 1000,
-                      }
-                    }
+                    className="euiAccordion__triggerWrapper"
                   >
-                    <EuiAccordion
-                      arrowDisplay="left"
-                      buttonContent={
-                        <React.Fragment>
-                          Additional details 
-                          <i>
-                            - optional
-                          </i>
-                        </React.Fragment>
-                      }
-                      id="additional-details"
-                      initialIsOpen={true}
-                      isLoading={false}
-                      isLoadingMessage={false}
-                      paddingSize="none"
+                    <button
+                      aria-controls="additional-details"
+                      aria-expanded={true}
+                      className="euiAccordion__button"
+                      id="some_html_id"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <div
-                        className="euiAccordion euiAccordion-isOpen"
+                      <span
+                        className="euiAccordion__iconWrapper"
                       >
-                        <div
-                          className="euiAccordion__triggerWrapper"
+                        <EuiIcon
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          size="m"
+                          type="arrowRight"
                         >
-                          <button
-                            aria-controls="additional-details"
-                            aria-expanded={true}
-                            className="euiAccordion__button"
-                            id="some_html_id"
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="euiAccordion__iconWrapper"
-                            >
-                              <EuiIcon
-                                className="euiAccordion__icon euiAccordion__icon-isOpen"
-                                size="m"
-                                type="arrowRight"
-                              >
-                                EuiIconMock
-                              </EuiIcon>
-                            </span>
-                            <span
-                              className="euiIEFlexWrapFix"
-                            >
-                              Additional details 
-                              <i>
-                                - optional
-                              </i>
-                            </span>
-                          </button>
-                        </div>
+                          EuiIconMock
+                        </EuiIcon>
+                      </span>
+                      <span
+                        className="euiIEFlexWrapFix"
+                      >
+                        Additional details 
+                        <i>
+                          - optional
+                        </i>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-labelledby="some_html_id"
+                    className="euiAccordion__childWrapper"
+                    id="additional-details"
+                    role="region"
+                    tabIndex={-1}
+                  >
+                    <EuiResizeObserver
+                      onResize={[Function]}
+                    >
+                      <div>
                         <div
-                          aria-labelledby="some_html_id"
-                          className="euiAccordion__childWrapper"
-                          id="additional-details"
-                          role="region"
-                          tabIndex={-1}
+                          className="euiAccordion__padding--l"
                         >
-                          <EuiResizeObserver
-                            onResize={[Function]}
+                          <div
+                            className="rule-editor-form-additional-details-panel-body"
                           >
-                            <div>
-                              <div
-                                className=""
+                            <FieldTextArray
+                              addButtonName="Add tag"
+                              data-test-subj="rule_tags_field"
+                              fields={Array []}
+                              label={
+                                <React.Fragment>
+                                  <EuiText
+                                    size="m"
+                                  >
+                                    <strong>
+                                      Tags 
+                                    </strong>
+                                    <i>
+                                      - optional
+                                    </i>
+                                  </EuiText>
+                                  <EuiSpacer
+                                    size="m"
+                                  />
+                                  <EuiText
+                                    size="xs"
+                                  >
+                                    <strong>
+                                      Tag
+                                    </strong>
+                                  </EuiText>
+                                </React.Fragment>
+                              }
+                              name="tags"
+                              onChange={[Function]}
+                              placeholder="tag"
+                            >
+                              <EuiFormRow
+                                describedByIds={Array []}
+                                display="row"
+                                error=""
+                                fullWidth={false}
+                                hasChildLabel={true}
+                                hasEmptyLabelSpace={false}
+                                label={
+                                  <React.Fragment>
+                                    <EuiText
+                                      size="m"
+                                    >
+                                      <strong>
+                                        Tags 
+                                      </strong>
+                                      <i>
+                                        - optional
+                                      </i>
+                                    </EuiText>
+                                    <EuiSpacer
+                                      size="m"
+                                    />
+                                    <EuiText
+                                      size="xs"
+                                    >
+                                      <strong>
+                                        Tag
+                                      </strong>
+                                    </EuiText>
+                                  </React.Fragment>
+                                }
+                                labelType="label"
                               >
                                 <div
-                                  className="rule-editor-form-additional-details-panel-body"
+                                  className="euiFormRow"
+                                  id="some_html_id-row"
                                 >
-                                  <EuiSpacer>
-                                    <div
-                                      className="euiSpacer euiSpacer--l"
-                                    />
-                                  </EuiSpacer>
-                                  <FieldTextArray
-                                    addButtonName="Add tag"
-                                    data-test-subj="rule_tags_field"
-                                    fields={Array []}
-                                    label={
-                                      <React.Fragment>
-                                        <EuiText
-                                          size="m"
-                                        >
-                                          <strong>
-                                            Tags 
-                                          </strong>
-                                          <i>
-                                            - optional
-                                          </i>
-                                        </EuiText>
-                                        <EuiSpacer
-                                          size="m"
-                                        />
-                                        <EuiText
-                                          size="xs"
-                                        >
-                                          <strong>
-                                            Tag
-                                          </strong>
-                                        </EuiText>
-                                      </React.Fragment>
-                                    }
-                                    name="tags"
-                                    onChange={[Function]}
-                                    placeholder="tag"
+                                  <div
+                                    className="euiFormRow__labelWrapper"
                                   >
-                                    <EuiFormRow
-                                      describedByIds={Array []}
-                                      display="row"
-                                      error=""
-                                      fullWidth={false}
-                                      hasChildLabel={true}
-                                      hasEmptyLabelSpace={false}
-                                      label={
-                                        <React.Fragment>
-                                          <EuiText
-                                            size="m"
+                                    <EuiFormLabel
+                                      className="euiFormRow__label"
+                                      htmlFor="some_html_id"
+                                      isFocused={false}
+                                      type="label"
+                                    >
+                                      <label
+                                        className="euiFormLabel euiFormRow__label"
+                                        htmlFor="some_html_id"
+                                      >
+                                        <EuiText
+                                          size="m"
+                                        >
+                                          <div
+                                            className="euiText euiText--medium"
                                           >
                                             <strong>
                                               Tags 
@@ -3102,239 +3070,239 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                             <i>
                                               - optional
                                             </i>
-                                          </EuiText>
-                                          <EuiSpacer
-                                            size="m"
+                                          </div>
+                                        </EuiText>
+                                        <EuiSpacer
+                                          size="m"
+                                        >
+                                          <div
+                                            className="euiSpacer euiSpacer--m"
                                           />
-                                          <EuiText
-                                            size="xs"
+                                        </EuiSpacer>
+                                        <EuiText
+                                          size="xs"
+                                        >
+                                          <div
+                                            className="euiText euiText--extraSmall"
                                           >
                                             <strong>
                                               Tag
                                             </strong>
-                                          </EuiText>
-                                        </React.Fragment>
-                                      }
-                                      labelType="label"
+                                          </div>
+                                        </EuiText>
+                                      </label>
+                                    </EuiFormLabel>
+                                  </div>
+                                  <div
+                                    className="euiFormRow__fieldWrapper"
+                                  >
+                                    <EuiFlexGroup
+                                      key="0"
                                     >
                                       <div
-                                        className="euiFormRow"
-                                        id="some_html_id-row"
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                                       >
-                                        <div
-                                          className="euiFormRow__labelWrapper"
+                                        <EuiFlexItem
+                                          style={
+                                            Object {
+                                              "minWidth": "100%",
+                                            }
+                                          }
                                         >
-                                          <EuiFormLabel
-                                            className="euiFormRow__label"
-                                            htmlFor="some_html_id"
-                                            isFocused={false}
-                                            type="label"
+                                          <div
+                                            className="euiFlexItem"
+                                            style={
+                                              Object {
+                                                "minWidth": "100%",
+                                              }
+                                            }
                                           >
-                                            <label
-                                              className="euiFormLabel euiFormRow__label"
-                                              htmlFor="some_html_id"
+                                            <EuiFieldText
+                                              data-test-subj="rule_tags_field_0"
+                                              name="tags"
+                                              onChange={[Function]}
+                                              placeholder="tag"
+                                              value=""
                                             >
-                                              <EuiText
-                                                size="m"
+                                              <EuiFormControlLayout
+                                                fullWidth={false}
                                               >
                                                 <div
-                                                  className="euiText euiText--medium"
+                                                  className="euiFormControlLayout"
                                                 >
-                                                  <strong>
-                                                    Tags 
-                                                  </strong>
-                                                  <i>
-                                                    - optional
-                                                  </i>
-                                                </div>
-                                              </EuiText>
-                                              <EuiSpacer
-                                                size="m"
-                                              >
-                                                <div
-                                                  className="euiSpacer euiSpacer--m"
-                                                />
-                                              </EuiSpacer>
-                                              <EuiText
-                                                size="xs"
-                                              >
-                                                <div
-                                                  className="euiText euiText--extraSmall"
-                                                >
-                                                  <strong>
-                                                    Tag
-                                                  </strong>
-                                                </div>
-                                              </EuiText>
-                                            </label>
-                                          </EuiFormLabel>
-                                        </div>
-                                        <div
-                                          className="euiFormRow__fieldWrapper"
-                                        >
-                                          <EuiFlexGroup
-                                            key="0"
-                                          >
-                                            <div
-                                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                            >
-                                              <EuiFlexItem
-                                                style={
-                                                  Object {
-                                                    "minWidth": "100%",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="euiFlexItem"
-                                                  style={
-                                                    Object {
-                                                      "minWidth": "100%",
-                                                    }
-                                                  }
-                                                >
-                                                  <EuiFieldText
-                                                    data-test-subj="rule_tags_field_0"
-                                                    name="tags"
-                                                    onChange={[Function]}
-                                                    placeholder="tag"
-                                                    value=""
+                                                  <div
+                                                    className="euiFormControlLayout__childrenWrapper"
                                                   >
-                                                    <EuiFormControlLayout
-                                                      fullWidth={false}
-                                                    >
-                                                      <div
-                                                        className="euiFormControlLayout"
-                                                      >
-                                                        <div
-                                                          className="euiFormControlLayout__childrenWrapper"
-                                                        >
-                                                          <EuiValidatableControl>
-                                                            <input
-                                                              className="euiFieldText"
-                                                              data-test-subj="rule_tags_field_0"
-                                                              name="tags"
-                                                              onChange={[Function]}
-                                                              placeholder="tag"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </EuiValidatableControl>
-                                                          <EuiFormControlLayoutIcons />
-                                                        </div>
-                                                      </div>
-                                                    </EuiFormControlLayout>
-                                                  </EuiFieldText>
+                                                    <EuiValidatableControl>
+                                                      <input
+                                                        className="euiFieldText"
+                                                        data-test-subj="rule_tags_field_0"
+                                                        name="tags"
+                                                        onChange={[Function]}
+                                                        placeholder="tag"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </EuiValidatableControl>
+                                                    <EuiFormControlLayoutIcons />
+                                                  </div>
                                                 </div>
-                                              </EuiFlexItem>
-                                            </div>
-                                          </EuiFlexGroup>
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                          <EuiButton
-                                            className="secondary"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonDisplay
-                                              baseClassName="euiButton"
-                                              className="secondary"
-                                              disabled={false}
-                                              element="button"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <button
-                                                className="euiButton euiButton--primary secondary"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                style={
-                                                  Object {
-                                                    "minWidth": undefined,
-                                                  }
-                                                }
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButton__content"
-                                                  iconSide="left"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButton__text",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButton__content"
-                                                  >
-                                                    <span
-                                                      className="euiButton__text"
-                                                    >
-                                                      Add tag
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonDisplay>
-                                          </EuiButton>
-                                        </div>
+                                              </EuiFormControlLayout>
+                                            </EuiFieldText>
+                                          </div>
+                                        </EuiFlexItem>
                                       </div>
-                                    </EuiFormRow>
-                                    <EuiSpacer>
+                                    </EuiFlexGroup>
+                                    <EuiSpacer
+                                      size="m"
+                                    >
                                       <div
-                                        className="euiSpacer euiSpacer--l"
+                                        className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                  </FieldTextArray>
-                                  <FieldTextArray
-                                    addButtonName="Add URL"
-                                    data-test-subj="rule_references_field"
-                                    fields={Array []}
-                                    label={
-                                      <React.Fragment>
-                                        <EuiText
-                                          size="m"
+                                    <EuiButton
+                                      className="secondary"
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonDisplay
+                                        baseClassName="euiButton"
+                                        className="secondary"
+                                        disabled={false}
+                                        element="button"
+                                        isDisabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <button
+                                          className="euiButton euiButton--primary secondary"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          style={
+                                            Object {
+                                              "minWidth": undefined,
+                                            }
+                                          }
+                                          type="button"
                                         >
-                                          <strong>
-                                            References 
-                                          </strong>
-                                          <i>
-                                            - optional
-                                          </i>
-                                        </EuiText>
-                                        <EuiSpacer
-                                          size="m"
-                                        />
-                                        <EuiText
-                                          size="xs"
-                                        >
-                                          <strong>
-                                            URL
-                                          </strong>
-                                        </EuiText>
-                                      </React.Fragment>
-                                    }
-                                    name="references"
-                                    onChange={[Function]}
-                                    placeholder="http://"
+                                          <EuiButtonContent
+                                            className="euiButton__content"
+                                            iconSide="left"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButton__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButton__content"
+                                            >
+                                              <span
+                                                className="euiButton__text"
+                                              >
+                                                Add tag
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonDisplay>
+                                    </EuiButton>
+                                  </div>
+                                </div>
+                              </EuiFormRow>
+                              <EuiSpacer>
+                                <div
+                                  className="euiSpacer euiSpacer--l"
+                                />
+                              </EuiSpacer>
+                            </FieldTextArray>
+                            <FieldTextArray
+                              addButtonName="Add URL"
+                              data-test-subj="rule_references_field"
+                              fields={Array []}
+                              label={
+                                <React.Fragment>
+                                  <EuiText
+                                    size="m"
                                   >
-                                    <EuiFormRow
-                                      describedByIds={Array []}
-                                      display="row"
-                                      error=""
-                                      fullWidth={false}
-                                      hasChildLabel={true}
-                                      hasEmptyLabelSpace={false}
-                                      label={
-                                        <React.Fragment>
-                                          <EuiText
-                                            size="m"
+                                    <strong>
+                                      References 
+                                    </strong>
+                                    <i>
+                                      - optional
+                                    </i>
+                                  </EuiText>
+                                  <EuiSpacer
+                                    size="m"
+                                  />
+                                  <EuiText
+                                    size="xs"
+                                  >
+                                    <strong>
+                                      URL
+                                    </strong>
+                                  </EuiText>
+                                </React.Fragment>
+                              }
+                              name="references"
+                              onChange={[Function]}
+                              placeholder="http://"
+                            >
+                              <EuiFormRow
+                                describedByIds={Array []}
+                                display="row"
+                                error=""
+                                fullWidth={false}
+                                hasChildLabel={true}
+                                hasEmptyLabelSpace={false}
+                                label={
+                                  <React.Fragment>
+                                    <EuiText
+                                      size="m"
+                                    >
+                                      <strong>
+                                        References 
+                                      </strong>
+                                      <i>
+                                        - optional
+                                      </i>
+                                    </EuiText>
+                                    <EuiSpacer
+                                      size="m"
+                                    />
+                                    <EuiText
+                                      size="xs"
+                                    >
+                                      <strong>
+                                        URL
+                                      </strong>
+                                    </EuiText>
+                                  </React.Fragment>
+                                }
+                                labelType="label"
+                              >
+                                <div
+                                  className="euiFormRow"
+                                  id="some_html_id-row"
+                                >
+                                  <div
+                                    className="euiFormRow__labelWrapper"
+                                  >
+                                    <EuiFormLabel
+                                      className="euiFormRow__label"
+                                      htmlFor="some_html_id"
+                                      isFocused={false}
+                                      type="label"
+                                    >
+                                      <label
+                                        className="euiFormLabel euiFormRow__label"
+                                        htmlFor="some_html_id"
+                                      >
+                                        <EuiText
+                                          size="m"
+                                        >
+                                          <div
+                                            className="euiText euiText--medium"
                                           >
                                             <strong>
                                               References 
@@ -3342,239 +3310,239 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                             <i>
                                               - optional
                                             </i>
-                                          </EuiText>
-                                          <EuiSpacer
-                                            size="m"
+                                          </div>
+                                        </EuiText>
+                                        <EuiSpacer
+                                          size="m"
+                                        >
+                                          <div
+                                            className="euiSpacer euiSpacer--m"
                                           />
-                                          <EuiText
-                                            size="xs"
+                                        </EuiSpacer>
+                                        <EuiText
+                                          size="xs"
+                                        >
+                                          <div
+                                            className="euiText euiText--extraSmall"
                                           >
                                             <strong>
                                               URL
                                             </strong>
-                                          </EuiText>
-                                        </React.Fragment>
-                                      }
-                                      labelType="label"
+                                          </div>
+                                        </EuiText>
+                                      </label>
+                                    </EuiFormLabel>
+                                  </div>
+                                  <div
+                                    className="euiFormRow__fieldWrapper"
+                                  >
+                                    <EuiFlexGroup
+                                      key="0"
                                     >
                                       <div
-                                        className="euiFormRow"
-                                        id="some_html_id-row"
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                                       >
-                                        <div
-                                          className="euiFormRow__labelWrapper"
+                                        <EuiFlexItem
+                                          style={
+                                            Object {
+                                              "minWidth": "100%",
+                                            }
+                                          }
                                         >
-                                          <EuiFormLabel
-                                            className="euiFormRow__label"
-                                            htmlFor="some_html_id"
-                                            isFocused={false}
-                                            type="label"
+                                          <div
+                                            className="euiFlexItem"
+                                            style={
+                                              Object {
+                                                "minWidth": "100%",
+                                              }
+                                            }
                                           >
-                                            <label
-                                              className="euiFormLabel euiFormRow__label"
-                                              htmlFor="some_html_id"
+                                            <EuiFieldText
+                                              data-test-subj="rule_references_field_0"
+                                              name="references"
+                                              onChange={[Function]}
+                                              placeholder="http://"
+                                              value=""
                                             >
-                                              <EuiText
-                                                size="m"
+                                              <EuiFormControlLayout
+                                                fullWidth={false}
                                               >
                                                 <div
-                                                  className="euiText euiText--medium"
+                                                  className="euiFormControlLayout"
                                                 >
-                                                  <strong>
-                                                    References 
-                                                  </strong>
-                                                  <i>
-                                                    - optional
-                                                  </i>
-                                                </div>
-                                              </EuiText>
-                                              <EuiSpacer
-                                                size="m"
-                                              >
-                                                <div
-                                                  className="euiSpacer euiSpacer--m"
-                                                />
-                                              </EuiSpacer>
-                                              <EuiText
-                                                size="xs"
-                                              >
-                                                <div
-                                                  className="euiText euiText--extraSmall"
-                                                >
-                                                  <strong>
-                                                    URL
-                                                  </strong>
-                                                </div>
-                                              </EuiText>
-                                            </label>
-                                          </EuiFormLabel>
-                                        </div>
-                                        <div
-                                          className="euiFormRow__fieldWrapper"
-                                        >
-                                          <EuiFlexGroup
-                                            key="0"
-                                          >
-                                            <div
-                                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                            >
-                                              <EuiFlexItem
-                                                style={
-                                                  Object {
-                                                    "minWidth": "100%",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="euiFlexItem"
-                                                  style={
-                                                    Object {
-                                                      "minWidth": "100%",
-                                                    }
-                                                  }
-                                                >
-                                                  <EuiFieldText
-                                                    data-test-subj="rule_references_field_0"
-                                                    name="references"
-                                                    onChange={[Function]}
-                                                    placeholder="http://"
-                                                    value=""
+                                                  <div
+                                                    className="euiFormControlLayout__childrenWrapper"
                                                   >
-                                                    <EuiFormControlLayout
-                                                      fullWidth={false}
-                                                    >
-                                                      <div
-                                                        className="euiFormControlLayout"
-                                                      >
-                                                        <div
-                                                          className="euiFormControlLayout__childrenWrapper"
-                                                        >
-                                                          <EuiValidatableControl>
-                                                            <input
-                                                              className="euiFieldText"
-                                                              data-test-subj="rule_references_field_0"
-                                                              name="references"
-                                                              onChange={[Function]}
-                                                              placeholder="http://"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </EuiValidatableControl>
-                                                          <EuiFormControlLayoutIcons />
-                                                        </div>
-                                                      </div>
-                                                    </EuiFormControlLayout>
-                                                  </EuiFieldText>
+                                                    <EuiValidatableControl>
+                                                      <input
+                                                        className="euiFieldText"
+                                                        data-test-subj="rule_references_field_0"
+                                                        name="references"
+                                                        onChange={[Function]}
+                                                        placeholder="http://"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </EuiValidatableControl>
+                                                    <EuiFormControlLayoutIcons />
+                                                  </div>
                                                 </div>
-                                              </EuiFlexItem>
-                                            </div>
-                                          </EuiFlexGroup>
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                          <EuiButton
-                                            className="secondary"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonDisplay
-                                              baseClassName="euiButton"
-                                              className="secondary"
-                                              disabled={false}
-                                              element="button"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <button
-                                                className="euiButton euiButton--primary secondary"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                style={
-                                                  Object {
-                                                    "minWidth": undefined,
-                                                  }
-                                                }
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButton__content"
-                                                  iconSide="left"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButton__text",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButton__content"
-                                                  >
-                                                    <span
-                                                      className="euiButton__text"
-                                                    >
-                                                      Add URL
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonDisplay>
-                                          </EuiButton>
-                                        </div>
+                                              </EuiFormControlLayout>
+                                            </EuiFieldText>
+                                          </div>
+                                        </EuiFlexItem>
                                       </div>
-                                    </EuiFormRow>
-                                    <EuiSpacer>
+                                    </EuiFlexGroup>
+                                    <EuiSpacer
+                                      size="m"
+                                    >
                                       <div
-                                        className="euiSpacer euiSpacer--l"
+                                        className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                  </FieldTextArray>
-                                  <FieldTextArray
-                                    addButtonName="Add false positive"
-                                    data-test-subj="rule_falsePositives_field"
-                                    fields={Array []}
-                                    label={
-                                      <React.Fragment>
-                                        <EuiText
-                                          size="m"
+                                    <EuiButton
+                                      className="secondary"
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonDisplay
+                                        baseClassName="euiButton"
+                                        className="secondary"
+                                        disabled={false}
+                                        element="button"
+                                        isDisabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <button
+                                          className="euiButton euiButton--primary secondary"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          style={
+                                            Object {
+                                              "minWidth": undefined,
+                                            }
+                                          }
+                                          type="button"
                                         >
-                                          <strong>
-                                            False positive cases 
-                                          </strong>
-                                          <i>
-                                            - optional
-                                          </i>
-                                        </EuiText>
-                                        <EuiSpacer
-                                          size="m"
-                                        />
-                                        <EuiText
-                                          size="xs"
-                                        >
-                                          <strong>
-                                            Description
-                                          </strong>
-                                        </EuiText>
-                                      </React.Fragment>
-                                    }
-                                    name="false_positives"
-                                    onChange={[Function]}
-                                    placeholder="format?"
+                                          <EuiButtonContent
+                                            className="euiButton__content"
+                                            iconSide="left"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButton__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButton__content"
+                                            >
+                                              <span
+                                                className="euiButton__text"
+                                              >
+                                                Add URL
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonDisplay>
+                                    </EuiButton>
+                                  </div>
+                                </div>
+                              </EuiFormRow>
+                              <EuiSpacer>
+                                <div
+                                  className="euiSpacer euiSpacer--l"
+                                />
+                              </EuiSpacer>
+                            </FieldTextArray>
+                            <FieldTextArray
+                              addButtonName="Add false positive"
+                              data-test-subj="rule_falsePositives_field"
+                              fields={Array []}
+                              label={
+                                <React.Fragment>
+                                  <EuiText
+                                    size="m"
                                   >
-                                    <EuiFormRow
-                                      describedByIds={Array []}
-                                      display="row"
-                                      error=""
-                                      fullWidth={false}
-                                      hasChildLabel={true}
-                                      hasEmptyLabelSpace={false}
-                                      label={
-                                        <React.Fragment>
-                                          <EuiText
-                                            size="m"
+                                    <strong>
+                                      False positive cases 
+                                    </strong>
+                                    <i>
+                                      - optional
+                                    </i>
+                                  </EuiText>
+                                  <EuiSpacer
+                                    size="m"
+                                  />
+                                  <EuiText
+                                    size="xs"
+                                  >
+                                    <strong>
+                                      Description
+                                    </strong>
+                                  </EuiText>
+                                </React.Fragment>
+                              }
+                              name="false_positives"
+                              onChange={[Function]}
+                              placeholder="format?"
+                            >
+                              <EuiFormRow
+                                describedByIds={Array []}
+                                display="row"
+                                error=""
+                                fullWidth={false}
+                                hasChildLabel={true}
+                                hasEmptyLabelSpace={false}
+                                label={
+                                  <React.Fragment>
+                                    <EuiText
+                                      size="m"
+                                    >
+                                      <strong>
+                                        False positive cases 
+                                      </strong>
+                                      <i>
+                                        - optional
+                                      </i>
+                                    </EuiText>
+                                    <EuiSpacer
+                                      size="m"
+                                    />
+                                    <EuiText
+                                      size="xs"
+                                    >
+                                      <strong>
+                                        Description
+                                      </strong>
+                                    </EuiText>
+                                  </React.Fragment>
+                                }
+                                labelType="label"
+                              >
+                                <div
+                                  className="euiFormRow"
+                                  id="some_html_id-row"
+                                >
+                                  <div
+                                    className="euiFormRow__labelWrapper"
+                                  >
+                                    <EuiFormLabel
+                                      className="euiFormRow__label"
+                                      htmlFor="some_html_id"
+                                      isFocused={false}
+                                      type="label"
+                                    >
+                                      <label
+                                        className="euiFormLabel euiFormRow__label"
+                                        htmlFor="some_html_id"
+                                      >
+                                        <EuiText
+                                          size="m"
+                                        >
+                                          <div
+                                            className="euiText euiText--medium"
                                           >
                                             <strong>
                                               False positive cases 
@@ -3582,209 +3550,162 @@ exports[`<RuleEditorForm /> spec renders the component 1`] = `
                                             <i>
                                               - optional
                                             </i>
-                                          </EuiText>
-                                          <EuiSpacer
-                                            size="m"
+                                          </div>
+                                        </EuiText>
+                                        <EuiSpacer
+                                          size="m"
+                                        >
+                                          <div
+                                            className="euiSpacer euiSpacer--m"
                                           />
-                                          <EuiText
-                                            size="xs"
+                                        </EuiSpacer>
+                                        <EuiText
+                                          size="xs"
+                                        >
+                                          <div
+                                            className="euiText euiText--extraSmall"
                                           >
                                             <strong>
                                               Description
                                             </strong>
-                                          </EuiText>
-                                        </React.Fragment>
-                                      }
-                                      labelType="label"
+                                          </div>
+                                        </EuiText>
+                                      </label>
+                                    </EuiFormLabel>
+                                  </div>
+                                  <div
+                                    className="euiFormRow__fieldWrapper"
+                                  >
+                                    <EuiFlexGroup
+                                      key="0"
                                     >
                                       <div
-                                        className="euiFormRow"
-                                        id="some_html_id-row"
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                                       >
-                                        <div
-                                          className="euiFormRow__labelWrapper"
+                                        <EuiFlexItem
+                                          style={
+                                            Object {
+                                              "minWidth": "100%",
+                                            }
+                                          }
                                         >
-                                          <EuiFormLabel
-                                            className="euiFormRow__label"
-                                            htmlFor="some_html_id"
-                                            isFocused={false}
-                                            type="label"
+                                          <div
+                                            className="euiFlexItem"
+                                            style={
+                                              Object {
+                                                "minWidth": "100%",
+                                              }
+                                            }
                                           >
-                                            <label
-                                              className="euiFormLabel euiFormRow__label"
-                                              htmlFor="some_html_id"
+                                            <EuiFieldText
+                                              data-test-subj="rule_false_positives_field_0"
+                                              name="false_positives"
+                                              onChange={[Function]}
+                                              placeholder="format?"
+                                              value=""
                                             >
-                                              <EuiText
-                                                size="m"
+                                              <EuiFormControlLayout
+                                                fullWidth={false}
                                               >
                                                 <div
-                                                  className="euiText euiText--medium"
+                                                  className="euiFormControlLayout"
                                                 >
-                                                  <strong>
-                                                    False positive cases 
-                                                  </strong>
-                                                  <i>
-                                                    - optional
-                                                  </i>
-                                                </div>
-                                              </EuiText>
-                                              <EuiSpacer
-                                                size="m"
-                                              >
-                                                <div
-                                                  className="euiSpacer euiSpacer--m"
-                                                />
-                                              </EuiSpacer>
-                                              <EuiText
-                                                size="xs"
-                                              >
-                                                <div
-                                                  className="euiText euiText--extraSmall"
-                                                >
-                                                  <strong>
-                                                    Description
-                                                  </strong>
-                                                </div>
-                                              </EuiText>
-                                            </label>
-                                          </EuiFormLabel>
-                                        </div>
-                                        <div
-                                          className="euiFormRow__fieldWrapper"
-                                        >
-                                          <EuiFlexGroup
-                                            key="0"
-                                          >
-                                            <div
-                                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                            >
-                                              <EuiFlexItem
-                                                style={
-                                                  Object {
-                                                    "minWidth": "100%",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="euiFlexItem"
-                                                  style={
-                                                    Object {
-                                                      "minWidth": "100%",
-                                                    }
-                                                  }
-                                                >
-                                                  <EuiFieldText
-                                                    data-test-subj="rule_false_positives_field_0"
-                                                    name="false_positives"
-                                                    onChange={[Function]}
-                                                    placeholder="format?"
-                                                    value=""
+                                                  <div
+                                                    className="euiFormControlLayout__childrenWrapper"
                                                   >
-                                                    <EuiFormControlLayout
-                                                      fullWidth={false}
-                                                    >
-                                                      <div
-                                                        className="euiFormControlLayout"
-                                                      >
-                                                        <div
-                                                          className="euiFormControlLayout__childrenWrapper"
-                                                        >
-                                                          <EuiValidatableControl>
-                                                            <input
-                                                              className="euiFieldText"
-                                                              data-test-subj="rule_false_positives_field_0"
-                                                              name="false_positives"
-                                                              onChange={[Function]}
-                                                              placeholder="format?"
-                                                              type="text"
-                                                              value=""
-                                                            />
-                                                          </EuiValidatableControl>
-                                                          <EuiFormControlLayoutIcons />
-                                                        </div>
-                                                      </div>
-                                                    </EuiFormControlLayout>
-                                                  </EuiFieldText>
+                                                    <EuiValidatableControl>
+                                                      <input
+                                                        className="euiFieldText"
+                                                        data-test-subj="rule_false_positives_field_0"
+                                                        name="false_positives"
+                                                        onChange={[Function]}
+                                                        placeholder="format?"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </EuiValidatableControl>
+                                                    <EuiFormControlLayoutIcons />
+                                                  </div>
                                                 </div>
-                                              </EuiFlexItem>
-                                            </div>
-                                          </EuiFlexGroup>
-                                          <EuiSpacer
-                                            size="m"
-                                          >
-                                            <div
-                                              className="euiSpacer euiSpacer--m"
-                                            />
-                                          </EuiSpacer>
-                                          <EuiButton
-                                            className="secondary"
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonDisplay
-                                              baseClassName="euiButton"
-                                              className="secondary"
-                                              disabled={false}
-                                              element="button"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <button
-                                                className="euiButton euiButton--primary secondary"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                style={
-                                                  Object {
-                                                    "minWidth": undefined,
-                                                  }
-                                                }
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButton__content"
-                                                  iconSide="left"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButton__text",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButton__content"
-                                                  >
-                                                    <span
-                                                      className="euiButton__text"
-                                                    >
-                                                      Add false positive
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonDisplay>
-                                          </EuiButton>
-                                        </div>
+                                              </EuiFormControlLayout>
+                                            </EuiFieldText>
+                                          </div>
+                                        </EuiFlexItem>
                                       </div>
-                                    </EuiFormRow>
-                                    <EuiSpacer>
+                                    </EuiFlexGroup>
+                                    <EuiSpacer
+                                      size="m"
+                                    >
                                       <div
-                                        className="euiSpacer euiSpacer--l"
+                                        className="euiSpacer euiSpacer--m"
                                       />
                                     </EuiSpacer>
-                                  </FieldTextArray>
+                                    <EuiButton
+                                      className="secondary"
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonDisplay
+                                        baseClassName="euiButton"
+                                        className="secondary"
+                                        disabled={false}
+                                        element="button"
+                                        isDisabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <button
+                                          className="euiButton euiButton--primary secondary"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          style={
+                                            Object {
+                                              "minWidth": undefined,
+                                            }
+                                          }
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButton__content"
+                                            iconSide="left"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButton__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButton__content"
+                                            >
+                                              <span
+                                                className="euiButton__text"
+                                              >
+                                                Add false positive
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonDisplay>
+                                    </EuiButton>
+                                  </div>
                                 </div>
-                              </div>
-                            </div>
-                          </EuiResizeObserver>
+                              </EuiFormRow>
+                              <EuiSpacer>
+                                <div
+                                  className="euiSpacer euiSpacer--l"
+                                />
+                              </EuiSpacer>
+                            </FieldTextArray>
+                          </div>
                         </div>
                       </div>
-                    </EuiAccordion>
+                    </EuiResizeObserver>
                   </div>
-                </EuiPanel>
-              </div>
+                </div>
+              </EuiAccordion>
             </div>
-          </EuiPanel>
-        </ContentPanel>
+          </div>
+        </EuiPanel>
         <EuiSpacer>
           <div
             className="euiSpacer euiSpacer--l"

--- a/public/pages/Rules/containers/CreateRule/CreateRule.tsx
+++ b/public/pages/Rules/containers/CreateRule/CreateRule.tsx
@@ -26,22 +26,22 @@ export const CreateRule: React.FC<CreateRuleProps> = ({ history, services, notif
 
   return (
     <RuleEditorContainer
-      title={
-        <>
-          <EuiTitle size={'m'}>
-            <h3>Create detection rule</h3>
-          </EuiTitle>
-          <EuiText size="s" color="subdued">
-            Create a rule for detectors to identify threat scenarios for different log sources.{' '}
-            <EuiLink
-              href="https://sigmahq.github.io/sigma-specification/Sigma_specification.html"
-              target="_blank"
-            >
-              Learn more in the Sigma rules specification
-            </EuiLink>
-          </EuiText>
-        </>
-      }
+      // title={
+      //   <>
+      //     <EuiTitle size={'m'}>
+      //       <h3>Create detection rule</h3>
+      //     </EuiTitle>
+      //     <EuiText size="s" color="subdued">
+      //       Create a rule for detectors to identify threat scenarios for different log sources.{' '}
+      //       <EuiLink
+      //         href="https://sigmahq.github.io/sigma-specification/Sigma_specification.html"
+      //         target="_blank"
+      //       >
+      //         Learn more in the Sigma rules specification
+      //       </EuiLink>
+      //     </EuiText>
+      //   </>
+      // }
       history={history}
       notifications={notifications}
       mode={'create'}

--- a/public/pages/Rules/containers/CreateRule/CreateRule.tsx
+++ b/public/pages/Rules/containers/CreateRule/CreateRule.tsx
@@ -10,7 +10,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS } from '../../../../utils/constants';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { setRulesRelatedBreadCrumb } from '../../utils/helpers';
-import { EuiTitle, EuiText, EuiLink } from '@elastic/eui';
 import { setBreadcrumbs } from '../../../../utils/helpers';
 
 export interface CreateRuleProps {
@@ -26,22 +25,17 @@ export const CreateRule: React.FC<CreateRuleProps> = ({ history, services, notif
 
   return (
     <RuleEditorContainer
-      // title={
-      //   <>
-      //     <EuiTitle size={'m'}>
-      //       <h3>Create detection rule</h3>
-      //     </EuiTitle>
-      //     <EuiText size="s" color="subdued">
-      //       Create a rule for detectors to identify threat scenarios for different log sources.{' '}
-      //       <EuiLink
-      //         href="https://sigmahq.github.io/sigma-specification/Sigma_specification.html"
-      //         target="_blank"
-      //       >
-      //         Learn more in the Sigma rules specification
-      //       </EuiLink>
-      //     </EuiText>
-      //   </>
-      // }
+      title="Create detection rule"
+      subtitleData={[
+        {
+          text:
+            'Create a rule for detectors to identify threat scenarios for different log sources.',
+        },
+        {
+          text: 'Learn more in the Sigma rules specification',
+          href: 'https://sigmahq.github.io/sigma-specification/Sigma_specification.html',
+        },
+      ]}
       history={history}
       notifications={notifications}
       mode={'create'}

--- a/public/pages/Rules/containers/CreateRule/CreateRule.tsx
+++ b/public/pages/Rules/containers/CreateRule/CreateRule.tsx
@@ -5,13 +5,13 @@
 
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS } from '../../../../utils/constants';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { setBreadCrumb } from '../../utils/helpers';
+import { setRulesRelatedBreadCrumb } from '../../utils/helpers';
 import { EuiTitle, EuiText, EuiLink } from '@elastic/eui';
+import { setBreadcrumbs } from '../../../../utils/helpers';
 
 export interface CreateRuleProps {
   services: BrowserServices;
@@ -20,10 +20,8 @@ export interface CreateRuleProps {
 }
 
 export const CreateRule: React.FC<CreateRuleProps> = ({ history, services, notifications }) => {
-  const context = useContext(CoreServicesContext);
-
   useEffect(() => {
-    setBreadCrumb(BREADCRUMBS.RULES_CREATE, context?.chrome.setBreadcrumbs);
+    setRulesRelatedBreadCrumb(BREADCRUMBS.RULES_CREATE, setBreadcrumbs);
   });
 
   return (

--- a/public/pages/Rules/containers/DuplicateRule/DuplicateRule.tsx
+++ b/public/pages/Rules/containers/DuplicateRule/DuplicateRule.tsx
@@ -5,13 +5,13 @@
 
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
-import React, { useContext } from 'react';
+import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS } from '../../../../utils/constants';
-import { CoreServicesContext } from '../../../../components/core_services';
-import { setBreadCrumb } from '../../utils/helpers';
+import { setRulesRelatedBreadCrumb } from '../../utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { RuleItemInfoBase } from '../../../../../types';
+import { setBreadcrumbs } from '../../../../utils/helpers';
 
 export interface DuplicateRuleProps
   extends RouteComponentProps<any, any, { ruleItem: RuleItemInfoBase }> {
@@ -25,8 +25,7 @@ export const DuplicateRule: React.FC<DuplicateRuleProps> = ({
   location,
   notifications,
 }) => {
-  const context = useContext(CoreServicesContext);
-  setBreadCrumb(BREADCRUMBS.RULES_DUPLICATE, context?.chrome.setBreadcrumbs);
+  setRulesRelatedBreadCrumb(BREADCRUMBS.RULES_DUPLICATE, setBreadcrumbs);
 
   return (
     <RuleEditorContainer

--- a/public/pages/Rules/containers/EditRule/EditRule.tsx
+++ b/public/pages/Rules/containers/EditRule/EditRule.tsx
@@ -5,13 +5,13 @@
 
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS } from '../../../../utils/constants';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { setBreadCrumb } from '../../utils/helpers';
+import { setRulesRelatedBreadCrumb } from '../../utils/helpers';
 import { RuleItemInfoBase } from '../../../../../types';
+import { setBreadcrumbs } from '../../../../utils/helpers';
 
 export interface EditRuleProps
   extends RouteComponentProps<any, any, { ruleItem: RuleItemInfoBase }> {
@@ -19,16 +19,9 @@ export interface EditRuleProps
   notifications?: NotificationsStart;
 }
 
-export const EditRule: React.FC<EditRuleProps> = ({
-  history,
-  services,
-  location,
-  notifications,
-}) => {
-  const context = useContext(CoreServicesContext);
-
+export const EditRule: React.FC<EditRuleProps> = ({ history, location, notifications }) => {
   useEffect(() => {
-    setBreadCrumb(BREADCRUMBS.RULES_EDIT, context?.chrome.setBreadcrumbs);
+    setRulesRelatedBreadCrumb(BREADCRUMBS.RULES_EDIT, setBreadcrumbs);
   });
 
   return (

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -5,17 +5,17 @@
 
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { EuiButton, EuiFilePicker, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { BREADCRUMBS, ROUTES } from '../../../../utils/constants';
 import { RouteComponentProps } from 'react-router-dom';
 import { dump, load } from 'js-yaml';
 import { ContentPanel } from '../../../../components/ContentPanel';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { CoreServicesContext } from '../../../../components/core_services';
-import { setBreadCrumb } from '../../utils/helpers';
+import { setRulesRelatedBreadCrumb } from '../../utils/helpers';
 import { Rule } from '../../../../../types';
 import { DEFAULT_RULE_UUID } from '../../../../../common/constants';
+import { setBreadcrumbs } from '../../../../utils/helpers';
 
 export interface ImportRuleProps {
   services: BrowserServices;
@@ -23,8 +23,7 @@ export interface ImportRuleProps {
   notifications?: NotificationsStart;
 }
 
-export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notifications }) => {
-  const context = useContext(CoreServicesContext);
+export const ImportRule: React.FC<ImportRuleProps> = ({ history, notifications }) => {
   const [fileError, setFileError] = useState('');
   const onChange = useCallback((files: FileList | null) => {
     setFileError('');
@@ -115,7 +114,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, services, notif
         </EuiFlexGroup>
       </>
     );
-    setBreadCrumb(BREADCRUMBS.RULES_IMPORT, context?.chrome.setBreadcrumbs);
+    setRulesRelatedBreadCrumb(BREADCRUMBS.RULES_IMPORT, setBreadcrumbs);
   }, [fileError, onChange]);
 
   return content;

--- a/public/pages/Rules/containers/ImportRule/ImportRule.tsx
+++ b/public/pages/Rules/containers/ImportRule/ImportRule.tsx
@@ -6,16 +6,24 @@
 import { BrowserServices } from '../../../../models/interfaces';
 import { RuleEditorContainer } from '../../components/RuleEditor/RuleEditorContainer';
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiButton, EuiFilePicker, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFilePicker,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
 import { BREADCRUMBS, ROUTES } from '../../../../utils/constants';
 import { RouteComponentProps } from 'react-router-dom';
 import { dump, load } from 'js-yaml';
-import { ContentPanel } from '../../../../components/ContentPanel';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { setRulesRelatedBreadCrumb } from '../../utils/helpers';
 import { Rule } from '../../../../../types';
 import { DEFAULT_RULE_UUID } from '../../../../../common/constants';
 import { setBreadcrumbs } from '../../../../utils/helpers';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface ImportRuleProps {
   services: BrowserServices;
@@ -92,7 +100,12 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, notifications }
   useEffect(() => {
     setContent(
       <>
-        <ContentPanel title="Import rule">
+        <EuiPanel>
+          <PageHeader>
+            <EuiTitle>
+              <h3>Import rule</h3>
+            </EuiTitle>
+          </PageHeader>
           <EuiFilePicker
             id={'filePickerId'}
             fullWidth
@@ -105,7 +118,7 @@ export const ImportRule: React.FC<ImportRuleProps> = ({ history, notifications }
             data-test-subj="import_rule_file_picker"
           />
           {fileError && <div style={{ color: 'red', margin: '0 auto' }}>Error: {fileError}</div>}
-        </ContentPanel>
+        </EuiPanel>
         <EuiSpacer size="xl" />
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>

--- a/public/pages/Rules/containers/Rules/Rules.tsx
+++ b/public/pages/Rules/containers/Rules/Rules.tsx
@@ -4,24 +4,23 @@
  */
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { RulesTable } from '../../components/RulesTable/RulesTable';
 import { RuleTableItem } from '../../utils/helpers';
 import { RuleViewerFlyout } from '../../components/RuleViewerFlyout/RuleViewerFlyout';
 import { BREADCRUMBS, ROUTES } from '../../../../utils/constants';
 import { NotificationsStart } from 'opensearch-dashboards/public';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { DataStore } from '../../../../store/DataStore';
 import { DataSourceProps } from '../../../../../types';
+import { setBreadcrumbs } from '../../../../utils/helpers';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface RulesProps extends RouteComponentProps, DataSourceProps {
   notifications?: NotificationsStart;
 }
 
 export const Rules: React.FC<RulesProps> = (props) => {
-  const context = useContext(CoreServicesContext);
-
   const [allRules, setAllRules] = useState<RuleTableItem[]>([]);
   const [flyoutData, setFlyoutData] = useState<RuleTableItem | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
@@ -46,7 +45,7 @@ export const Rules: React.FC<RulesProps> = (props) => {
   }, [DataStore.rules.getAllRules]);
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES]);
+    setBreadcrumbs([BREADCRUMBS.RULES]);
   }, []);
 
   useEffect(() => {
@@ -95,25 +94,31 @@ export const Rules: React.FC<RulesProps> = (props) => {
         />
       ) : null}
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
-            <EuiFlexItem>
-              <EuiTitle size="m">
-                <h1>Detection rules</h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup justifyContent="flexEnd">
-                {headerActions.map((action, idx) => (
-                  <EuiFlexItem key={idx} grow={false}>
-                    {action}
-                  </EuiFlexItem>
-                ))}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size={'m'} />
-        </EuiFlexItem>
+        <PageHeader
+          appRightControls={headerActions.map((action) => ({
+            renderComponent: action,
+          }))}
+        >
+          <EuiFlexItem>
+            <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
+              <EuiFlexItem>
+                <EuiTitle size="m">
+                  <h1>Detection rules</h1>
+                </EuiTitle>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFlexGroup justifyContent="flexEnd">
+                  {headerActions.map((action, idx) => (
+                    <EuiFlexItem key={idx} grow={false}>
+                      {action}
+                    </EuiFlexItem>
+                  ))}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size={'m'} />
+          </EuiFlexItem>
+        </PageHeader>
         <EuiFlexItem>
           <EuiPanel>
             <RulesTable loading={loading} ruleItems={allRules} showRuleDetails={setFlyoutData} />

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -176,11 +176,11 @@ export function validateRule(
   return true;
 }
 
-export function setBreadCrumb(
+export function setRulesRelatedBreadCrumb(
   breadCrumb: EuiBreadcrumb,
   breadCrumbSetter?: (breadCrumbs: EuiBreadcrumb[]) => void
 ) {
-  breadCrumbSetter?.([BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.RULES, breadCrumb]);
+  breadCrumbSetter?.([BREADCRUMBS.RULES, breadCrumb]);
 }
 
 export function getLogTypeFromLogSource(logSource: { [k: string]: string }) {

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -47,6 +47,7 @@ import {
   validateName,
 } from '../../../../utils/validation';
 import { setBreadcrumbs } from '../../../../utils/helpers';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 enum ErrorKeys {
   s3 = 's3',
@@ -353,17 +354,26 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
   return (
     <>
       <EuiPanel>
-        <EuiTitle>
-          <h4>Add custom threat intelligence source</h4>
-        </EuiTitle>
-        <EuiSpacer size="xs" />
-        <EuiText color="subdued">
-          <p>
-            Add your custom threat intelligence source that contains indicators of malicious
-            behaviors in STIX (Structured Threat Information Expression) format.
-          </p>
-        </EuiText>
-        <EuiSpacer />
+        <PageHeader
+          appDescriptionControls={[
+            {
+              description: `Add your custom threat intelligence source that contains indicators of malicious
+            behaviors in STIX (Structured Threat Information Expression) format.`,
+            },
+          ]}
+        >
+          <EuiTitle>
+            <h4>Add custom threat intelligence source</h4>
+          </EuiTitle>
+          <EuiSpacer size="xs" />
+          <EuiText color="subdued">
+            <p>
+              Add your custom threat intelligence source that contains indicators of malicious
+              behaviors in STIX (Structured Threat Information Expression) format.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+        </PageHeader>
         <EuiText>
           <h4>Details</h4>
         </EuiText>

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   EuiButton,
   EuiCheckableCard,
@@ -20,7 +20,6 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { BREADCRUMBS, ROUTES, defaultIntervalUnitOptions } from '../../../../utils/constants';
 import { Interval } from '../../../CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval';
 import { RouteComponentProps } from 'react-router-dom';
@@ -47,6 +46,7 @@ import {
   validateDescription,
   validateName,
 } from '../../../../utils/validation';
+import { setBreadcrumbs } from '../../../../utils/helpers';
 
 enum ErrorKeys {
   s3 = 's3',
@@ -92,7 +92,6 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
   history,
   threatIntelService,
 }) => {
-  const context = useContext(CoreServicesContext);
   const [source, setSource] = useState<ThreatIntelSourcePayloadBase>(
     getEmptyThreatIntelSourcePayloadBase()
   );
@@ -131,11 +130,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
   };
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
-      BREADCRUMBS.THREAT_INTEL_OVERVIEW,
-      BREADCRUMBS.THREAT_INTEL_ADD_CUSTOM_SOURCE,
-    ]);
+    setBreadcrumbs([BREADCRUMBS.THREAT_INTEL_OVERVIEW, BREADCRUMBS.THREAT_INTEL_ADD_CUSTOM_SOURCE]);
   }, []);
 
   const validateIocTypes = (iocTypeMap: Record<string, boolean>) => {

--- a/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
+++ b/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
@@ -17,8 +17,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import React, { MouseEventHandler, useCallback, useContext, useEffect, useMemo } from 'react';
-import { CoreServicesContext } from '../../../../components/core_services';
+import React, { MouseEventHandler, useCallback, useEffect, useMemo } from 'react';
 import { BREADCRUMBS, ROUTES } from '../../../../utils/constants';
 import { useState } from 'react';
 import {
@@ -32,6 +31,7 @@ import { deriveFormModelFromConfig, getThreatIntelNextStepsProps } from '../../u
 import { ThreatIntelOverviewActions } from '../../components/ThreatIntelOverviewActions/ThreatIntelOverviewActions';
 import ThreatIntelService from '../../../../services/ThreatIntelService';
 import { ThreatIntelLogScanConfig } from '../../components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig';
+import { setBreadcrumbs } from '../../../../utils/helpers';
 
 export interface ThreatIntelOverviewProps extends RouteComponentProps {
   threatIntelService: ThreatIntelService;
@@ -41,7 +41,6 @@ export const ThreatIntelOverview: React.FC<ThreatIntelOverviewProps> = ({
   history,
   threatIntelService,
 }) => {
-  const context = useContext(CoreServicesContext);
   const [threatIntelSources, setThreatIntelSources] = useState<ThreatIntelSourceItem[]>([]);
   const [scanConfig, setScanConfig] = useState<ThreatIntelScanConfig | undefined>(undefined);
   const [flyoutContent, setFlyoutContent] = useState<React.ReactNode>(null);
@@ -122,10 +121,7 @@ export const ThreatIntelOverview: React.FC<ThreatIntelOverviewProps> = ({
   );
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
-      BREADCRUMBS.THREAT_INTEL_OVERVIEW,
-    ]);
+    setBreadcrumbs([BREADCRUMBS.THREAT_INTEL_OVERVIEW]);
   }, []);
 
   useEffect(() => {

--- a/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
+++ b/public/pages/ThreatIntel/containers/Overview/ThreatIntelOverview.tsx
@@ -32,6 +32,7 @@ import { ThreatIntelOverviewActions } from '../../components/ThreatIntelOverview
 import ThreatIntelService from '../../../../services/ThreatIntelService';
 import { ThreatIntelLogScanConfig } from '../../components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig';
 import { setBreadcrumbs } from '../../../../utils/helpers';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface ThreatIntelOverviewProps extends RouteComponentProps {
   threatIntelService: ThreatIntelService;
@@ -155,35 +156,59 @@ export const ThreatIntelOverview: React.FC<ThreatIntelOverviewProps> = ({
     logSources.length > 0
   );
 
+  const threatIntelOverviewActions = (
+    <ThreatIntelOverviewActions
+      history={history}
+      scanConfig={scanConfig}
+      sourceCount={threatIntelSources.length}
+      toggleScan={toggleScan}
+    />
+  );
+
   return (
     <>
-      <EuiFlexGroup alignItems="flexStart">
-        <EuiFlexItem>
-          <EuiTitle size="m">
-            <h1>Threat intelligence</h1>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <ThreatIntelOverviewActions
-            history={history}
-            scanConfig={scanConfig}
-            sourceCount={threatIntelSources.length}
-            toggleScan={toggleScan}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="s" />
-      <EuiText color="subdued">
-        <span>
-          Scan log data for indicators of compromise from threat intel data streams to identify
-          malicious actors and security threats.{' '}
-          <EuiLink href="" external>
-            Learn more
-          </EuiLink>
-          .
-        </span>
-      </EuiText>
-      <EuiSpacer />
+      <PageHeader
+        appRightControls={[{ renderComponent: threatIntelOverviewActions }]}
+        appDescriptionControls={[
+          {
+            description: `Scan log data for indicators of compromise from threat intel data streams to identify
+          malicious actors and security threats.`,
+          },
+          {
+            label: 'Learn more',
+            href:
+              'https://opensearch.org/docs/latest/security-analytics/threat-intelligence/index/',
+            controlType: 'link',
+            target: '_blank',
+            iconType: 'popout',
+            iconSide: 'right',
+          },
+        ]}
+      >
+        <EuiFlexGroup alignItems="flexStart">
+          <EuiFlexItem>
+            <EuiTitle size="m">
+              <h1>Threat intelligence</h1>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{threatIntelOverviewActions}</EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="s" />
+        <EuiText color="subdued">
+          <span>
+            Scan log data for indicators of compromise from threat intel data streams to identify
+            malicious actors and security threats.{' '}
+            <EuiLink
+              href="https://opensearch.org/docs/latest/security-analytics/threat-intelligence/index/"
+              external
+            >
+              Learn more
+            </EuiLink>
+            .
+          </span>
+        </EuiText>
+        <EuiSpacer />
+      </PageHeader>
       <EuiAccordion
         id="threat-intel-management-steps"
         buttonContent="Get started"

--- a/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
+++ b/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -14,7 +14,6 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { BREADCRUMBS, PLUGIN_NAME, ROUTES } from '../../../../utils/constants';
-import { CoreServicesContext } from '../../../../components/core_services';
 import { SelectThreatIntelLogSources } from '../../components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm';
 import {
   ThreatIntelScanConfig,
@@ -33,7 +32,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { ConfigureThreatIntelScanStep } from '../../utils/constants';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { PeriodSchedule } from '../../../../../models/interfaces';
-import { errorNotificationToast } from '../../../../utils/helpers';
+import { errorNotificationToast, setBreadcrumbs } from '../../../../utils/helpers';
 import { validateName } from '../../../../utils/validation';
 
 export interface ThreatIntelScanConfigFormProps
@@ -69,7 +68,6 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
 }) => {
   const isEdit = location.pathname.includes(ROUTES.THREAT_INTEL_EDIT_SCAN_CONFIG);
   const [scanId, setScanId] = useState('');
-  const context = useContext(CoreServicesContext);
   const [currentStep, setCurrentStep] = useState(
     location.state?.step ?? ConfigureThreatIntelScanStep.SelectLogSources
   );
@@ -101,8 +99,7 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
   }, [formErrors]);
 
   useEffect(() => {
-    context?.chrome.setBreadcrumbs([
-      BREADCRUMBS.SECURITY_ANALYTICS,
+    setBreadcrumbs([
       BREADCRUMBS.THREAT_INTEL_OVERVIEW,
       isEdit
         ? BREADCRUMBS.THREAT_INTEL_EDIT_SCAN_CONFIG

--- a/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
+++ b/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
@@ -34,6 +34,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { PeriodSchedule } from '../../../../../models/interfaces';
 import { errorNotificationToast, setBreadcrumbs } from '../../../../utils/helpers';
 import { validateName } from '../../../../utils/validation';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface ThreatIntelScanConfigFormProps
   extends RouteComponentProps<
@@ -328,10 +329,12 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
           />
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiTitle>
-            <h1>{isEdit ? 'Edit' : 'Set up'} real-time scan</h1>
-          </EuiTitle>
-          <EuiSpacer />
+          <PageHeader>
+            <EuiTitle>
+              <h1>{isEdit ? 'Edit' : 'Set up'} real-time scan</h1>
+            </EuiTitle>
+            <EuiSpacer />
+          </PageHeader>
           {getStepConent(currentStep)}
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
@@ -28,7 +28,12 @@ import { IoCsTable } from '../../components/IoCsTable/IoCsTable';
 import { ThreatIntelSourceDetails } from '../../components/ThreatIntelSourceDetails/ThreatIntelSourceDetails';
 import { IocLabel } from '../../../../../common/constants';
 import { ThreatIntelService } from '../../../../services';
-import { errorNotificationToast, parseSchedule, renderTime } from '../../../../utils/helpers';
+import {
+  errorNotificationToast,
+  parseSchedule,
+  renderTime,
+  setBreadcrumbs,
+} from '../../../../utils/helpers';
 import DeleteModal from '../../../../components/DeleteModal';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 
@@ -65,9 +70,8 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
   }, []);
 
   useEffect(() => {
-    const baseCrumbs = [BREADCRUMBS.SECURITY_ANALYTICS, BREADCRUMBS.THREAT_INTEL_OVERVIEW];
-
-    coreContext?.chrome.setBreadcrumbs(
+    const baseCrumbs = [BREADCRUMBS.THREAT_INTEL_OVERVIEW];
+    setBreadcrumbs(
       !source
         ? baseCrumbs
         : [...baseCrumbs, BREADCRUMBS.THREAT_INTEL_SOURCE_DETAILS(source.name, sourceId)]

--- a/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useContext, useState, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { ThreatIntelSourceItem } from '../../../../../types';
 import { RouteComponentProps } from 'react-router-dom';
 import { BREADCRUMBS, DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
 import { useEffect } from 'react';
-import { CoreServicesContext } from '../../../../components/core_services';
 import {
   EuiButton,
   EuiButtonIcon,
@@ -36,6 +35,7 @@ import {
 } from '../../../../utils/helpers';
 import DeleteModal from '../../../../components/DeleteModal';
 import { NotificationsStart } from 'opensearch-dashboards/public';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface ThreatIntelSource
   extends RouteComponentProps<any, any, { source?: ThreatIntelSourceItem }> {
@@ -49,7 +49,6 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
   threatIntelService,
   notifications,
 }) => {
-  const coreContext = useContext(CoreServicesContext);
   const [source, setSource] = useState<ThreatIntelSourceItem | undefined>(location.state?.source);
   const sourceId =
     source?.id ?? location.pathname.replace(`${ROUTES.THREAT_INTEL_SOURCE_DETAILS}/`, '');
@@ -158,61 +157,68 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
   const schedule = type === 'S3_CUSTOM' ? source.schedule : undefined;
   const showActivateControls = 'enabled_for_scan' in source;
 
+  const headerControls = [];
+
+  if (showActivateControls) {
+    headerControls.push(
+      <EuiToolTip
+        content={
+          'When Active, the indicators of compromise from this source are used to scan the log data as part of the threat intel scan.'
+        }
+      >
+        <span>
+          <EuiIcon
+            type={'dot'}
+            color={enabled_for_scan ? 'success' : 'text'}
+            style={{ marginBottom: 4 }}
+          />{' '}
+          {enabled_for_scan ? 'Active' : 'Inactive'}&nbsp;
+          <EuiIcon type={'iInCircle'} />
+        </span>
+      </EuiToolTip>,
+      <EuiButton color={enabled_for_scan ? 'danger' : 'primary'} onClick={toggleActiveState}>
+        {enabled_for_scan ? 'Deactivate' : 'Activate'}
+      </EuiButton>
+    );
+  }
+
+  if (type === 'S3_CUSTOM') {
+    headerControls.push(
+      <EuiButton fill onClick={onRefresh}>
+        Refresh
+      </EuiButton>
+    );
+  }
+
+  headerControls.push(
+    <EuiToolTip content={'Delete'}>
+      <EuiButtonIcon iconType={'trash'} color="danger" onClick={onDeleteButtonClick} />
+    </EuiToolTip>
+  );
+
   return (
     <>
-      <EuiFlexGroup alignItems="flexStart">
-        <EuiFlexItem>
-          <EuiTitle>
-            <h2>{name}</h2>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center" wrap>
-            {showActivateControls && (
-              <>
-                <EuiFlexItem grow={false}>
-                  <EuiToolTip
-                    content={
-                      'When Active, the indicators of compromise from this source are used to scan the log data as part of the threat intel scan.'
-                    }
-                  >
-                    <span>
-                      <EuiIcon
-                        type={'dot'}
-                        color={enabled_for_scan ? 'success' : 'text'}
-                        style={{ marginBottom: 4 }}
-                      />{' '}
-                      {enabled_for_scan ? 'Active' : 'Inactive'}&nbsp;
-                      <EuiIcon type={'iInCircle'} />
-                    </span>
-                  </EuiToolTip>
+      <PageHeader
+        appRightControls={headerControls.map((control) => ({ renderComponent: control }))}
+      >
+        <EuiFlexGroup alignItems="flexStart">
+          <EuiFlexItem>
+            <EuiTitle>
+              <h2>{name}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup alignItems="center" wrap>
+              {headerControls.map((control, idx) => (
+                <EuiFlexItem grow={false} key={idx}>
+                  {control}
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    color={enabled_for_scan ? 'danger' : 'primary'}
-                    onClick={toggleActiveState}
-                  >
-                    {enabled_for_scan ? 'Deactivate' : 'Activate'}
-                  </EuiButton>
-                </EuiFlexItem>
-              </>
-            )}
-            {type === 'S3_CUSTOM' && (
-              <EuiFlexItem grow={false}>
-                <EuiButton fill onClick={onRefresh}>
-                  Refresh
-                </EuiButton>
-              </EuiFlexItem>
-            )}
-            <EuiFlexItem grow={false}>
-              <EuiToolTip content={'Delete'}>
-                <EuiButtonIcon iconType={'trash'} color="danger" onClick={onDeleteButtonClick} />
-              </EuiToolTip>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer />
+              ))}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer />
+      </PageHeader>
       <EuiPanel>
         <DescriptionGroup
           listItems={[

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -24,11 +24,7 @@ import {
   ROUTES,
   THREAT_ALERTS_NAV_ID,
   THREAT_INTEL_NAV_ID,
-  setApplication,
-  setBreadCrumbsSetter,
   setDarkMode,
-  setNavigationUI,
-  setUISettings,
 } from './utils/constants';
 import { SecurityAnalyticsPluginSetup, SecurityAnalyticsPluginStart } from './index';
 import { DataPublicPluginStart, DataPublicPluginSetup } from '../../../src/plugins/data/public';
@@ -37,6 +33,12 @@ import { setSecurityAnalyticsPluginConfig } from '../common/helpers';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 import { DataSourcePluginStart } from '../../../src/plugins/data_source/public';
 import { NavigationPublicPluginStart } from 'src/plugins/navigation/public';
+import {
+  setUISettings,
+  setNavigationUI,
+  setApplication,
+  setBreadCrumbsSetter,
+} from './services/utils/constants';
 
 export interface SecurityAnalyticsPluginSetupDeps {
   data: DataPublicPluginSetup;
@@ -185,14 +187,11 @@ export class SecurityAnalyticsPlugin
         { id: DETECTORS_NAV_ID, parentNavLinkId: PLUGIN_NAME },
         { id: DETECTORS_RULE_NAV_ID, parentNavLinkId: PLUGIN_NAME },
         { id: CORRELATIONS_RULE_NAV_ID },
-        { id: THREAT_INTEL_NAV_ID},
-        { id: LOG_TYPES_NAV_ID }
+        { id: THREAT_INTEL_NAV_ID },
+        { id: LOG_TYPES_NAV_ID },
       ];
 
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS['security-analytics'],
-        navlinks
-      );
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], navlinks);
     }
 
     setDarkMode(core.uiSettings.get('theme:darkMode'));

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -12,13 +12,31 @@ import {
   Plugin,
   PluginInitializerContext,
 } from '../../../src/core/public';
-import { CORRELATIONS_NAV_ID, CORRELATIONS_RULE_NAV_ID, DETECTORS_NAV_ID, DETECTORS_RULE_NAV_ID, FINDINGS_NAV_ID, LOG_TYPES_NAV_ID, PLUGIN_NAME, ROUTES, THREAT_ALERTS_NAV_ID, THREAT_INTEL_NAV_ID, setDarkMode } from './utils/constants';
+import {
+  CORRELATIONS_NAV_ID,
+  CORRELATIONS_RULE_NAV_ID,
+  DETECTORS_NAV_ID,
+  DETECTORS_RULE_NAV_ID,
+  FINDINGS_NAV_ID,
+  LOG_TYPES_NAV_ID,
+  OVERVIEW_NAV_ID,
+  PLUGIN_NAME,
+  ROUTES,
+  THREAT_ALERTS_NAV_ID,
+  THREAT_INTEL_NAV_ID,
+  setApplication,
+  setBreadCrumbsSetter,
+  setDarkMode,
+  setNavigationUI,
+  setUISettings,
+} from './utils/constants';
 import { SecurityAnalyticsPluginSetup, SecurityAnalyticsPluginStart } from './index';
 import { DataPublicPluginStart, DataPublicPluginSetup } from '../../../src/plugins/data/public';
 import { SecurityAnalyticsPluginConfigType } from '../config';
 import { setSecurityAnalyticsPluginConfig } from '../common/helpers';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 import { DataSourcePluginStart } from '../../../src/plugins/data_source/public';
+import { NavigationPublicPluginStart } from 'src/plugins/navigation/public';
 
 export interface SecurityAnalyticsPluginSetupDeps {
   data: DataPublicPluginSetup;
@@ -26,6 +44,7 @@ export interface SecurityAnalyticsPluginSetupDeps {
 }
 export interface SecurityAnalyticsPluginStartDeps {
   data: DataPublicPluginStart;
+  navigation: NavigationPublicPluginStart;
   dataSource?: DataSourcePluginStart;
 }
 
@@ -45,9 +64,8 @@ export class SecurityAnalyticsPlugin
     core: CoreSetup<SecurityAnalyticsPluginStartDeps>,
     { dataSourceManagement }: SecurityAnalyticsPluginSetupDeps
   ): SecurityAnalyticsPluginSetup {
-
     const mountWrapper = async (params: AppMountParameters, redirect: string) => {
-      const { renderApp } = await import("./security_analytics_app");
+      const { renderApp } = await import('./security_analytics_app');
       const [coreStart, depsStart] = await core.getStartServices();
       return renderApp(coreStart, params, redirect, depsStart, dataSourceManagement);
     };
@@ -69,8 +87,15 @@ export class SecurityAnalyticsPlugin
     });
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
+      core.application.register({
+        id: OVERVIEW_NAV_ID,
+        title: 'Overview',
+        order: 0,
+        mount: async (params: AppMountParameters) => {
+          return mountWrapper(params, ROUTES.LANDING_PAGE);
+        },
+      });
 
-      // register investigate and configure routes
       core.application.register({
         id: THREAT_ALERTS_NAV_ID,
         title: 'Threat alerts',
@@ -152,6 +177,7 @@ export class SecurityAnalyticsPlugin
       });
 
       const navlinks = [
+        { id: OVERVIEW_NAV_ID, showInAllNavGroup: true },
         { id: THREAT_ALERTS_NAV_ID, showInAllNavGroup: true },
         { id: FINDINGS_NAV_ID, showInAllNavGroup: true },
         { id: CORRELATIONS_NAV_ID },
@@ -179,7 +205,14 @@ export class SecurityAnalyticsPlugin
     };
   }
 
-  public start(_core: CoreStart): SecurityAnalyticsPluginStart {
+  public start(
+    core: CoreStart,
+    { navigation }: SecurityAnalyticsPluginStartDeps
+  ): SecurityAnalyticsPluginStart {
+    setUISettings(core.uiSettings);
+    setNavigationUI(navigation.ui);
+    setApplication(core.application);
+    setBreadCrumbsSetter(core.chrome.setBreadcrumbs);
     return {};
   }
 }

--- a/public/services/utils/constants.ts
+++ b/public/services/utils/constants.ts
@@ -4,9 +4,30 @@
  */
 
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
+import { createGetterSetter } from '../../../../../src/plugins/opensearch_dashboards_utils/common';
+import { CoreStart, IUiSettingsClient } from 'opensearch-dashboards/public';
+import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
 
 export const dataSourceInfo: { activeDataSource: DataSourceOption } = {
   activeDataSource: {
     id: '',
   },
 };
+
+export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
+
+export const getUseUpdatedUx = () => {
+  return getUISettings().get('home:useNewHomePage', false);
+};
+
+export const [getNavigationUI, setNavigationUI] = createGetterSetter<
+  NavigationPublicPluginStart['ui']
+>('navigation');
+
+export const [getApplication, setApplication] = createGetterSetter<CoreStart['application']>(
+  'application'
+);
+
+export const [getBreadCrumbsSetter, setBreadCrumbsSetter] = createGetterSetter<
+  CoreStart['chrome']['setBreadcrumbs']
+>('breadCrumbSetter');

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -9,7 +9,7 @@ import { DetectorInput, PeriodSchedule } from '../../models/interfaces';
 import { DetectorHit } from '../../server/models/interfaces';
 import _ from 'lodash';
 import { euiPaletteColorBlind } from '@elastic/eui';
-import { createGetterSetter } from '../../../../src/plugins/opensearch_dashboards_utils/public';
+import { createGetterSetter } from '../../../../src/plugins/opensearch_dashboards_utils/common';
 import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
 export const DATE_MATH_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SimpleSavedObject } from 'opensearch-dashboards/public';
+import { CoreStart, IUiSettingsClient, SimpleSavedObject } from 'opensearch-dashboards/public';
 import { Detector, LogType, ServerResponse } from '../../types';
 import { DetectorInput, PeriodSchedule } from '../../models/interfaces';
 import { DetectorHit } from '../../server/models/interfaces';
 import _ from 'lodash';
 import { euiPaletteColorBlind } from '@elastic/eui';
+import { createGetterSetter } from '../../../../src/plugins/opensearch_dashboards_utils/public';
+import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
 export const DATE_MATH_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 export const MAX_RECENTLY_USED_TIME_RANGES = 5;
@@ -19,6 +21,7 @@ export const PLUGIN_NAME = 'opensearch_security_analytics_dashboards';
 export const OS_NOTIFICATION_PLUGIN = 'opensearch-notifications';
 
 export const DEFAULT_EMPTY_DATA = '-';
+export const OVERVIEW_NAV_ID = `overview`;
 export const THREAT_ALERTS_NAV_ID = `threat_alerts`;
 export const FINDINGS_NAV_ID = `findings`;
 export const CORRELATIONS_NAV_ID = `correlations`;
@@ -239,3 +242,21 @@ export enum AlertTabId {
   ThreatIntel = 'threat-intel',
   Correlations = 'correlations',
 }
+
+export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
+
+export const getUseUpdatedUx = () => {
+  return getUISettings().get('home:useNewHomePage', false);
+};
+
+export const [getNavigationUI, setNavigationUI] = createGetterSetter<
+  NavigationPublicPluginStart['ui']
+>('navigation');
+
+export const [getApplication, setApplication] = createGetterSetter<CoreStart['application']>(
+  'application'
+);
+
+export const [getBreadCrumbsSetter, setBreadCrumbsSetter] = createGetterSetter<
+  CoreStart['chrome']['setBreadcrumbs']
+>('breadCrumbSetter');

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -81,6 +81,7 @@ export const BREADCRUMBS = Object.freeze({
   FINDINGS: { text: 'Findings', href: `#${ROUTES.FINDINGS}` },
   DETECTORS: { text: 'Detectors', href: `#${ROUTES.DETECTORS}` },
   DETECTORS_CREATE: { text: 'Create detector', href: `#${ROUTES.DETECTORS_CREATE}` },
+  EDIT_DETECTOR_DETAILS: { text: 'Edit detector details' },
   DETECTORS_DETAILS: (name: string, detectorId: string) => ({
     text: `${name}`,
     href: `#${ROUTES.DETECTOR_DETAILS}/${detectorId}`,
@@ -97,10 +98,10 @@ export const BREADCRUMBS = Object.freeze({
   RULES_IMPORT: { text: 'Import rule', href: `#${ROUTES.RULES_IMPORT}` },
   CORRELATIONS: { text: 'Correlations', href: `#${ROUTES.CORRELATIONS}` },
   CORRELATION_RULES: { text: 'Correlation rules', href: `#${ROUTES.CORRELATION_RULES}` },
-  CORRELATIONS_RULE_CREATE: {
-    text: 'Create correlation rule',
+  CORRELATIONS_RULE_CREATE: (action: string) => ({
+    text: `${action} correlation rule`,
     href: `#${ROUTES.CORRELATION_RULE_CREATE}`,
-  },
+  }),
   LOG_TYPES: { text: 'Log types', href: `#${ROUTES.LOG_TYPES}` },
   LOG_TYPE_CREATE: { text: 'Create log type', href: `#${ROUTES.LOG_TYPES_CREATE}` },
   THREAT_INTEL_OVERVIEW: { text: 'Threat intelligence', href: `#${ROUTES.THREAT_INTEL_OVERVIEW}` },
@@ -109,7 +110,7 @@ export const BREADCRUMBS = Object.freeze({
     href: `#${ROUTES.THREAT_INTEL_ADD_CUSTOM_SOURCE}`,
   },
   THREAT_INTEL_SETUP_SCAN_CONFIG: {
-    text: 'Setup real-time scan',
+    text: 'Set up real-time scan',
     href: `#${ROUTES.THREAT_INTEL_CREATE_SCAN_CONFIG}`,
   },
   THREAT_INTEL_EDIT_SCAN_CONFIG: {

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CoreStart, IUiSettingsClient, SimpleSavedObject } from 'opensearch-dashboards/public';
+import { SimpleSavedObject } from 'opensearch-dashboards/public';
 import { Detector, LogType, ServerResponse } from '../../types';
 import { DetectorInput, PeriodSchedule } from '../../models/interfaces';
 import { DetectorHit } from '../../server/models/interfaces';
 import _ from 'lodash';
 import { euiPaletteColorBlind } from '@elastic/eui';
-import { createGetterSetter } from '../../../../src/plugins/opensearch_dashboards_utils/common';
-import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
 export const DATE_MATH_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 export const MAX_RECENTLY_USED_TIME_RANGES = 5;
@@ -243,21 +241,3 @@ export enum AlertTabId {
   ThreatIntel = 'threat-intel',
   Correlations = 'correlations',
 }
-
-export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
-
-export const getUseUpdatedUx = () => {
-  return getUISettings().get('home:useNewHomePage', false);
-};
-
-export const [getNavigationUI, setNavigationUI] = createGetterSetter<
-  NavigationPublicPluginStart['ui']
->('navigation');
-
-export const [getApplication, setApplication] = createGetterSetter<CoreStart['application']>(
-  'application'
-);
-
-export const [getBreadCrumbsSetter, setBreadCrumbsSetter] = createGetterSetter<
-  CoreStart['chrome']['setBreadcrumbs']
->('breadCrumbSetter');

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -22,8 +22,6 @@ import {
   BREADCRUMBS,
   DEFAULT_EMPTY_DATA,
   defaultColorForVisualizations,
-  getBreadCrumbsSetter,
-  getUseUpdatedUx,
   logTypeCategories,
   logTypeCategoryDescription,
   logTypesByCategories,
@@ -49,6 +47,7 @@ import { parse, View } from 'vega/build-es5/vega.js';
 import { compile } from 'vega-lite';
 import { Handler } from 'vega-tooltip';
 import { expressionInterpreter as vegaExpressionInterpreter } from 'vega-interpreter/build/vega-interpreter';
+import { getBreadCrumbsSetter, getUseUpdatedUx } from '../services/utils/constants';
 
 export const parseStringsToOptions = (strings: string[]) => {
   return strings.map((str) => ({ id: str, label: str }));

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -19,8 +19,11 @@ import moment from 'moment';
 import { PeriodSchedule } from '../../models/interfaces';
 import React from 'react';
 import {
+  BREADCRUMBS,
   DEFAULT_EMPTY_DATA,
   defaultColorForVisualizations,
+  getBreadCrumbsSetter,
+  getUseUpdatedUx,
   logTypeCategories,
   logTypeCategoryDescription,
   logTypesByCategories,
@@ -31,7 +34,7 @@ import {
   RuleItemInfo,
 } from '../pages/CreateDetector/components/DefineDetector/components/DetectionRules/types/interfaces';
 import { RuleInfo } from '../../server/models/interfaces';
-import { NotificationsStart } from 'opensearch-dashboards/public';
+import { ChromeBreadcrumb, NotificationsStart } from 'opensearch-dashboards/public';
 import { FieldMappingService, IndexService, OpenSearchService } from '../services';
 import { ruleSeverity, ruleTypes } from '../pages/Rules/utils/constants';
 import _ from 'lodash';
@@ -600,4 +603,8 @@ export async function getFieldsForIndex(
 
 export function renderIoCType(iocType: ThreatIntelIocType) {
   return IocLabel[iocType] || DEFAULT_EMPTY_DATA;
+}
+
+export function setBreadcrumbs(crumbs: ChromeBreadcrumb[]) {
+  getBreadCrumbsSetter()(getUseUpdatedUx() ? crumbs : [BREADCRUMBS.SECURITY_ANALYTICS, ...crumbs]);
 }

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { navigationPluginMock } from '../../../../src/plugins/navigation/public/mocks';
+import { applicationServiceMock } from '../../../../src/core/public/application/application_service.mock';
+import { uiSettingsServiceMock } from '../../../../src/core/public/ui_settings/ui_settings_service.mock';
+import {
+  setApplication,
+  setBreadCrumbsSetter,
+  setNavigationUI,
+  setUISettings,
+} from '../../public/utils/constants';
+
+export function setupCoreStart() {
+  setNavigationUI(navigationPluginMock.createStartContract().ui);
+  setApplication(applicationServiceMock.createStartContract());
+  setUISettings(uiSettingsServiceMock.createStartContract());
+  setBreadCrumbsSetter(jest.fn());
+}

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -11,7 +11,7 @@ import {
   setBreadCrumbsSetter,
   setNavigationUI,
   setUISettings,
-} from '../../public/utils/constants';
+} from '../../public/services/utils/constants';
 
 export function setupCoreStart() {
   setNavigationUI(navigationPluginMock.createStartContract().ui);


### PR DESCRIPTION
### Description
This PR updates all the pages to leverage the shared page header control updates gated behind the `[newHomePage](home:useNewHomePage)` setting.


https://github.com/user-attachments/assets/259de3c0-ffd3-480c-b053-5c1218f2d89a



### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).