### PR TITLE
Fix findings page crash and rule severity correctness

### DIFF
--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -28,6 +28,7 @@ import {
 import {
   BREADCRUMBS,
   DEFAULT_DATE_RANGE,
+  DEFAULT_EMPTY_DATA,
   FindingTabId,
   MAX_RECENTLY_USED_TIME_RANGES,
 } from '../../../../utils/constants';
@@ -49,6 +50,7 @@ import {
   getDuration,
   getIsNotificationPluginInstalled,
   setBreadcrumbs,
+  isThreatIntelQuery,
 } from '../../../../utils/helpers';
 import { RuleSource } from '../../../../../server/models/interfaces';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -66,6 +68,7 @@ import {
 } from '../../../../../types';
 import { ThreatIntelFindingsTable } from '../../components/FindingsTable/ThreatIntelFindingsTable';
 import { PageHeader } from '../../../../components/PageHeader/PageHeader';
+import { RuleSeverityValue, RuleSeverityPriority } from '../../../Rules/utils/constants';
 
 interface FindingsProps extends RouteComponentProps, DataSourceProps {
   detectorService: DetectorsService;
@@ -436,7 +439,8 @@ class Findings extends Component<FindingsProps, FindingsState> {
         const ruleLevel =
           finding.detectionType === 'Threat intelligence'
             ? 'high'
-            : (findingsState as DetectionRulesFindingsState).rules[finding.queries[0].id].level;
+            : (findingsState as DetectionRulesFindingsState).rules[finding.queries[0].id]?.level ||
+              DEFAULT_EMPTY_DATA;
         visData.push({
           finding: 1,
           time: findingTime.getTime(),
@@ -521,13 +525,30 @@ class Findings extends Component<FindingsProps, FindingsState> {
     } = this.props;
     if (selectedTabId === FindingTabId.DetectionRules && Object.keys(rules).length > 0) {
       findings = findings.map((finding: any) => {
-        const rule = rules[finding.queries[0].id];
-        if (rule) {
-          finding['ruleName'] = rule.title;
-          finding['ruleSeverity'] =
-            rule.level === 'critical' ? rule.level : finding['ruleSeverity'] || rule.level;
-          finding['tags'] = rule.tags;
-        }
+        const matchedRules: RuleSource[] = [];
+        finding.queries.forEach((query: any) => {
+          if (rules[query.id]) {
+            matchedRules.push(rules[query.id]);
+          }
+        });
+
+        matchedRules.sort((a, b) => {
+          return RuleSeverityPriority[a.level as RuleSeverityValue] <
+            RuleSeverityPriority[b.level as RuleSeverityValue]
+            ? -1
+            : 1;
+        });
+
+        finding['ruleName'] =
+          matchedRules[0]?.title ||
+          (finding.queries.find(({ id }) => isThreatIntelQuery(id))
+            ? 'Threat intel'
+            : DEFAULT_EMPTY_DATA);
+        finding['ruleSeverity'] =
+          matchedRules[0]?.level === 'critical'
+            ? 'critical'
+            : finding['ruleSeverity'] || matchedRules[0]?.level || DEFAULT_EMPTY_DATA;
+        finding['tags'] = matchedRules[0]?.tags || [];
         return finding;
       });
     }
@@ -625,7 +646,11 @@ class Findings extends Component<FindingsProps, FindingsState> {
               <EuiFlexItem>
                 {!findings || findings.length === 0 ? (
                   <EuiEmptyPrompt
-                    title={<EuiText size="s"><h2>No findings</h2></EuiText>}
+                    title={
+                      <EuiText size="s">
+                        <h2>No findings</h2>
+                      </EuiText>
+                    }
                     body={
                       <EuiText size="s">
                         {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}

--- a/public/pages/Rules/utils/constants.ts
+++ b/public/pages/Rules/utils/constants.ts
@@ -15,6 +15,22 @@ export const ruleTypes: {
 
 const paletteColors = euiPaletteForStatus(5);
 
+export enum RuleSeverityValue {
+  Critical = 'critical',
+  High = 'high',
+  Medium = 'medium',
+  Low = 'low',
+  Informational = 'informational',
+}
+
+export const RuleSeverityPriority: Record<RuleSeverityValue, string> = {
+  [RuleSeverityValue.Critical]: '1',
+  [RuleSeverityValue.High]: '2',
+  [RuleSeverityValue.Medium]: '3',
+  [RuleSeverityValue.Low]: '4',
+  [RuleSeverityValue.Informational]: '5',
+};
+
 export const ruleSeverity: {
   name: string;
   value: string;
@@ -23,32 +39,32 @@ export const ruleSeverity: {
 }[] = [
   {
     name: 'Critical',
-    value: 'critical',
-    priority: '1',
+    value: RuleSeverityValue.Critical,
+    priority: RuleSeverityPriority[RuleSeverityValue.Critical],
     color: { background: paletteColors[4], text: 'white' },
   },
   {
     name: 'High',
-    value: 'high',
-    priority: '2',
+    value: RuleSeverityValue.High,
+    priority: RuleSeverityPriority[RuleSeverityValue.High],
     color: { background: paletteColors[3], text: 'white' },
   },
   {
     name: 'Medium',
-    value: 'medium',
-    priority: '3',
+    value: RuleSeverityValue.Medium,
+    priority: RuleSeverityPriority[RuleSeverityValue.Medium],
     color: { background: paletteColors[2], text: 'black' },
   },
   {
     name: 'Low',
-    value: 'low',
-    priority: '4',
+    value: RuleSeverityValue.Low,
+    priority: RuleSeverityPriority[RuleSeverityValue.Low],
     color: { background: paletteColors[1], text: 'white' },
   },
   {
     name: 'Informational',
-    value: 'informational',
-    priority: '5',
+    value: RuleSeverityValue.Informational,
+    priority: RuleSeverityPriority[RuleSeverityValue.Informational],
     color: { background: paletteColors[0], text: 'white' },
   },
 ];


### PR DESCRIPTION
### Description
1. Fixes the findings page crash when a custom rule generated a finding and was deleted. 
2. Fixes the correctness of the findings rule severity so that it always shows the highest severity in the table. 
3. FIxes the correctness of the correlations findings table in the flyout to show the rule with the highest severity. However, this currently excludes threat intel rules. 
![Screenshot 2024-09-11 at 10 22 49 AM](https://github.com/user-attachments/assets/880e7611-b1ee-4a35-a849-b3d96d70838b)

### Issues Resolved


[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).