### PR TITLE
Pass through remaining location arguments when updating the url query params

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -213,6 +213,7 @@ export default class Main extends Component<MainProps, MainState> {
       const searchParams = new URLSearchParams(this.props.location.search);
       searchParams.set('dataSourceId', this.state.selectedDataSource.id);
       this.props.history.replace({
+        ...this.props.location,
         search: searchParams.toString(),
       });
     }

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -212,10 +212,13 @@ export default class Main extends Component<MainProps, MainState> {
     if (pathnameChanged || this.state.selectedDataSource.id !== prevState.selectedDataSource.id) {
       const searchParams = new URLSearchParams(this.props.location.search);
       searchParams.set('dataSourceId', this.state.selectedDataSource.id);
-      this.props.history.replace({
-        ...this.props.location,
-        search: searchParams.toString(),
-      });
+      this.props.history.replace(
+        {
+          ...this.props.location,
+          search: searchParams.toString(),
+        },
+        this.props.location.state
+      );
     }
 
     if (pathnameChanged) {

--- a/release-notes/opensearch-security-analytics-dashboards.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-security-analytics-dashboards.release-notes-2.17.0.0.md
@@ -22,6 +22,8 @@ Compatible with OpenSearch Dashboards 2.17.0
 * Bug fixes PageHeader and SideNav ([#1123](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1123))
 * Added check for multi data source support when rendering threat alerts card in all use case workspace ([#1132](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1132))
 * Made import more specific to avoid importing incorrect modules ([#1136](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1136))
+* remove import causing error ([#1144](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1144))
+* Passthrough URL state and other params when updating search query ([#1148](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1148))
 
 ### Documentation
 * Added v2.17 release notes. ([#1141](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1141))


### PR DESCRIPTION
### Description
Currently we update the url with the current data source id when the path gets updated, however in cases when state is passed from the calling component (like Duplicate rule from Rule flyout), it is not getting passed through and as a result it fails to render those pages correctly

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).