### PR TITLE
[navigation]feat: update category to flatten menus in analytics(all) use case

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -134,7 +134,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: THREAT_ALERTS_NAV_ID,
         title: 'Threat alerts',
-        order: 9070,
+        order: 300,
         category: DEFAULT_APP_CATEGORIES.investigate,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -145,7 +145,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: FINDINGS_NAV_ID,
         title: 'Findings',
-        order: 9080,
+        order: 400,
         category: DEFAULT_APP_CATEGORIES.investigate,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -156,7 +156,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: CORRELATIONS_NAV_ID,
         title: 'Correlations',
-        order: 9080,
+        order: 500,
         category: DEFAULT_APP_CATEGORIES.investigate,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -167,7 +167,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: DETECTORS_NAV_ID,
         title: 'Threat detectors',
-        order: 9080,
+        order: 600,
         category: DEFAULT_APP_CATEGORIES.configure,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -178,7 +178,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: DETECTION_RULE_NAV_ID,
         title: 'Detection rules',
-        order: 9080,
+        order: 700,
         category: DEFAULT_APP_CATEGORIES.configure,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -189,7 +189,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: CORRELATIONS_RULE_NAV_ID,
         title: 'Correlation rules',
-        order: 9080,
+        order: 800,
         category: DEFAULT_APP_CATEGORIES.configure,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -200,7 +200,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: THREAT_INTEL_NAV_ID,
         title: 'Threat intelligence',
-        order: 9080,
+        order: 900,
         category: DEFAULT_APP_CATEGORIES.configure,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -211,7 +211,7 @@ export class SecurityAnalyticsPlugin
       core.application.register({
         id: LOG_TYPES_NAV_ID,
         title: 'Log types',
-        order: 9080,
+        order: 1000,
         category: DEFAULT_APP_CATEGORIES.configure,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -230,13 +230,13 @@ export class SecurityAnalyticsPlugin
         { id: GETTING_STARTED_NAV_ID, showInAllNavGroup: true },
         { id: THREAT_ALERTS_NAV_ID, showInAllNavGroup: true },
         { id: FINDINGS_NAV_ID, showInAllNavGroup: true },
-        { id: CORRELATIONS_NAV_ID },
-        { id: PLUGIN_NAME, category: DEFAULT_APP_CATEGORIES.configure, title: 'Threat detection' },
-        { id: DETECTORS_NAV_ID, parentNavLinkId: PLUGIN_NAME },
-        { id: DETECTION_RULE_NAV_ID, parentNavLinkId: PLUGIN_NAME },
-        { id: CORRELATIONS_RULE_NAV_ID },
-        { id: THREAT_INTEL_NAV_ID },
-        { id: LOG_TYPES_NAV_ID },
+        { id: CORRELATIONS_NAV_ID, showInAllNavGroup: true },
+        { id: PLUGIN_NAME, category: DEFAULT_APP_CATEGORIES.configure, title: 'Threat detection', showInAllNavGroup: true, order: 600 },
+        { id: DETECTORS_NAV_ID, parentNavLinkId: PLUGIN_NAME, showInAllNavGroup: true },
+        { id: DETECTION_RULE_NAV_ID, parentNavLinkId: PLUGIN_NAME, showInAllNavGroup: true },
+        { id: CORRELATIONS_RULE_NAV_ID, showInAllNavGroup: true },
+        { id: THREAT_INTEL_NAV_ID, showInAllNavGroup: true },
+        { id: LOG_TYPES_NAV_ID, showInAllNavGroup: true },
       ];
 
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], navlinks);


### PR DESCRIPTION
### Description

Based on https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8332, security analytics needs to make some adjustment to flatten the menus in analytics(all) use case.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).