### PR TITLE
Made import more specific to avoid importing incorrect modules

### DIFF
--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -79,7 +79,7 @@ import SavedObjectService from '../services/SavedObjectService';
 import MetricsService from '../services/MetricsService';
 import ThreatIntelService from '../services/ThreatIntelService';
 import { BrowserServices } from '../models/interfaces';
-import { IndexPatternsService as CoreIndexPatternsService } from '../../../../src/plugins/data/common';
+import { IndexPatternsService as CoreIndexPatternsService } from '../../../../src/plugins/data/common/index_patterns';
 import semver from 'semver';
 import * as pluginManifest from '../../opensearch_dashboards.json';
 import { DataSourceThreatAlertsCard } from '../components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard';


### PR DESCRIPTION
### Description
When importing CoreIndexPatternService we are importing the entire common module inside data plugin which is causing an incorrectly setup module (kuery.js which is using module.exports) to get imported as well causing webpack errors at runtime.
We can simply import the required service from the IndexPatterns module and avoid importing the faulty code.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).