### PR TITLE
Remove import causing error in webpack as mitigation

### DIFF
--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -70,7 +70,6 @@ import {
   setBrowserServices,
   getDataSourceManagementPlugin,
 } from '../services/utils/constants';
-import { ANALYTICS_ALL_OVERVIEW_CONTENT_AREAS } from '../../../../src/plugins/content_management/public';
 import DetectorsService from '../services/DetectorService';
 import CorrelationService from '../services/CorrelationService';
 import FindingsService from '../services/FindingsService';
@@ -690,7 +689,7 @@ export const getTruncatedText = (text: string, textLength: number = 14) => {
 export function registerThreatAlertsCard() {
   getContentManagement().registerContentProvider({
     id: `analytics_all_recent_threat_alerts_card_content`,
-    getTargetArea: () => ANALYTICS_ALL_OVERVIEW_CONTENT_AREAS.SERVICE_CARDS,
+    getTargetArea: () => 'all_overview/service_cards',
     getContent: () => ({
       id: 'analytics_all_recent_threat_alerts_card',
       kind: 'custom',


### PR DESCRIPTION
### Description
Importing the section enum is causing unwanted imports from core leading to error `Cannot assign to read only property 'exports' of object '#<Object>'`. As mitigation, using the enum value directly.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).