### PR TITLE
Fit and Finish UX Fixes

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -53,7 +53,7 @@ const ContentPanel = ({
       <EuiFlexItem>
         {typeof title === 'string' ? (
           <EuiText size={titleSize}>
-            <h2>{title}</h2>
+            <h3>{title}</h3>
           </EuiText>
         ) : (
           title

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -48,10 +48,7 @@ const ContentPanel = ({
   hideHeaderBorder = false,
   className = '',
 }: ContentPanelProps): JSX.Element => (
-  <EuiPanel
-    style={{ paddingLeft: '0px', paddingRight: '0px', ...panelStyles }}
-    className={className}
-  >
+  <EuiPanel style={{ padding: '16px', ...panelStyles }} className={className}>
     <EuiFlexGroup style={{ padding: '0px 10px' }} justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem>
         {typeof title === 'string' ? (

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ContentPanel /> spec renders the component 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left: 0px; padding-right: 0px;"
+  style="padding: 16px;"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -15,9 +15,9 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
       <div
         class="euiText euiText--small"
       >
-        <h2>
+        <h3>
           Testing
-        </h2>
+        </h3>
       </div>
     </div>
     <div

--- a/public/pages/Alerts/components/ThreatIntelAlertsTable/ThreatIntelAlertsTable.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertsTable/ThreatIntelAlertsTable.tsx
@@ -126,6 +126,12 @@ export const ThreatIntelAlertsTable: React.FC<ThreatIntelAlertsTableProps> = ({
     },
   ];
 
+  const search = {
+    box: {
+      compressed: true,
+    },
+  };
+
   return (
     <>
       <EuiInMemoryTable
@@ -133,7 +139,7 @@ export const ThreatIntelAlertsTable: React.FC<ThreatIntelAlertsTableProps> = ({
         items={alerts}
         itemId={(item) => `${item.id}`}
         pagination
-        search
+        search={search}
         selection={itemSelection}
         isSelectable={true}
       />

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -1127,7 +1127,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
             onAcknowledge={this.onAcknowledgeCorrelationAlert}
           />
         )}
-        <EuiFlexGroup direction="column">
+        <EuiFlexGroup direction="column" gutterSize={'m'}>
           <PageHeader
             appRightControls={[
               {
@@ -1144,7 +1144,6 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>{datePicker}</EuiFlexItem>
               </EuiFlexGroup>
-              <EuiSpacer size={'m'} />
             </EuiFlexItem>
           </PageHeader>
 

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -1018,18 +1018,52 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
         content: (
           <>
             <EuiSpacer size="m" />
-            <EuiInMemoryTable
-              columns={this.getColumns()}
-              items={alertsFiltered ? filteredDetectionRuleAlerts : detectionRuleAlerts}
-              itemId={(item) => `${item.id}`}
-              isSelectable={true}
-              pagination
-              search={search}
-              sorting={sorting}
-              selection={selection}
-              loading={loading}
-              message={widgetEmptyMessage}
-            />
+            <EuiPanel>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
+                  {this.createGroupByControl()}
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  {!alerts || alerts.length === 0 ? (
+                    <EuiEmptyPrompt
+                      title={
+                        <EuiText size="s">
+                          <h2>No alerts</h2>
+                        </EuiText>
+                      }
+                      body={
+                        <p>
+                          <EuiText size="s">
+                            Adjust the time range to see more results or create alert triggers in
+                            your{' '}
+                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
+                            generate alerts.
+                          </EuiText>
+                        </p>
+                      }
+                    />
+                  ) : (
+                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size="m" />
+
+            <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
+              <EuiInMemoryTable
+                columns={this.getColumns()}
+                items={alertsFiltered ? filteredDetectionRuleAlerts : detectionRuleAlerts}
+                itemId={(item) => `${item.id}`}
+                isSelectable={true}
+                pagination
+                search={search}
+                sorting={sorting}
+                selection={selection}
+                loading={loading}
+                message={widgetEmptyMessage}
+              />
+            </ContentPanel>
           </>
         ),
       },
@@ -1039,11 +1073,44 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
         content: (
           <>
             <EuiSpacer size="m" />
-            <ThreatIntelAlertsTable
-              alerts={alertsFiltered ? filteredThreatIntelAlerts : threatIntelAlerts}
-              onAlertStateChange={this.onThreatIntelAlertStateChange}
-              onSelectionChange={this.onThreatIntelAlertSelectionChange}
-            />
+            <EuiPanel>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
+                  {this.createGroupByControl()}
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  {!alerts || alerts.length === 0 ? (
+                    <EuiEmptyPrompt
+                      title={
+                        <EuiText size="s">
+                          <h2>No alerts</h2>
+                        </EuiText>
+                      }
+                      body={
+                        <p>
+                          <EuiText size="s">
+                            Adjust the time range to see more results or create alert triggers in
+                            your{' '}
+                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
+                            generate alerts.
+                          </EuiText>
+                        </p>
+                      }
+                    />
+                  ) : (
+                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size="m" />
+            <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
+              <ThreatIntelAlertsTable
+                alerts={alertsFiltered ? filteredThreatIntelAlerts : threatIntelAlerts}
+                onAlertStateChange={this.onThreatIntelAlertStateChange}
+                onSelectionChange={this.onThreatIntelAlertSelectionChange}
+              />
+            </ContentPanel>
           </>
         ),
       },
@@ -1060,18 +1127,51 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
         content: (
           <>
             <EuiSpacer size="m" />
-            <EuiInMemoryTable
-              columns={this.getCorrelationColumns()}
-              items={alertsFiltered ? filteredCorrelationAlerts : correlationAlerts}
-              itemId={(item) => `${item.id}`}
-              isSelectable={true}
-              pagination
-              search={correlationSearch}
-              sorting={sorting}
-              selection={correlationSelection}
-              loading={loading}
-              message={widgetEmptyCorrelationMessage}
-            />
+            <EuiPanel>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
+                  {this.createGroupByControl()}
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  {!alerts || alerts.length === 0 ? (
+                    <EuiEmptyPrompt
+                      title={
+                        <EuiText size="s">
+                          <h2>No alerts</h2>
+                        </EuiText>
+                      }
+                      body={
+                        <p>
+                          <EuiText size="s">
+                            Adjust the time range to see more results or create alert triggers in
+                            your{' '}
+                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
+                            generate alerts.
+                          </EuiText>
+                        </p>
+                      }
+                    />
+                  ) : (
+                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size="m" />
+            <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
+              <EuiInMemoryTable
+                columns={this.getCorrelationColumns()}
+                items={alertsFiltered ? filteredCorrelationAlerts : correlationAlerts}
+                itemId={(item) => `${item.id}`}
+                isSelectable={true}
+                pagination
+                search={correlationSearch}
+                sorting={sorting}
+                selection={correlationSelection}
+                loading={loading}
+                message={widgetEmptyCorrelationMessage}
+              />
+            </ContentPanel>
           </>
         ),
       },
@@ -1131,42 +1231,12 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           </PageHeader>
 
           <EuiFlexItem>
-            <EuiPanel>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                  {this.createGroupByControl()}
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  {!alerts || alerts.length === 0 ? (
-                    <EuiEmptyPrompt
-                      title={<EuiText size="s"><h2>No alerts</h2></EuiText>}
-                      body={
-                        <p>
-                          <EuiText size="s">
-                            Adjust the time range to see more results or create alert triggers in your{' '}
-                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
-                            generate alerts.
-                          </EuiText>
-                        </p>
-                      }
-                    />
-                  ) : (
-                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPanel>
-            <EuiSpacer size="xxl" />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
-              <EuiTabbedContent
-                tabs={tabs}
-                size="s"
-                onTabClick={({ id }) => this.setState({ selectedTabId: id as AlertTabId })}
-                initialSelectedTab={tabs.find(({ id }) => id === selectedTabId) ?? tabs[0]}
-              />
-            </ContentPanel>
+            <EuiTabbedContent
+              tabs={tabs}
+              size="s"
+              onTabClick={({ id }) => this.setState({ selectedTabId: id as AlertTabId })}
+              initialSelectedTab={tabs.find(({ id }) => id === selectedTabId) ?? tabs[0]}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       </>

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -938,12 +938,14 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
       box: {
         placeholder: 'Search alerts',
         schema: true,
+        compressed: true,
       },
       filters: [
         {
           type: 'field_value_selection',
           field: 'severity',
           name: 'Alert severity',
+          compressed: true,
           options: Array.from(severities).map((severity) => ({
             value: severity,
             name: parseAlertSeverityToOption(severity)?.label || severity,
@@ -954,6 +956,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           type: 'field_value_selection',
           field: 'state',
           name: 'Status',
+          compressed: true,
           options: Array.from(statuses).map((status) => ({
             value: status,
             name: capitalizeFirstLetter(status) || status,
@@ -967,12 +970,14 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
       box: {
         placeholder: 'Search alerts',
         schema: true,
+        compressed: true,
       },
       filters: [
         {
           type: 'field_value_selection',
           field: 'severity',
           name: 'Alert severity',
+          compressed: true,
           options: Array.from(corrSeverities).map((severity) => ({
             value: severity,
             name: parseAlertSeverityToOption(severity)?.label || severity,
@@ -983,6 +988,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           type: 'field_value_selection',
           field: 'state',
           name: 'Status',
+          compressed: true,
           options: Array.from(corrStatuses).map((status) => ({
             value: status,
             name: capitalizeFirstLetter(status) || status,

--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -1018,38 +1018,8 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
         content: (
           <>
             <EuiSpacer size="m" />
-            <EuiPanel>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                  {this.createGroupByControl()}
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  {!alerts || alerts.length === 0 ? (
-                    <EuiEmptyPrompt
-                      title={
-                        <EuiText size="s">
-                          <h2>No alerts</h2>
-                        </EuiText>
-                      }
-                      body={
-                        <p>
-                          <EuiText size="s">
-                            Adjust the time range to see more results or create alert triggers in
-                            your{' '}
-                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
-                            generate alerts.
-                          </EuiText>
-                        </p>
-                      }
-                    />
-                  ) : (
-                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPanel>
+            {this.getAlertsGraph(alerts, loading)}
             <EuiSpacer size="m" />
-
             <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
               <EuiInMemoryTable
                 columns={this.getColumns()}
@@ -1073,36 +1043,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
         content: (
           <>
             <EuiSpacer size="m" />
-            <EuiPanel>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                  {this.createGroupByControl()}
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  {!alerts || alerts.length === 0 ? (
-                    <EuiEmptyPrompt
-                      title={
-                        <EuiText size="s">
-                          <h2>No alerts</h2>
-                        </EuiText>
-                      }
-                      body={
-                        <p>
-                          <EuiText size="s">
-                            Adjust the time range to see more results or create alert triggers in
-                            your{' '}
-                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
-                            generate alerts.
-                          </EuiText>
-                        </p>
-                      }
-                    />
-                  ) : (
-                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPanel>
+            {this.getAlertsGraph(alerts, loading)}
             <EuiSpacer size="m" />
             <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
               <ThreatIntelAlertsTable
@@ -1127,36 +1068,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
         content: (
           <>
             <EuiSpacer size="m" />
-            <EuiPanel>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                  {this.createGroupByControl()}
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  {!alerts || alerts.length === 0 ? (
-                    <EuiEmptyPrompt
-                      title={
-                        <EuiText size="s">
-                          <h2>No alerts</h2>
-                        </EuiText>
-                      }
-                      body={
-                        <p>
-                          <EuiText size="s">
-                            Adjust the time range to see more results or create alert triggers in
-                            your{' '}
-                            <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
-                            generate alerts.
-                          </EuiText>
-                        </p>
-                      }
-                    />
-                  ) : (
-                    <ChartContainer chartViewId={'alerts-view'} loading={loading} />
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPanel>
+            {this.getAlertsGraph(alerts, loading)}
             <EuiSpacer size="m" />
             <ContentPanel title={'Alerts'} actions={[this.getContelPanelActions()]}>
               <EuiInMemoryTable
@@ -1240,6 +1152,38 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
           </EuiFlexItem>
         </EuiFlexGroup>
       </>
+    );
+  }
+
+  private getAlertsGraph(alerts: any[], loading: boolean) {
+    return (
+      <EuiPanel>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem style={{ alignSelf: 'flex-end' }}>{this.createGroupByControl()}</EuiFlexItem>
+          <EuiFlexItem>
+            {!alerts || alerts.length === 0 ? (
+              <EuiEmptyPrompt
+                title={
+                  <EuiText size="s">
+                    <h2>No alerts</h2>
+                  </EuiText>
+                }
+                body={
+                  <p>
+                    <EuiText size="s">
+                      Adjust the time range to see more results or create alert triggers in your{' '}
+                      <EuiLink href={`${location.pathname}#/detectors`}>detectors</EuiLink> to
+                      generate alerts.
+                    </EuiText>
+                  </p>
+                }
+              />
+            ) : (
+              <ChartContainer chartViewId={'alerts-view'} loading={loading} />
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
     );
   }
 }

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -209,9 +209,10 @@ exports[`<Alerts /> spec renders the component 1`] = `
   >
     <EuiFlexGroup
       direction="column"
+      gutterSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+        className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionColumn euiFlexGroup--responsive"
       >
         <PageHeader
           appRightControls={
@@ -818,13 +819,6 @@ exports[`<Alerts /> spec renders the component 1`] = `
                   </EuiFlexItem>
                 </div>
               </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
             </div>
           </EuiFlexItem>
         </PageHeader>
@@ -832,43 +826,235 @@ exports[`<Alerts /> spec renders the component 1`] = `
           <div
             className="euiFlexItem"
           >
-            <EuiPanel>
-              <div
-                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-              >
-                <EuiFlexGroup
-                  direction="column"
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-                  >
-                    <EuiFlexItem
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                        }
-                      }
-                    >
-                      <div
-                        className="euiFlexItem"
-                        style={
-                          Object {
-                            "alignSelf": "flex-end",
-                          }
-                        }
+            <EuiTabbedContent
+              autoFocus="initial"
+              initialSelectedTab={
+                Object {
+                  "content": <React.Fragment>
+                    <EuiSpacer
+                      size="m"
+                    />
+                    <EuiPanel>
+                      <EuiFlexGroup
+                        direction="column"
                       >
-                        <EuiFlexGroup
-                          alignItems="center"
-                          justifyContent="flexEnd"
+                        <EuiFlexItem
+                          style={
+                            Object {
+                              "alignSelf": "flex-end",
+                            }
+                          }
                         >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          <EuiFlexGroup
+                            alignItems="center"
+                            justifyContent="flexEnd"
                           >
                             <EuiFlexItem
                               grow={false}
                             >
-                              <div
-                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              <EuiCompressedSelect
+                                id="alert-vis-groupBy"
+                                onChange={[Function]}
+                                options={
+                                  Array [
+                                    Object {
+                                      "text": "Alert status",
+                                      "value": "status",
+                                    },
+                                    Object {
+                                      "text": "Alert severity",
+                                      "value": "severity",
+                                    },
+                                  ]
+                                }
+                                prepend="Group by"
+                                value="status"
+                              />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiEmptyPrompt
+                            body={
+                              <p>
+                                <EuiText
+                                  size="s"
+                                >
+                                  Adjust the time range to see more results or create alert triggers in your
+                                   
+                                  <EuiLink
+                                    href="/#/detectors"
+                                  >
+                                    detectors
+                                  </EuiLink>
+                                   to generate alerts.
+                                </EuiText>
+                              </p>
+                            }
+                            title={
+                              <EuiText
+                                size="s"
+                              >
+                                <h2>
+                                  No alerts
+                                </h2>
+                              </EuiText>
+                            }
+                          />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiPanel>
+                    <EuiSpacer
+                      size="m"
+                    />
+                    <ContentPanel
+                      actions={
+                        Array [
+                          <EuiSmallButton
+                            data-test-subj="acknowledge-button"
+                            disabled={true}
+                            onClick={[Function]}
+                          >
+                            Acknowledge
+                          </EuiSmallButton>,
+                        ]
+                      }
+                      title="Alerts"
+                    >
+                      <EuiInMemoryTable
+                        columns={
+                          Array [
+                            Object {
+                              "dataType": "date",
+                              "field": "start_time",
+                              "name": "Start time",
+                              "render": [Function],
+                              "sortable": true,
+                            },
+                            Object {
+                              "dataType": "string",
+                              "field": "trigger_name",
+                              "name": "Alert trigger name",
+                              "render": [Function],
+                              "sortable": false,
+                            },
+                            Object {
+                              "dataType": "string",
+                              "field": "detectorName",
+                              "name": "Detector",
+                              "render": [Function],
+                              "sortable": true,
+                            },
+                            Object {
+                              "dataType": "string",
+                              "field": "state",
+                              "name": "Status",
+                              "render": [Function],
+                              "sortable": true,
+                            },
+                            Object {
+                              "dataType": "string",
+                              "field": "severity",
+                              "name": "Alert severity",
+                              "render": [Function],
+                              "sortable": true,
+                            },
+                            Object {
+                              "actions": Array [
+                                Object {
+                                  "render": [Function],
+                                },
+                                Object {
+                                  "render": [Function],
+                                },
+                              ],
+                              "name": "Actions",
+                              "sortable": false,
+                            },
+                          ]
+                        }
+                        isSelectable={true}
+                        itemId={[Function]}
+                        items={Array []}
+                        loading={true}
+                        pagination={true}
+                        responsive={true}
+                        search={
+                          Object {
+                            "box": Object {
+                              "compressed": true,
+                              "placeholder": "Search alerts",
+                              "schema": true,
+                            },
+                            "filters": Array [
+                              Object {
+                                "compressed": true,
+                                "field": "severity",
+                                "multiSelect": "or",
+                                "name": "Alert severity",
+                                "options": Array [],
+                                "type": "field_value_selection",
+                              },
+                              Object {
+                                "compressed": true,
+                                "field": "state",
+                                "multiSelect": "or",
+                                "name": "Status",
+                                "options": Array [],
+                                "type": "field_value_selection",
+                              },
+                            ],
+                          }
+                        }
+                        selection={
+                          Object {
+                            "onSelectionChange": [Function],
+                            "selectable": [Function],
+                            "selectableMessage": [Function],
+                          }
+                        }
+                        sorting={
+                          Object {
+                            "sort": Object {
+                              "direction": "dsc",
+                              "field": "start_time",
+                            },
+                          }
+                        }
+                        tableLayout="fixed"
+                      />
+                    </ContentPanel>
+                  </React.Fragment>,
+                  "id": "detection-rules",
+                  "name": "Detection rules",
+                }
+              }
+              onTabClick={[Function]}
+              size="s"
+              tabs={
+                Array [
+                  Object {
+                    "content": <React.Fragment>
+                      <EuiSpacer
+                        size="m"
+                      />
+                      <EuiPanel>
+                        <EuiFlexGroup
+                          direction="column"
+                        >
+                          <EuiFlexItem
+                            style={
+                              Object {
+                                "alignSelf": "flex-end",
+                              }
+                            }
+                          >
+                            <EuiFlexGroup
+                              alignItems="center"
+                              justifyContent="flexEnd"
+                            >
+                              <EuiFlexItem
+                                grow={false}
                               >
                                 <EuiCompressedSelect
                                   id="alert-vis-groupBy"
@@ -887,758 +1073,594 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                   }
                                   prepend="Group by"
                                   value="status"
-                                >
-                                  <EuiSelect
-                                    compressed={true}
-                                    id="alert-vis-groupBy"
-                                    onChange={[Function]}
-                                    options={
-                                      Array [
-                                        Object {
-                                          "text": "Alert status",
-                                          "value": "status",
-                                        },
-                                        Object {
-                                          "text": "Alert severity",
-                                          "value": "severity",
-                                        },
-                                      ]
-                                    }
-                                    prepend="Group by"
-                                    value="status"
+                                />
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiEmptyPrompt
+                              body={
+                                <p>
+                                  <EuiText
+                                    size="s"
                                   >
-                                    <EuiFormControlLayout
-                                      compressed={true}
-                                      fullWidth={false}
-                                      icon={
-                                        Object {
-                                          "side": "right",
-                                          "type": "arrowDown",
-                                        }
-                                      }
-                                      inputId="alert-vis-groupBy"
-                                      isLoading={false}
-                                      prepend="Group by"
+                                    Adjust the time range to see more results or create alert triggers in your
+                                     
+                                    <EuiLink
+                                      href="/#/detectors"
                                     >
-                                      <div
-                                        className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group"
-                                      >
-                                        <EuiFormLabel
-                                          className="euiFormControlLayout__prepend"
-                                          htmlFor="alert-vis-groupBy"
-                                        >
-                                          <label
-                                            className="euiFormLabel euiFormControlLayout__prepend"
-                                            htmlFor="alert-vis-groupBy"
-                                          >
-                                            Group by
-                                          </label>
-                                        </EuiFormLabel>
-                                        <div
-                                          className="euiFormControlLayout__childrenWrapper"
-                                        >
-                                          <EuiValidatableControl>
-                                            <select
-                                              className="euiSelect euiSelect--compressed euiSelect--inGroup"
-                                              id="alert-vis-groupBy"
-                                              onChange={[Function]}
-                                              onMouseUp={[Function]}
-                                              value="status"
-                                            >
-                                              <option
-                                                key="0"
-                                                value="status"
-                                              >
-                                                Alert status
-                                              </option>
-                                              <option
-                                                key="1"
-                                                value="severity"
-                                              >
-                                                Alert severity
-                                              </option>
-                                            </select>
-                                          </EuiValidatableControl>
-                                          <EuiFormControlLayoutIcons
-                                            compressed={true}
-                                            icon={
-                                              Object {
-                                                "side": "right",
-                                                "type": "arrowDown",
-                                              }
-                                            }
-                                            isLoading={false}
-                                          >
-                                            <div
-                                              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                                            >
-                                              <EuiFormControlLayoutCustomIcon
-                                                size="s"
-                                                type="arrowDown"
-                                              >
-                                                <span
-                                                  className="euiFormControlLayoutCustomIcon"
-                                                >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiFormControlLayoutCustomIcon__icon"
-                                                    size="s"
-                                                    type="arrowDown"
-                                                  >
-                                                    EuiIconMock
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiFormControlLayoutCustomIcon>
-                                            </div>
-                                          </EuiFormControlLayoutIcons>
-                                        </div>
-                                      </div>
-                                    </EuiFormControlLayout>
-                                  </EuiSelect>
-                                </EuiCompressedSelect>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </div>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiEmptyPrompt
-                          body={
-                            <p>
-                              <EuiText
-                                size="s"
-                              >
-                                Adjust the time range to see more results or create alert triggers in your
-                                 
-                                <EuiLink
-                                  href="/#/detectors"
-                                >
-                                  detectors
-                                </EuiLink>
-                                 to generate alerts.
-                              </EuiText>
-                            </p>
-                          }
-                          title={
-                            <EuiText
-                              size="s"
-                            >
-                              <h2>
-                                No alerts
-                              </h2>
-                            </EuiText>
-                          }
-                        >
-                          <div
-                            className="euiEmptyPrompt"
-                          >
-                            <EuiTitle
-                              size="m"
-                            >
-                              <EuiText
-                                className="euiTitle euiTitle--medium"
-                                size="s"
-                              >
-                                <div
-                                  className="euiText euiText--small euiTitle euiTitle--medium"
+                                      detectors
+                                    </EuiLink>
+                                     to generate alerts.
+                                  </EuiText>
+                                </p>
+                              }
+                              title={
+                                <EuiText
+                                  size="s"
                                 >
                                   <h2>
                                     No alerts
                                   </h2>
-                                </div>
-                              </EuiText>
-                            </EuiTitle>
-                            <EuiTextColor
-                              color="subdued"
-                            >
-                              <span
-                                className="euiTextColor euiTextColor--subdued"
-                              >
-                                <EuiSpacer
-                                  size="m"
-                                >
-                                  <div
-                                    className="euiSpacer euiSpacer--m"
-                                  />
-                                </EuiSpacer>
-                                <EuiText>
-                                  <div
-                                    className="euiText euiText--medium"
-                                  >
-                                    <p>
-                                      <EuiText
-                                        size="s"
-                                      >
-                                        <div
-                                          className="euiText euiText--small"
-                                        >
-                                          Adjust the time range to see more results or create alert triggers in your
-                                           
-                                          <EuiLink
-                                            href="/#/detectors"
-                                          >
-                                            <a
-                                              className="euiLink euiLink--primary"
-                                              href="/#/detectors"
-                                              rel="noreferrer"
-                                            >
-                                              detectors
-                                            </a>
-                                          </EuiLink>
-                                           to generate alerts.
-                                        </div>
-                                      </EuiText>
-                                    </p>
-                                  </div>
                                 </EuiText>
-                              </span>
-                            </EuiTextColor>
-                          </div>
-                        </EuiEmptyPrompt>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </div>
-            </EuiPanel>
-            <EuiSpacer
-              size="xxl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xxl"
-              />
-            </EuiSpacer>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <div
-            className="euiFlexItem"
-          >
-            <ContentPanel
-              actions={
-                Array [
-                  <EuiSmallButton
-                    data-test-subj="acknowledge-button"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    Acknowledge
-                  </EuiSmallButton>,
-                ]
-              }
-              title="Alerts"
-            >
-              <EuiPanel
-                className=""
-                style={
-                  Object {
-                    "paddingLeft": "0px",
-                    "paddingRight": "0px",
-                  }
-                }
-              >
-                <div
-                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                  style={
-                    Object {
-                      "paddingLeft": "0px",
-                      "paddingRight": "0px",
-                    }
-                  }
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    style={
-                      Object {
-                        "padding": "0px 10px",
-                      }
-                    }
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-                      style={
-                        Object {
-                          "padding": "0px 10px",
-                        }
-                      }
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
+                              }
+                            />
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="m"
+                      />
+                      <ContentPanel
+                        actions={
+                          Array [
+                            <EuiSmallButton
+                              data-test-subj="acknowledge-button"
+                              disabled={true}
+                              onClick={[Function]}
                             >
-                              <h2>
-                                Alerts
-                              </h2>
-                            </div>
-                          </EuiText>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
+                              Acknowledge
+                            </EuiSmallButton>,
+                          ]
+                        }
+                        title="Alerts"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiInMemoryTable
+                          columns={
+                            Array [
+                              Object {
+                                "dataType": "date",
+                                "field": "start_time",
+                                "name": "Start time",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "trigger_name",
+                                "name": "Alert trigger name",
+                                "render": [Function],
+                                "sortable": false,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "detectorName",
+                                "name": "Detector",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "state",
+                                "name": "Status",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "severity",
+                                "name": "Alert severity",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "actions": Array [
+                                  Object {
+                                    "render": [Function],
+                                  },
+                                  Object {
+                                    "render": [Function],
+                                  },
+                                ],
+                                "name": "Actions",
+                                "sortable": false,
+                              },
+                            ]
+                          }
+                          isSelectable={true}
+                          itemId={[Function]}
+                          items={Array []}
+                          loading={true}
+                          pagination={true}
+                          responsive={true}
+                          search={
+                            Object {
+                              "box": Object {
+                                "compressed": true,
+                                "placeholder": "Search alerts",
+                                "schema": true,
+                              },
+                              "filters": Array [
+                                Object {
+                                  "compressed": true,
+                                  "field": "severity",
+                                  "multiSelect": "or",
+                                  "name": "Alert severity",
+                                  "options": Array [],
+                                  "type": "field_value_selection",
+                                },
+                                Object {
+                                  "compressed": true,
+                                  "field": "state",
+                                  "multiSelect": "or",
+                                  "name": "Status",
+                                  "options": Array [],
+                                  "type": "field_value_selection",
+                                },
+                              ],
+                            }
+                          }
+                          selection={
+                            Object {
+                              "onSelectionChange": [Function],
+                              "selectable": [Function],
+                              "selectableMessage": [Function],
+                            }
+                          }
+                          sorting={
+                            Object {
+                              "sort": Object {
+                                "direction": "dsc",
+                                "field": "start_time",
+                              },
+                            }
+                          }
+                          tableLayout="fixed"
+                        />
+                      </ContentPanel>
+                    </React.Fragment>,
+                    "id": "detection-rules",
+                    "name": "Detection rules",
+                  },
+                  Object {
+                    "content": <React.Fragment>
+                      <EuiSpacer
+                        size="m"
+                      />
+                      <EuiPanel>
+                        <EuiFlexGroup
+                          direction="column"
                         >
-                          <EuiFlexGroup
-                            alignItems="center"
-                            justifyContent="spaceBetween"
+                          <EuiFlexItem
+                            style={
+                              Object {
+                                "alignSelf": "flex-end",
+                              }
+                            }
                           >
-                            <div
-                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            <EuiFlexGroup
+                              alignItems="center"
+                              justifyContent="flexEnd"
                             >
                               <EuiFlexItem
-                                key="0"
+                                grow={false}
                               >
-                                <div
-                                  className="euiFlexItem"
-                                >
-                                  <EuiSmallButton
-                                    data-test-subj="acknowledge-button"
-                                    disabled={true}
-                                    onClick={[Function]}
-                                  >
-                                    <EuiButton
-                                      data-test-subj="acknowledge-button"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      size="s"
-                                    >
-                                      <EuiButtonDisplay
-                                        baseClassName="euiButton"
-                                        data-test-subj="acknowledge-button"
-                                        disabled={true}
-                                        element="button"
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        size="s"
-                                        type="button"
-                                      >
-                                        <button
-                                          className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
-                                          data-test-subj="acknowledge-button"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          style={
-                                            Object {
-                                              "minWidth": undefined,
-                                            }
-                                          }
-                                          type="button"
-                                        >
-                                          <EuiButtonContent
-                                            className="euiButton__content"
-                                            iconGap="m"
-                                            iconSide="left"
-                                            textProps={
-                                              Object {
-                                                "className": "euiButton__text",
-                                              }
-                                            }
-                                          >
-                                            <span
-                                              className="euiButtonContent euiButton__content"
-                                            >
-                                              <span
-                                                className="euiButton__text"
-                                              >
-                                                Acknowledge
-                                              </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonDisplay>
-                                    </EuiButton>
-                                  </EuiSmallButton>
-                                </div>
+                                <EuiCompressedSelect
+                                  id="alert-vis-groupBy"
+                                  onChange={[Function]}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "text": "Alert status",
+                                        "value": "status",
+                                      },
+                                      Object {
+                                        "text": "Alert severity",
+                                        "value": "severity",
+                                      },
+                                    ]
+                                  }
+                                  prepend="Group by"
+                                  value="status"
+                                />
                               </EuiFlexItem>
-                            </div>
-                          </EuiFlexGroup>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                  <EuiHorizontalRule
-                    margin="xs"
-                  >
-                    <hr
-                      className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-                    />
-                  </EuiHorizontalRule>
-                  <div
-                    style={
-                      Object {
-                        "padding": "0px 10px",
-                      }
-                    }
-                  >
-                    <EuiTabbedContent
-                      autoFocus="initial"
-                      initialSelectedTab={
-                        Object {
-                          "content": <React.Fragment>
-                            <EuiSpacer
-                              size="m"
+                            </EuiFlexGroup>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiEmptyPrompt
+                              body={
+                                <p>
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    Adjust the time range to see more results or create alert triggers in your
+                                     
+                                    <EuiLink
+                                      href="/#/detectors"
+                                    >
+                                      detectors
+                                    </EuiLink>
+                                     to generate alerts.
+                                  </EuiText>
+                                </p>
+                              }
+                              title={
+                                <EuiText
+                                  size="s"
+                                >
+                                  <h2>
+                                    No alerts
+                                  </h2>
+                                </EuiText>
+                              }
                             />
-                            <EuiInMemoryTable
-                              columns={
-                                Array [
-                                  Object {
-                                    "dataType": "date",
-                                    "field": "start_time",
-                                    "name": "Start time",
-                                    "render": [Function],
-                                    "sortable": true,
-                                  },
-                                  Object {
-                                    "dataType": "string",
-                                    "field": "trigger_name",
-                                    "name": "Alert trigger name",
-                                    "render": [Function],
-                                    "sortable": false,
-                                  },
-                                  Object {
-                                    "dataType": "string",
-                                    "field": "detectorName",
-                                    "name": "Detector",
-                                    "render": [Function],
-                                    "sortable": true,
-                                  },
-                                  Object {
-                                    "dataType": "string",
-                                    "field": "state",
-                                    "name": "Status",
-                                    "render": [Function],
-                                    "sortable": true,
-                                  },
-                                  Object {
-                                    "dataType": "string",
-                                    "field": "severity",
-                                    "name": "Alert severity",
-                                    "render": [Function],
-                                    "sortable": true,
-                                  },
-                                  Object {
-                                    "actions": Array [
-                                      Object {
-                                        "render": [Function],
-                                      },
-                                      Object {
-                                        "render": [Function],
-                                      },
-                                    ],
-                                    "name": "Actions",
-                                    "sortable": false,
-                                  },
-                                ]
-                              }
-                              isSelectable={true}
-                              itemId={[Function]}
-                              items={Array []}
-                              loading={true}
-                              pagination={true}
-                              responsive={true}
-                              search={
-                                Object {
-                                  "box": Object {
-                                    "placeholder": "Search alerts",
-                                    "schema": true,
-                                  },
-                                  "filters": Array [
-                                    Object {
-                                      "field": "severity",
-                                      "multiSelect": "or",
-                                      "name": "Alert severity",
-                                      "options": Array [],
-                                      "type": "field_value_selection",
-                                    },
-                                    Object {
-                                      "field": "state",
-                                      "multiSelect": "or",
-                                      "name": "Status",
-                                      "options": Array [],
-                                      "type": "field_value_selection",
-                                    },
-                                  ],
-                                }
-                              }
-                              selection={
-                                Object {
-                                  "onSelectionChange": [Function],
-                                  "selectable": [Function],
-                                  "selectableMessage": [Function],
-                                }
-                              }
-                              sorting={
-                                Object {
-                                  "sort": Object {
-                                    "direction": "dsc",
-                                    "field": "start_time",
-                                  },
-                                }
-                              }
-                              tableLayout="fixed"
-                            />
-                          </React.Fragment>,
-                          "id": "detection-rules",
-                          "name": "Detection rules",
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="m"
+                      />
+                      <ContentPanel
+                        actions={
+                          Array [
+                            <EuiSmallButton
+                              data-test-subj="acknowledge-button"
+                              disabled={true}
+                              onClick={[Function]}
+                            >
+                              Acknowledge
+                            </EuiSmallButton>,
+                          ]
                         }
-                      }
-                      onTabClick={[Function]}
-                      size="s"
-                      tabs={
-                        Array [
+                        title="Alerts"
+                      >
+                        <ThreatIntelAlertsTable
+                          alerts={Array []}
+                          onAlertStateChange={[Function]}
+                          onSelectionChange={[Function]}
+                        />
+                      </ContentPanel>
+                    </React.Fragment>,
+                    "id": "threat-intel",
+                    "name": "Threat intel",
+                  },
+                  Object {
+                    "content": <React.Fragment>
+                      <EuiSpacer
+                        size="m"
+                      />
+                      <EuiPanel>
+                        <EuiFlexGroup
+                          direction="column"
+                        >
+                          <EuiFlexItem
+                            style={
+                              Object {
+                                "alignSelf": "flex-end",
+                              }
+                            }
+                          >
+                            <EuiFlexGroup
+                              alignItems="center"
+                              justifyContent="flexEnd"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <EuiCompressedSelect
+                                  id="alert-vis-groupBy"
+                                  onChange={[Function]}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "text": "Alert status",
+                                        "value": "status",
+                                      },
+                                      Object {
+                                        "text": "Alert severity",
+                                        "value": "severity",
+                                      },
+                                    ]
+                                  }
+                                  prepend="Group by"
+                                  value="status"
+                                />
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiEmptyPrompt
+                              body={
+                                <p>
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    Adjust the time range to see more results or create alert triggers in your
+                                     
+                                    <EuiLink
+                                      href="/#/detectors"
+                                    >
+                                      detectors
+                                    </EuiLink>
+                                     to generate alerts.
+                                  </EuiText>
+                                </p>
+                              }
+                              title={
+                                <EuiText
+                                  size="s"
+                                >
+                                  <h2>
+                                    No alerts
+                                  </h2>
+                                </EuiText>
+                              }
+                            />
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="m"
+                      />
+                      <ContentPanel
+                        actions={
+                          Array [
+                            <EuiSmallButton
+                              data-test-subj="acknowledge-button"
+                              disabled={true}
+                              onClick={[Function]}
+                            >
+                              Acknowledge
+                            </EuiSmallButton>,
+                          ]
+                        }
+                        title="Alerts"
+                      >
+                        <EuiInMemoryTable
+                          columns={
+                            Array [
+                              Object {
+                                "dataType": "date",
+                                "field": "start_time",
+                                "name": "Start time",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "trigger_name",
+                                "name": "Alert trigger name",
+                                "render": [Function],
+                                "sortable": false,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "correlation_rule_name",
+                                "name": "Correlation Rule Name",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "correlation_rule_categories",
+                                "name": "Log Types",
+                                "render": [Function],
+                                "sortable": false,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "state",
+                                "name": "Status",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "dataType": "string",
+                                "field": "severity",
+                                "name": "Alert severity",
+                                "render": [Function],
+                                "sortable": true,
+                              },
+                              Object {
+                                "actions": Array [
+                                  Object {
+                                    "render": [Function],
+                                  },
+                                  Object {
+                                    "render": [Function],
+                                  },
+                                ],
+                                "name": "Actions",
+                                "sortable": false,
+                              },
+                            ]
+                          }
+                          isSelectable={true}
+                          itemId={[Function]}
+                          items={Array []}
+                          loading={true}
+                          pagination={true}
+                          responsive={true}
+                          search={
+                            Object {
+                              "box": Object {
+                                "compressed": true,
+                                "placeholder": "Search alerts",
+                                "schema": true,
+                              },
+                              "filters": Array [
+                                Object {
+                                  "compressed": true,
+                                  "field": "severity",
+                                  "multiSelect": "or",
+                                  "name": "Alert severity",
+                                  "options": Array [],
+                                  "type": "field_value_selection",
+                                },
+                                Object {
+                                  "compressed": true,
+                                  "field": "state",
+                                  "multiSelect": "or",
+                                  "name": "Status",
+                                  "options": Array [],
+                                  "type": "field_value_selection",
+                                },
+                              ],
+                            }
+                          }
+                          selection={
+                            Object {
+                              "onSelectionChange": [Function],
+                              "selectable": [Function],
+                              "selectableMessage": [Function],
+                            }
+                          }
+                          sorting={
+                            Object {
+                              "sort": Object {
+                                "direction": "dsc",
+                                "field": "start_time",
+                              },
+                            }
+                          }
+                          tableLayout="fixed"
+                        />
+                      </ContentPanel>
+                    </React.Fragment>,
+                    "id": "correlations",
+                    "name": <EuiToolTip
+                      content="This object was created using an experimental feature. It may not appear in view if the feature is discontinued."
+                      delay="regular"
+                      position="top"
+                    >
+                      <div
+                        style={
                           Object {
-                            "content": <React.Fragment>
-                              <EuiSpacer
-                                size="m"
-                              />
-                              <EuiInMemoryTable
-                                columns={
-                                  Array [
-                                    Object {
-                                      "dataType": "date",
-                                      "field": "start_time",
-                                      "name": "Start time",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "trigger_name",
-                                      "name": "Alert trigger name",
-                                      "render": [Function],
-                                      "sortable": false,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "detectorName",
-                                      "name": "Detector",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "state",
-                                      "name": "Status",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "severity",
-                                      "name": "Alert severity",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "actions": Array [
-                                        Object {
-                                          "render": [Function],
-                                        },
-                                        Object {
-                                          "render": [Function],
-                                        },
-                                      ],
-                                      "name": "Actions",
-                                      "sortable": false,
-                                    },
-                                  ]
-                                }
-                                isSelectable={true}
-                                itemId={[Function]}
-                                items={Array []}
-                                loading={true}
-                                pagination={true}
-                                responsive={true}
-                                search={
-                                  Object {
-                                    "box": Object {
-                                      "placeholder": "Search alerts",
-                                      "schema": true,
-                                    },
-                                    "filters": Array [
-                                      Object {
-                                        "field": "severity",
-                                        "multiSelect": "or",
-                                        "name": "Alert severity",
-                                        "options": Array [],
-                                        "type": "field_value_selection",
-                                      },
-                                      Object {
-                                        "field": "state",
-                                        "multiSelect": "or",
-                                        "name": "Status",
-                                        "options": Array [],
-                                        "type": "field_value_selection",
-                                      },
-                                    ],
-                                  }
-                                }
-                                selection={
-                                  Object {
-                                    "onSelectionChange": [Function],
-                                    "selectable": [Function],
-                                    "selectableMessage": [Function],
-                                  }
-                                }
-                                sorting={
-                                  Object {
-                                    "sort": Object {
-                                      "direction": "dsc",
-                                      "field": "start_time",
-                                    },
-                                  }
-                                }
-                                tableLayout="fixed"
-                              />
-                            </React.Fragment>,
-                            "id": "detection-rules",
-                            "name": "Detection rules",
-                          },
-                          Object {
-                            "content": <React.Fragment>
-                              <EuiSpacer
-                                size="m"
-                              />
-                              <ThreatIntelAlertsTable
-                                alerts={Array []}
-                                onAlertStateChange={[Function]}
-                                onSelectionChange={[Function]}
-                              />
-                            </React.Fragment>,
-                            "id": "threat-intel",
-                            "name": "Threat intel",
-                          },
-                          Object {
-                            "content": <React.Fragment>
-                              <EuiSpacer
-                                size="m"
-                              />
-                              <EuiInMemoryTable
-                                columns={
-                                  Array [
-                                    Object {
-                                      "dataType": "date",
-                                      "field": "start_time",
-                                      "name": "Start time",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "trigger_name",
-                                      "name": "Alert trigger name",
-                                      "render": [Function],
-                                      "sortable": false,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "correlation_rule_name",
-                                      "name": "Correlation Rule Name",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "correlation_rule_categories",
-                                      "name": "Log Types",
-                                      "render": [Function],
-                                      "sortable": false,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "state",
-                                      "name": "Status",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "dataType": "string",
-                                      "field": "severity",
-                                      "name": "Alert severity",
-                                      "render": [Function],
-                                      "sortable": true,
-                                    },
-                                    Object {
-                                      "actions": Array [
-                                        Object {
-                                          "render": [Function],
-                                        },
-                                        Object {
-                                          "render": [Function],
-                                        },
-                                      ],
-                                      "name": "Actions",
-                                      "sortable": false,
-                                    },
-                                  ]
-                                }
-                                isSelectable={true}
-                                itemId={[Function]}
-                                items={Array []}
-                                loading={true}
-                                pagination={true}
-                                responsive={true}
-                                search={
-                                  Object {
-                                    "box": Object {
-                                      "placeholder": "Search alerts",
-                                      "schema": true,
-                                    },
-                                    "filters": Array [
-                                      Object {
-                                        "field": "severity",
-                                        "multiSelect": "or",
-                                        "name": "Alert severity",
-                                        "options": Array [],
-                                        "type": "field_value_selection",
-                                      },
-                                      Object {
-                                        "field": "state",
-                                        "multiSelect": "or",
-                                        "name": "Status",
-                                        "options": Array [],
-                                        "type": "field_value_selection",
-                                      },
-                                    ],
-                                  }
-                                }
-                                selection={
-                                  Object {
-                                    "onSelectionChange": [Function],
-                                    "selectable": [Function],
-                                    "selectableMessage": [Function],
-                                  }
-                                }
-                                sorting={
-                                  Object {
-                                    "sort": Object {
-                                      "direction": "dsc",
-                                      "field": "start_time",
-                                    },
-                                  }
-                                }
-                                tableLayout="fixed"
-                              />
-                            </React.Fragment>,
-                            "id": "correlations",
-                            "name": <EuiToolTip
-                              content="This object was created using an experimental feature. It may not appear in view if the feature is discontinued."
-                              delay="regular"
-                              position="top"
+                            "alignItems": "center",
+                            "display": "flex",
+                          }
+                        }
+                      >
+                        <span
+                          style={
+                            Object {
+                              "marginRight": "4px",
+                            }
+                          }
+                        >
+                          Correlations
+                        </span>
+                        <EuiIcon
+                          type="beaker"
+                        />
+                      </div>
+                    </EuiToolTip>,
+                  },
+                ]
+              }
+            >
+              <div>
+                <EuiTabs
+                  onFocus={[Function]}
+                  size="s"
+                >
+                  <div
+                    className="euiTabs euiTabs--small"
+                    onFocus={[Function]}
+                    role="tablist"
+                  >
+                    <EuiTab
+                      aria-controls="some_html_id"
+                      id="detection-rules"
+                      isSelected={true}
+                      key="detection-rules"
+                      onClick={[Function]}
+                    >
+                      <button
+                        aria-controls="some_html_id"
+                        aria-selected={true}
+                        className="euiTab euiTab-isSelected"
+                        disabled={false}
+                        id="detection-rules"
+                        onClick={[Function]}
+                        role="tab"
+                        type="button"
+                      >
+                        <span
+                          className="euiTab__content"
+                        >
+                          Detection rules
+                        </span>
+                      </button>
+                    </EuiTab>
+                    <EuiTab
+                      aria-controls="some_html_id"
+                      id="threat-intel"
+                      isSelected={false}
+                      key="threat-intel"
+                      onClick={[Function]}
+                    >
+                      <button
+                        aria-controls="some_html_id"
+                        aria-selected={false}
+                        className="euiTab"
+                        disabled={false}
+                        id="threat-intel"
+                        onClick={[Function]}
+                        role="tab"
+                        type="button"
+                      >
+                        <span
+                          className="euiTab__content"
+                        >
+                          Threat intel
+                        </span>
+                      </button>
+                    </EuiTab>
+                    <EuiTab
+                      aria-controls="some_html_id"
+                      id="correlations"
+                      isSelected={false}
+                      key="correlations"
+                      onClick={[Function]}
+                    >
+                      <button
+                        aria-controls="some_html_id"
+                        aria-selected={false}
+                        className="euiTab"
+                        disabled={false}
+                        id="correlations"
+                        onClick={[Function]}
+                        role="tab"
+                        type="button"
+                      >
+                        <span
+                          className="euiTab__content"
+                        >
+                          <EuiToolTip
+                            content="This object was created using an experimental feature. It may not appear in view if the feature is discontinued."
+                            delay="regular"
+                            position="top"
+                          >
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                             >
                               <div
+                                onBlur={[Function]}
+                                onFocus={[Function]}
                                 style={
                                   Object {
                                     "alignItems": "center",
@@ -1657,146 +1679,471 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                 </span>
                                 <EuiIcon
                                   type="beaker"
-                                />
+                                >
+                                  EuiIconMock
+                                </EuiIcon>
                               </div>
-                            </EuiToolTip>,
-                          },
-                        ]
-                      }
+                            </span>
+                          </EuiToolTip>
+                        </span>
+                      </button>
+                    </EuiTab>
+                  </div>
+                </EuiTabs>
+                <div
+                  aria-labelledby="detection-rules"
+                  id="some_html_id"
+                  role="tabpanel"
+                >
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiPanel>
+                    <div
+                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                     >
-                      <div>
-                        <EuiTabs
-                          onFocus={[Function]}
-                          size="s"
-                        >
-                          <div
-                            className="euiTabs euiTabs--small"
-                            onFocus={[Function]}
-                            role="tablist"
-                          >
-                            <EuiTab
-                              aria-controls="some_html_id"
-                              id="detection-rules"
-                              isSelected={true}
-                              key="detection-rules"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-controls="some_html_id"
-                                aria-selected={true}
-                                className="euiTab euiTab-isSelected"
-                                disabled={false}
-                                id="detection-rules"
-                                onClick={[Function]}
-                                role="tab"
-                                type="button"
-                              >
-                                <span
-                                  className="euiTab__content"
-                                >
-                                  Detection rules
-                                </span>
-                              </button>
-                            </EuiTab>
-                            <EuiTab
-                              aria-controls="some_html_id"
-                              id="threat-intel"
-                              isSelected={false}
-                              key="threat-intel"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-controls="some_html_id"
-                                aria-selected={false}
-                                className="euiTab"
-                                disabled={false}
-                                id="threat-intel"
-                                onClick={[Function]}
-                                role="tab"
-                                type="button"
-                              >
-                                <span
-                                  className="euiTab__content"
-                                >
-                                  Threat intel
-                                </span>
-                              </button>
-                            </EuiTab>
-                            <EuiTab
-                              aria-controls="some_html_id"
-                              id="correlations"
-                              isSelected={false}
-                              key="correlations"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-controls="some_html_id"
-                                aria-selected={false}
-                                className="euiTab"
-                                disabled={false}
-                                id="correlations"
-                                onClick={[Function]}
-                                role="tab"
-                                type="button"
-                              >
-                                <span
-                                  className="euiTab__content"
-                                >
-                                  <EuiToolTip
-                                    content="This object was created using an experimental feature. It may not appear in view if the feature is discontinued."
-                                    delay="regular"
-                                    position="top"
-                                  >
-                                    <span
-                                      className="euiToolTipAnchor"
-                                      onKeyUp={[Function]}
-                                      onMouseOut={[Function]}
-                                      onMouseOver={[Function]}
-                                    >
-                                      <div
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        style={
-                                          Object {
-                                            "alignItems": "center",
-                                            "display": "flex",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          style={
-                                            Object {
-                                              "marginRight": "4px",
-                                            }
-                                          }
-                                        >
-                                          Correlations
-                                        </span>
-                                        <EuiIcon
-                                          type="beaker"
-                                        >
-                                          EuiIconMock
-                                        </EuiIcon>
-                                      </div>
-                                    </span>
-                                  </EuiToolTip>
-                                </span>
-                              </button>
-                            </EuiTab>
-                          </div>
-                        </EuiTabs>
+                      <EuiFlexGroup
+                        direction="column"
+                      >
                         <div
-                          aria-labelledby="detection-rules"
-                          id="some_html_id"
-                          role="tabpanel"
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
                         >
-                          <EuiSpacer
-                            size="m"
+                          <EuiFlexItem
+                            style={
+                              Object {
+                                "alignSelf": "flex-end",
+                              }
+                            }
                           >
                             <div
-                              className="euiSpacer euiSpacer--m"
-                            />
-                          </EuiSpacer>
+                              className="euiFlexItem"
+                              style={
+                                Object {
+                                  "alignSelf": "flex-end",
+                                }
+                              }
+                            >
+                              <EuiFlexGroup
+                                alignItems="center"
+                                justifyContent="flexEnd"
+                              >
+                                <div
+                                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                >
+                                  <EuiFlexItem
+                                    grow={false}
+                                  >
+                                    <div
+                                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                                    >
+                                      <EuiCompressedSelect
+                                        id="alert-vis-groupBy"
+                                        onChange={[Function]}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "text": "Alert status",
+                                              "value": "status",
+                                            },
+                                            Object {
+                                              "text": "Alert severity",
+                                              "value": "severity",
+                                            },
+                                          ]
+                                        }
+                                        prepend="Group by"
+                                        value="status"
+                                      >
+                                        <EuiSelect
+                                          compressed={true}
+                                          id="alert-vis-groupBy"
+                                          onChange={[Function]}
+                                          options={
+                                            Array [
+                                              Object {
+                                                "text": "Alert status",
+                                                "value": "status",
+                                              },
+                                              Object {
+                                                "text": "Alert severity",
+                                                "value": "severity",
+                                              },
+                                            ]
+                                          }
+                                          prepend="Group by"
+                                          value="status"
+                                        >
+                                          <EuiFormControlLayout
+                                            compressed={true}
+                                            fullWidth={false}
+                                            icon={
+                                              Object {
+                                                "side": "right",
+                                                "type": "arrowDown",
+                                              }
+                                            }
+                                            inputId="alert-vis-groupBy"
+                                            isLoading={false}
+                                            prepend="Group by"
+                                          >
+                                            <div
+                                              className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group"
+                                            >
+                                              <EuiFormLabel
+                                                className="euiFormControlLayout__prepend"
+                                                htmlFor="alert-vis-groupBy"
+                                              >
+                                                <label
+                                                  className="euiFormLabel euiFormControlLayout__prepend"
+                                                  htmlFor="alert-vis-groupBy"
+                                                >
+                                                  Group by
+                                                </label>
+                                              </EuiFormLabel>
+                                              <div
+                                                className="euiFormControlLayout__childrenWrapper"
+                                              >
+                                                <EuiValidatableControl>
+                                                  <select
+                                                    className="euiSelect euiSelect--compressed euiSelect--inGroup"
+                                                    id="alert-vis-groupBy"
+                                                    onChange={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    value="status"
+                                                  >
+                                                    <option
+                                                      key="0"
+                                                      value="status"
+                                                    >
+                                                      Alert status
+                                                    </option>
+                                                    <option
+                                                      key="1"
+                                                      value="severity"
+                                                    >
+                                                      Alert severity
+                                                    </option>
+                                                  </select>
+                                                </EuiValidatableControl>
+                                                <EuiFormControlLayoutIcons
+                                                  compressed={true}
+                                                  icon={
+                                                    Object {
+                                                      "side": "right",
+                                                      "type": "arrowDown",
+                                                    }
+                                                  }
+                                                  isLoading={false}
+                                                >
+                                                  <div
+                                                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                                  >
+                                                    <EuiFormControlLayoutCustomIcon
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <span
+                                                        className="euiFormControlLayoutCustomIcon"
+                                                      >
+                                                        <EuiIcon
+                                                          aria-hidden="true"
+                                                          className="euiFormControlLayoutCustomIcon__icon"
+                                                          size="s"
+                                                          type="arrowDown"
+                                                        >
+                                                          EuiIconMock
+                                                        </EuiIcon>
+                                                      </span>
+                                                    </EuiFormControlLayoutCustomIcon>
+                                                  </div>
+                                                </EuiFormControlLayoutIcons>
+                                              </div>
+                                            </div>
+                                          </EuiFormControlLayout>
+                                        </EuiSelect>
+                                      </EuiCompressedSelect>
+                                    </div>
+                                  </EuiFlexItem>
+                                </div>
+                              </EuiFlexGroup>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiEmptyPrompt
+                                body={
+                                  <p>
+                                    <EuiText
+                                      size="s"
+                                    >
+                                      Adjust the time range to see more results or create alert triggers in your
+                                       
+                                      <EuiLink
+                                        href="/#/detectors"
+                                      >
+                                        detectors
+                                      </EuiLink>
+                                       to generate alerts.
+                                    </EuiText>
+                                  </p>
+                                }
+                                title={
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    <h2>
+                                      No alerts
+                                    </h2>
+                                  </EuiText>
+                                }
+                              >
+                                <div
+                                  className="euiEmptyPrompt"
+                                >
+                                  <EuiTitle
+                                    size="m"
+                                  >
+                                    <EuiText
+                                      className="euiTitle euiTitle--medium"
+                                      size="s"
+                                    >
+                                      <div
+                                        className="euiText euiText--small euiTitle euiTitle--medium"
+                                      >
+                                        <h2>
+                                          No alerts
+                                        </h2>
+                                      </div>
+                                    </EuiText>
+                                  </EuiTitle>
+                                  <EuiTextColor
+                                    color="subdued"
+                                  >
+                                    <span
+                                      className="euiTextColor euiTextColor--subdued"
+                                    >
+                                      <EuiSpacer
+                                        size="m"
+                                      >
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          <p>
+                                            <EuiText
+                                              size="s"
+                                            >
+                                              <div
+                                                className="euiText euiText--small"
+                                              >
+                                                Adjust the time range to see more results or create alert triggers in your
+                                                 
+                                                <EuiLink
+                                                  href="/#/detectors"
+                                                >
+                                                  <a
+                                                    className="euiLink euiLink--primary"
+                                                    href="/#/detectors"
+                                                    rel="noreferrer"
+                                                  >
+                                                    detectors
+                                                  </a>
+                                                </EuiLink>
+                                                 to generate alerts.
+                                              </div>
+                                            </EuiText>
+                                          </p>
+                                        </div>
+                                      </EuiText>
+                                    </span>
+                                  </EuiTextColor>
+                                </div>
+                              </EuiEmptyPrompt>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiPanel>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <ContentPanel
+                    actions={
+                      Array [
+                        <EuiSmallButton
+                          data-test-subj="acknowledge-button"
+                          disabled={true}
+                          onClick={[Function]}
+                        >
+                          Acknowledge
+                        </EuiSmallButton>,
+                      ]
+                    }
+                    title="Alerts"
+                  >
+                    <EuiPanel
+                      className=""
+                      style={
+                        Object {
+                          "padding": "16px",
+                        }
+                      }
+                    >
+                      <div
+                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style={
+                          Object {
+                            "padding": "16px",
+                          }
+                        }
+                      >
+                        <EuiFlexGroup
+                          alignItems="center"
+                          justifyContent="spaceBetween"
+                          style={
+                            Object {
+                              "padding": "0px 10px",
+                            }
+                          }
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            style={
+                              Object {
+                                "padding": "0px 10px",
+                              }
+                            }
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    <h3>
+                                      Alerts
+                                    </h3>
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiFlexItem>
+                            <EuiFlexItem
+                              grow={false}
+                            >
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <EuiFlexGroup
+                                  alignItems="center"
+                                  justifyContent="spaceBetween"
+                                >
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  >
+                                    <EuiFlexItem
+                                      key="0"
+                                    >
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiSmallButton
+                                          data-test-subj="acknowledge-button"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                        >
+                                          <EuiButton
+                                            data-test-subj="acknowledge-button"
+                                            disabled={true}
+                                            onClick={[Function]}
+                                            size="s"
+                                          >
+                                            <EuiButtonDisplay
+                                              baseClassName="euiButton"
+                                              data-test-subj="acknowledge-button"
+                                              disabled={true}
+                                              element="button"
+                                              isDisabled={true}
+                                              onClick={[Function]}
+                                              size="s"
+                                              type="button"
+                                            >
+                                              <button
+                                                className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
+                                                data-test-subj="acknowledge-button"
+                                                disabled={true}
+                                                onClick={[Function]}
+                                                style={
+                                                  Object {
+                                                    "minWidth": undefined,
+                                                  }
+                                                }
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButton__content"
+                                                  iconGap="m"
+                                                  iconSide="left"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButton__text",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButton__content"
+                                                  >
+                                                    <span
+                                                      className="euiButton__text"
+                                                    >
+                                                      Acknowledge
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonDisplay>
+                                          </EuiButton>
+                                        </EuiSmallButton>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                        <EuiHorizontalRule
+                          margin="xs"
+                        >
+                          <hr
+                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+                          />
+                        </EuiHorizontalRule>
+                        <div
+                          style={
+                            Object {
+                              "padding": "0px 10px",
+                            }
+                          }
+                        >
                           <EuiInMemoryTable
                             columns={
                               Array [
@@ -1858,11 +2205,13 @@ exports[`<Alerts /> spec renders the component 1`] = `
                             search={
                               Object {
                                 "box": Object {
+                                  "compressed": true,
                                   "placeholder": "Search alerts",
                                   "schema": true,
                                 },
                                 "filters": Array [
                                   Object {
+                                    "compressed": true,
                                     "field": "severity",
                                     "multiSelect": "or",
                                     "name": "Alert severity",
@@ -1870,6 +2219,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                     "type": "field_value_selection",
                                   },
                                   Object {
+                                    "compressed": true,
                                     "field": "state",
                                     "multiSelect": "or",
                                     "name": "Status",
@@ -1900,6 +2250,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                               <EuiSearchBar
                                 box={
                                   Object {
+                                    "compressed": true,
                                     "placeholder": "Search alerts",
                                     "schema": Object {
                                       "fields": Object {
@@ -1926,6 +2277,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                 filters={
                                   Array [
                                     Object {
+                                      "compressed": true,
                                       "field": "severity",
                                       "multiSelect": "or",
                                       "name": "Alert severity",
@@ -1933,6 +2285,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                       "type": "field_value_selection",
                                     },
                                     Object {
+                                      "compressed": true,
                                       "field": "state",
                                       "multiSelect": "or",
                                       "name": "Status",
@@ -1959,6 +2312,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                         className="euiFlexItem euiSearchBar__searchHolder"
                                       >
                                         <EuiSearchBox
+                                          compressed={true}
                                           incremental={false}
                                           isInvalid={false}
                                           onSearch={[Function]}
@@ -1967,7 +2321,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                         >
                                           <EuiFieldSearch
                                             aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                            compressed={false}
+                                            compressed={true}
                                             defaultValue=""
                                             fullWidth={true}
                                             incremental={false}
@@ -1979,13 +2333,13 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                             placeholder="Search alerts"
                                           >
                                             <EuiFormControlLayout
-                                              compressed={false}
+                                              compressed={true}
                                               fullWidth={true}
                                               icon="search"
                                               isLoading={false}
                                             >
                                               <div
-                                                className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                               >
                                                 <div
                                                   className="euiFormControlLayout__childrenWrapper"
@@ -1995,7 +2349,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                   >
                                                     <input
                                                       aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                                      className="euiFieldSearch euiFieldSearch--fullWidth"
+                                                      className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                                                       defaultValue=""
                                                       onKeyUp={[Function]}
                                                       placeholder="Search alerts"
@@ -2003,7 +2357,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                     />
                                                   </EuiValidatableControl>
                                                   <EuiFormControlLayoutIcons
-                                                    compressed={false}
+                                                    compressed={true}
                                                     icon="search"
                                                     isLoading={false}
                                                   >
@@ -2011,7 +2365,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                       className="euiFormControlLayoutIcons"
                                                     >
                                                       <EuiFormControlLayoutCustomIcon
-                                                        size="m"
+                                                        size="s"
                                                         type="search"
                                                       >
                                                         <span
@@ -2020,7 +2374,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                           <EuiIcon
                                                             aria-hidden="true"
                                                             className="euiFormControlLayoutCustomIcon__icon"
-                                                            size="m"
+                                                            size="s"
                                                             type="search"
                                                           >
                                                             EuiIconMock
@@ -2047,6 +2401,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                           filters={
                                             Array [
                                               Object {
+                                                "compressed": true,
                                                 "field": "severity",
                                                 "multiSelect": "or",
                                                 "name": "Alert severity",
@@ -2054,6 +2409,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                 "type": "field_value_selection",
                                               },
                                               Object {
+                                                "compressed": true,
                                                 "field": "state",
                                                 "multiSelect": "or",
                                                 "name": "Status",
@@ -2090,7 +2446,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                               <FieldValueSelectionFilter
                                                 config={
                                                   Object {
-                                                    "compressed": undefined,
+                                                    "compressed": true,
                                                     "field": "severity",
                                                     "multiSelect": "or",
                                                     "name": "Alert severity",
@@ -2129,6 +2485,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                       iconSide="right"
                                                       iconType="arrowDown"
                                                       onClick={[Function]}
+                                                      size="s"
                                                     >
                                                       Alert severity
                                                     </EuiFilterButton>
@@ -2155,6 +2512,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                         iconSide="right"
                                                         iconType="arrowDown"
                                                         onClick={[Function]}
+                                                        size="s"
                                                       >
                                                         <EuiButtonEmpty
                                                           className="euiFilterButton euiFilterButton--hasIcon"
@@ -2162,6 +2520,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                           iconSide="right"
                                                           iconType="arrowDown"
                                                           onClick={[Function]}
+                                                          size="s"
                                                           textProps={
                                                             Object {
                                                               "className": "",
@@ -2170,7 +2529,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                           type="button"
                                                         >
                                                           <button
-                                                            className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                            className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                             disabled={false}
                                                             onClick={[Function]}
                                                             type="button"
@@ -2221,7 +2580,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                               <FieldValueSelectionFilter
                                                 config={
                                                   Object {
-                                                    "compressed": undefined,
+                                                    "compressed": true,
                                                     "field": "state",
                                                     "multiSelect": "or",
                                                     "name": "Status",
@@ -2260,6 +2619,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                       iconSide="right"
                                                       iconType="arrowDown"
                                                       onClick={[Function]}
+                                                      size="s"
                                                     >
                                                       Status
                                                     </EuiFilterButton>
@@ -2286,6 +2646,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                         iconSide="right"
                                                         iconType="arrowDown"
                                                         onClick={[Function]}
+                                                        size="s"
                                                       >
                                                         <EuiButtonEmpty
                                                           className="euiFilterButton euiFilterButton--hasIcon"
@@ -2293,6 +2654,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                           iconSide="right"
                                                           iconType="arrowDown"
                                                           onClick={[Function]}
+                                                          size="s"
                                                           textProps={
                                                             Object {
                                                               "className": "",
@@ -2301,7 +2663,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                                                           type="button"
                                                         >
                                                           <button
-                                                            className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                            className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                             disabled={false}
                                                             onClick={[Function]}
                                                             type="button"
@@ -3102,11 +3464,11 @@ exports[`<Alerts /> spec renders the component 1`] = `
                           </EuiInMemoryTable>
                         </div>
                       </div>
-                    </EuiTabbedContent>
-                  </div>
+                    </EuiPanel>
+                  </ContentPanel>
                 </div>
-              </EuiPanel>
-            </ContentPanel>
+              </div>
+            </EuiTabbedContent>
           </div>
         </EuiFlexItem>
       </div>

--- a/public/pages/Correlations/containers/CorrelationRules.tsx
+++ b/public/pages/Correlations/containers/CorrelationRules.tsx
@@ -109,7 +109,7 @@ export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: Correla
   return (
     <>
       {isDeleteModalVisible && deleteModal ? deleteModal : null}
-      <EuiFlexGroup direction="column">
+      <EuiFlexGroup direction="column" gutterSize={'m'}>
         <PageHeader appRightControls={[{ renderComponent: createRuleAction }]}>
           <EuiFlexItem>
             <EuiFlexGroup gutterSize={'s'} justifyContent={'spaceBetween'}>
@@ -120,7 +120,6 @@ export const CorrelationRules: React.FC<CorrelationRulesProps> = (props: Correla
               </EuiFlexItem>
               <EuiFlexItem grow={false}>{createRuleAction}</EuiFlexItem>
             </EuiFlexGroup>
-            <EuiSpacer size={'m'} />
           </EuiFlexItem>
         </PageHeader>
         <EuiFlexItem>

--- a/public/pages/Correlations/containers/CorrelationsContainer.tsx
+++ b/public/pages/Correlations/containers/CorrelationsContainer.tsx
@@ -454,7 +454,11 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
             <h2>No correlations found</h2>
           </EuiText>
         }
-        body={<EuiText size="s"><p>There are no correlated findings in the system.</p></EuiText>}
+        body={
+          <EuiText size="s">
+            <p>There are no correlated findings in the system.</p>
+          </EuiText>
+        }
         actions={[
           <EuiSmallButton fill={true} color="primary" href={`#${ROUTES.CORRELATION_RULE_CREATE}`}>
             Create correlation rule
@@ -548,7 +552,7 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
             </EuiFlyoutBody>
           </EuiFlyout>
         ) : null}
-        <EuiFlexGroup direction="column">
+        <EuiFlexGroup direction="column" gutterSize={'m'}>
           <PageHeader
             appRightControls={[
               {
@@ -587,7 +591,9 @@ export class Correlations extends React.Component<CorrelationsProps, Correlation
                   </EuiFilterGroup>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiSmallButtonEmpty onClick={this.resetFilters}>Reset filters</EuiSmallButtonEmpty>
+                  <EuiSmallButtonEmpty onClick={this.resetFilters}>
+                    Reset filters
+                  </EuiSmallButtonEmpty>
                 </EuiFlexItem>
               </EuiFlexGroup>
               <EuiSpacer />

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -386,7 +386,7 @@ export default class CreateDetector extends Component<CreateDetectorProps, Creat
                 <EuiText size="s">
                   <h1>Create detector</h1>
                 </EuiText>
-                <EuiSpacer />
+                <EuiSpacer size={'m'} />
               </PageHeader>
               {this.getStepContent()}
             </>

--- a/public/pages/Detectors/components/DetectorBasicDetailsView/__snapshots__/DetectorBasicDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorBasicDetailsView/__snapshots__/DetectorBasicDetailsView.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        style="padding-left: 0px; padding-right: 0px;"
+        style="padding: 16px;"
       >
         <div
           class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -19,9 +19,9 @@ Object {
             <div
               class="euiText euiText--small"
             >
-              <h2>
+              <h3>
                 Detector details
-              </h2>
+              </h3>
             </div>
           </div>
           <div
@@ -392,7 +392,7 @@ Object {
   "container": <div>
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      style="padding-left: 0px; padding-right: 0px;"
+      style="padding: 16px;"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -404,9 +404,9 @@ Object {
           <div
             class="euiText euiText--small"
           >
-            <h2>
+            <h3>
               Detector details
-            </h2>
+            </h3>
           </div>
         </div>
         <div

--- a/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorRulesView/__snapshots__/DetectorRulesView.test.tsx.snap
@@ -215,8 +215,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
       className=""
       style={
         Object {
-          "paddingLeft": "0px",
-          "paddingRight": "0px",
+          "padding": "16px",
         }
       }
     >
@@ -224,8 +223,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
         className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -256,9 +254,9 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                   <div
                     className="euiText euiText--small"
                   >
-                    <h2>
+                    <h3>
                       Active rules (2)
-                    </h2>
+                    </h3>
                   </div>
                 </EuiText>
               </div>
@@ -424,11 +422,13 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
               search={
                 Object {
                   "box": Object {
+                    "compressed": true,
                     "placeholder": "Search rules",
                     "schema": true,
                   },
                   "filters": Array [
                     Object {
+                      "compressed": true,
                       "field": "category",
                       "multiSelect": "or",
                       "name": "Log type",
@@ -436,6 +436,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                       "type": "field_value_selection",
                     },
                     Object {
+                      "compressed": true,
                       "field": "level",
                       "multiSelect": "or",
                       "name": "Rule severity",
@@ -489,6 +490,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                       "type": "field_value_selection",
                     },
                     Object {
+                      "compressed": true,
                       "field": "source",
                       "multiSelect": "or",
                       "name": "Source",
@@ -512,6 +514,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                 <EuiSearchBar
                   box={
                     Object {
+                      "compressed": true,
                       "placeholder": "Search rules",
                       "schema": Object {
                         "fields": Object {
@@ -538,6 +541,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                   filters={
                     Array [
                       Object {
+                        "compressed": true,
                         "field": "category",
                         "multiSelect": "or",
                         "name": "Log type",
@@ -545,6 +549,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                         "type": "field_value_selection",
                       },
                       Object {
+                        "compressed": true,
                         "field": "level",
                         "multiSelect": "or",
                         "name": "Rule severity",
@@ -598,6 +603,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                         "type": "field_value_selection",
                       },
                       Object {
+                        "compressed": true,
                         "field": "source",
                         "multiSelect": "or",
                         "name": "Source",
@@ -631,6 +637,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                           className="euiFlexItem euiSearchBar__searchHolder"
                         >
                           <EuiSearchBox
+                            compressed={true}
                             incremental={false}
                             isInvalid={false}
                             onSearch={[Function]}
@@ -639,7 +646,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                           >
                             <EuiFieldSearch
                               aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                              compressed={false}
+                              compressed={true}
                               defaultValue=""
                               fullWidth={true}
                               incremental={false}
@@ -651,13 +658,13 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                               placeholder="Search rules"
                             >
                               <EuiFormControlLayout
-                                compressed={false}
+                                compressed={true}
                                 fullWidth={true}
                                 icon="search"
                                 isLoading={false}
                               >
                                 <div
-                                  className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                  className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                 >
                                   <div
                                     className="euiFormControlLayout__childrenWrapper"
@@ -667,7 +674,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                     >
                                       <input
                                         aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                        className="euiFieldSearch euiFieldSearch--fullWidth"
+                                        className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                                         defaultValue=""
                                         onKeyUp={[Function]}
                                         placeholder="Search rules"
@@ -675,7 +682,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                       />
                                     </EuiValidatableControl>
                                     <EuiFormControlLayoutIcons
-                                      compressed={false}
+                                      compressed={true}
                                       icon="search"
                                       isLoading={false}
                                     >
@@ -683,7 +690,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                         className="euiFormControlLayoutIcons"
                                       >
                                         <EuiFormControlLayoutCustomIcon
-                                          size="m"
+                                          size="s"
                                           type="search"
                                         >
                                           <span
@@ -692,7 +699,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             <EuiIcon
                                               aria-hidden="true"
                                               className="euiFormControlLayoutCustomIcon__icon"
-                                              size="m"
+                                              size="s"
                                               type="search"
                                             >
                                               EuiIconMock
@@ -719,6 +726,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                             filters={
                               Array [
                                 Object {
+                                  "compressed": true,
                                   "field": "category",
                                   "multiSelect": "or",
                                   "name": "Log type",
@@ -726,6 +734,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                   "type": "field_value_selection",
                                 },
                                 Object {
+                                  "compressed": true,
                                   "field": "level",
                                   "multiSelect": "or",
                                   "name": "Rule severity",
@@ -779,6 +788,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                   "type": "field_value_selection",
                                 },
                                 Object {
+                                  "compressed": true,
                                   "field": "source",
                                   "multiSelect": "or",
                                   "name": "Source",
@@ -822,7 +832,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                 <FieldValueSelectionFilter
                                   config={
                                     Object {
-                                      "compressed": undefined,
+                                      "compressed": true,
                                       "field": "category",
                                       "multiSelect": "or",
                                       "name": "Log type",
@@ -861,6 +871,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                         iconSide="right"
                                         iconType="arrowDown"
                                         onClick={[Function]}
+                                        size="s"
                                       >
                                         Log type
                                       </EuiFilterButton>
@@ -887,6 +898,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           <EuiButtonEmpty
                                             className="euiFilterButton euiFilterButton--hasIcon"
@@ -894,6 +906,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                             textProps={
                                               Object {
                                                 "className": "",
@@ -902,7 +915,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                               disabled={false}
                                               onClick={[Function]}
                                               type="button"
@@ -953,7 +966,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                 <FieldValueSelectionFilter
                                   config={
                                     Object {
-                                      "compressed": undefined,
+                                      "compressed": true,
                                       "field": "level",
                                       "multiSelect": "or",
                                       "name": "Rule severity",
@@ -1038,6 +1051,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                         iconSide="right"
                                         iconType="arrowDown"
                                         onClick={[Function]}
+                                        size="s"
                                       >
                                         Rule severity
                                       </EuiFilterButton>
@@ -1064,6 +1078,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           <EuiButtonEmpty
                                             className="euiFilterButton euiFilterButton--hasIcon"
@@ -1071,6 +1086,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                             textProps={
                                               Object {
                                                 "className": "",
@@ -1079,7 +1095,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                               disabled={false}
                                               onClick={[Function]}
                                               type="button"
@@ -1130,7 +1146,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                 <FieldValueSelectionFilter
                                   config={
                                     Object {
-                                      "compressed": undefined,
+                                      "compressed": true,
                                       "field": "source",
                                       "multiSelect": "or",
                                       "name": "Source",
@@ -1176,6 +1192,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                         iconSide="right"
                                         iconType="arrowDown"
                                         onClick={[Function]}
+                                        size="s"
                                       >
                                         Source
                                       </EuiFilterButton>
@@ -1202,6 +1219,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           <EuiButtonEmpty
                                             className="euiFilterButton euiFilterButton--hasIcon"
@@ -1209,6 +1227,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                             textProps={
                                               Object {
                                                 "className": "",
@@ -1217,7 +1236,7 @@ exports[`<DetectorRulesView /> spec renders the component 1`] = `
                                             type="button"
                                           >
                                             <button
-                                              className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                               disabled={false}
                                               onClick={[Function]}
                                               type="button"

--- a/public/pages/Detectors/components/FieldMappingsView/__snapshots__/FieldMappingsView.test.tsx.snap
+++ b/public/pages/Detectors/components/FieldMappingsView/__snapshots__/FieldMappingsView.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        style="padding-left: 0px; padding-right: 0px;"
+        style="padding: 16px;"
       >
         <div
           class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -19,9 +19,9 @@ Object {
             <div
               class="euiText euiText--small"
             >
-              <h2>
+              <h3>
                 Field mapping
-              </h2>
+              </h3>
             </div>
           </div>
           <div
@@ -214,7 +214,7 @@ Object {
   "container": <div>
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      style="padding-left: 0px; padding-right: 0px;"
+      style="padding: 16px;"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -226,9 +226,9 @@ Object {
           <div
             class="euiText euiText--small"
           >
-            <h2>
+            <h3>
               Field mapping
-            </h2>
+            </h3>
           </div>
         </div>
         <div

--- a/public/pages/Detectors/components/UpdateRules/__snapshots__/UpdateDetectorRules.test.tsx.snap
+++ b/public/pages/Detectors/components/UpdateRules/__snapshots__/UpdateDetectorRules.test.tsx.snap
@@ -16,7 +16,7 @@ Object {
         />
         <div
           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          style="padding-left: 0px; padding-right: 0px;"
+          style="padding: 16px;"
         >
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -28,9 +28,9 @@ Object {
               <div
                 class="euiText euiText--small"
               >
-                <h2>
+                <h3>
                   Detection rules (0)
-                </h2>
+                </h3>
               </div>
             </div>
           </div>
@@ -395,7 +395,7 @@ Object {
       />
       <div
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        style="padding-left: 0px; padding-right: 0px;"
+        style="padding: 16px;"
       >
         <div
           class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -407,9 +407,9 @@ Object {
             <div
               class="euiText euiText--small"
             >
-              <h2>
+              <h3>
                 Detection rules (0)
-              </h2>
+              </h3>
             </div>
           </div>
         </div>

--- a/public/pages/Detectors/containers/AlertTriggersView/__snapshots__/AlertTriggersView.test.tsx.snap
+++ b/public/pages/Detectors/containers/AlertTriggersView/__snapshots__/AlertTriggersView.test.tsx.snap
@@ -212,8 +212,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
       className=""
       style={
         Object {
-          "paddingLeft": "0px",
-          "paddingRight": "0px",
+          "padding": "16px",
         }
       }
     >
@@ -221,8 +220,7 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
         className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -253,9 +251,9 @@ exports[`<AlertTriggersView /> spec renders the component 1`] = `
                   <div
                     className="euiText euiText--small"
                   >
-                    <h2>
+                    <h3>
                       Alert triggers (2)
-                    </h2>
+                    </h3>
                   </div>
                 </EuiText>
               </div>

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -514,10 +514,10 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
               </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiSpacer size="xl" />
+          <EuiSpacer size="m" />
         </PageHeader>
         <EuiTabs size="s">{this.renderTabs()}</EuiTabs>
-        <EuiSpacer size="xl" />
+        <EuiSpacer size="m" />
         {selectedTabContent}
       </>
     );

--- a/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
@@ -545,10 +545,10 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
       </div>
     </EuiFlexGroup>
     <EuiSpacer
-      size="xl"
+      size="m"
     >
       <div
-        className="euiSpacer euiSpacer--xl"
+        className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
   </PageHeader>
@@ -622,10 +622,10 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
     </div>
   </EuiTabs>
   <EuiSpacer
-    size="xl"
+    size="m"
   >
     <div
-      className="euiSpacer euiSpacer--xl"
+      className="euiSpacer euiSpacer--m"
     />
   </EuiSpacer>
   <DetectorDetailsView
@@ -1496,8 +1496,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
           className=""
           style={
             Object {
-              "paddingLeft": "0px",
-              "paddingRight": "0px",
+              "padding": "16px",
             }
           }
         >
@@ -1505,8 +1504,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
             className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             style={
               Object {
-                "paddingLeft": "0px",
-                "paddingRight": "0px",
+                "padding": "16px",
               }
             }
           >
@@ -1537,9 +1535,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                       <div
                         className="euiText euiText--small"
                       >
-                        <h2>
+                        <h3>
                           Detector details
-                        </h2>
+                        </h3>
                       </div>
                     </EuiText>
                   </div>
@@ -2330,13 +2328,6 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
     <DetectorRulesView
       detector={
         Object {
@@ -2780,8 +2771,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
           className=""
           style={
             Object {
-              "paddingLeft": "0px",
-              "paddingRight": "0px",
+              "padding": "16px",
             }
           }
         >
@@ -2789,8 +2779,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
             className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             style={
               Object {
-                "paddingLeft": "0px",
-                "paddingRight": "0px",
+                "padding": "16px",
               }
             }
           >
@@ -2821,9 +2810,9 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                       <div
                         className="euiText euiText--small"
                       >
-                        <h2>
+                        <h3>
                           Active rules (2)
-                        </h2>
+                        </h3>
                       </div>
                     </EuiText>
                   </div>
@@ -2989,11 +2978,13 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                   search={
                     Object {
                       "box": Object {
+                        "compressed": true,
                         "placeholder": "Search rules",
                         "schema": true,
                       },
                       "filters": Array [
                         Object {
+                          "compressed": true,
                           "field": "category",
                           "multiSelect": "or",
                           "name": "Log type",
@@ -3001,6 +2992,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           "type": "field_value_selection",
                         },
                         Object {
+                          "compressed": true,
                           "field": "level",
                           "multiSelect": "or",
                           "name": "Rule severity",
@@ -3054,6 +3046,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                           "type": "field_value_selection",
                         },
                         Object {
+                          "compressed": true,
                           "field": "source",
                           "multiSelect": "or",
                           "name": "Source",
@@ -3077,6 +3070,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                     <EuiSearchBar
                       box={
                         Object {
+                          "compressed": true,
                           "placeholder": "Search rules",
                           "schema": Object {
                             "fields": Object {
@@ -3103,6 +3097,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                       filters={
                         Array [
                           Object {
+                            "compressed": true,
                             "field": "category",
                             "multiSelect": "or",
                             "name": "Log type",
@@ -3110,6 +3105,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             "type": "field_value_selection",
                           },
                           Object {
+                            "compressed": true,
                             "field": "level",
                             "multiSelect": "or",
                             "name": "Rule severity",
@@ -3163,6 +3159,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                             "type": "field_value_selection",
                           },
                           Object {
+                            "compressed": true,
                             "field": "source",
                             "multiSelect": "or",
                             "name": "Source",
@@ -3196,6 +3193,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                               className="euiFlexItem euiSearchBar__searchHolder"
                             >
                               <EuiSearchBox
+                                compressed={true}
                                 incremental={false}
                                 isInvalid={false}
                                 onSearch={[Function]}
@@ -3204,7 +3202,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                               >
                                 <EuiFieldSearch
                                   aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                  compressed={false}
+                                  compressed={true}
                                   defaultValue=""
                                   fullWidth={true}
                                   incremental={false}
@@ -3216,13 +3214,13 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                   placeholder="Search rules"
                                 >
                                   <EuiFormControlLayout
-                                    compressed={false}
+                                    compressed={true}
                                     fullWidth={true}
                                     icon="search"
                                     isLoading={false}
                                   >
                                     <div
-                                      className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                      className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                     >
                                       <div
                                         className="euiFormControlLayout__childrenWrapper"
@@ -3232,7 +3230,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                         >
                                           <input
                                             aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                            className="euiFieldSearch euiFieldSearch--fullWidth"
+                                            className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                                             defaultValue=""
                                             onKeyUp={[Function]}
                                             placeholder="Search rules"
@@ -3240,7 +3238,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                           />
                                         </EuiValidatableControl>
                                         <EuiFormControlLayoutIcons
-                                          compressed={false}
+                                          compressed={true}
                                           icon="search"
                                           isLoading={false}
                                         >
@@ -3248,7 +3246,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                             className="euiFormControlLayoutIcons"
                                           >
                                             <EuiFormControlLayoutCustomIcon
-                                              size="m"
+                                              size="s"
                                               type="search"
                                             >
                                               <span
@@ -3257,7 +3255,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 <EuiIcon
                                                   aria-hidden="true"
                                                   className="euiFormControlLayoutCustomIcon__icon"
-                                                  size="m"
+                                                  size="s"
                                                   type="search"
                                                 >
                                                   EuiIconMock
@@ -3284,6 +3282,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                 filters={
                                   Array [
                                     Object {
+                                      "compressed": true,
                                       "field": "category",
                                       "multiSelect": "or",
                                       "name": "Log type",
@@ -3291,6 +3290,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                       "type": "field_value_selection",
                                     },
                                     Object {
+                                      "compressed": true,
                                       "field": "level",
                                       "multiSelect": "or",
                                       "name": "Rule severity",
@@ -3344,6 +3344,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                       "type": "field_value_selection",
                                     },
                                     Object {
+                                      "compressed": true,
                                       "field": "source",
                                       "multiSelect": "or",
                                       "name": "Source",
@@ -3387,7 +3388,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                     <FieldValueSelectionFilter
                                       config={
                                         Object {
-                                          "compressed": undefined,
+                                          "compressed": true,
                                           "field": "category",
                                           "multiSelect": "or",
                                           "name": "Log type",
@@ -3426,6 +3427,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             Log type
                                           </EuiFilterButton>
@@ -3452,6 +3454,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                             >
                                               <EuiButtonEmpty
                                                 className="euiFilterButton euiFilterButton--hasIcon"
@@ -3459,6 +3462,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 onClick={[Function]}
+                                                size="s"
                                                 textProps={
                                                   Object {
                                                     "className": "",
@@ -3467,7 +3471,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 type="button"
                                               >
                                                 <button
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   type="button"
@@ -3518,7 +3522,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                     <FieldValueSelectionFilter
                                       config={
                                         Object {
-                                          "compressed": undefined,
+                                          "compressed": true,
                                           "field": "level",
                                           "multiSelect": "or",
                                           "name": "Rule severity",
@@ -3603,6 +3607,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             Rule severity
                                           </EuiFilterButton>
@@ -3629,6 +3634,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                             >
                                               <EuiButtonEmpty
                                                 className="euiFilterButton euiFilterButton--hasIcon"
@@ -3636,6 +3642,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 onClick={[Function]}
+                                                size="s"
                                                 textProps={
                                                   Object {
                                                     "className": "",
@@ -3644,7 +3651,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 type="button"
                                               >
                                                 <button
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   type="button"
@@ -3695,7 +3702,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                     <FieldValueSelectionFilter
                                       config={
                                         Object {
-                                          "compressed": undefined,
+                                          "compressed": true,
                                           "field": "source",
                                           "multiSelect": "or",
                                           "name": "Source",
@@ -3741,6 +3748,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             Source
                                           </EuiFilterButton>
@@ -3767,6 +3775,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                             >
                                               <EuiButtonEmpty
                                                 className="euiFilterButton euiFilterButton--hasIcon"
@@ -3774,6 +3783,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 onClick={[Function]}
+                                                size="s"
                                                 textProps={
                                                   Object {
                                                     "className": "",
@@ -3782,7 +3792,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                                 type="button"
                                               >
                                                 <button
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   type="button"

--- a/public/pages/Detectors/containers/DetectorDetailsView/DetectorDetailsView.tsx
+++ b/public/pages/Detectors/containers/DetectorDetailsView/DetectorDetailsView.tsx
@@ -42,7 +42,6 @@ export class DetectorDetailsView extends React.Component<
     } = this.props;
     const detectorRules = (
       <>
-        <EuiSpacer size="m" />
         <DetectorRulesView
           {...this.props}
           detector={detector}

--- a/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
@@ -418,8 +418,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
         className=""
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -427,8 +426,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
           className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           style={
             Object {
-              "paddingLeft": "0px",
-              "paddingRight": "0px",
+              "padding": "16px",
             }
           }
         >
@@ -459,9 +457,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                     <div
                       className="euiText euiText--small"
                     >
-                      <h2>
+                      <h3>
                         Detector details
-                      </h2>
+                      </h3>
                     </div>
                   </EuiText>
                 </div>
@@ -1252,13 +1250,6 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
       className="euiSpacer euiSpacer--m"
     />
   </EuiSpacer>
-  <EuiSpacer
-    size="m"
-  >
-    <div
-      className="euiSpacer euiSpacer--m"
-    />
-  </EuiSpacer>
   <DetectorRulesView
     detector={
       Object {
@@ -1477,8 +1468,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
         className=""
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -1486,8 +1476,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
           className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           style={
             Object {
-              "paddingLeft": "0px",
-              "paddingRight": "0px",
+              "padding": "16px",
             }
           }
         >
@@ -1518,9 +1507,9 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                     <div
                       className="euiText euiText--small"
                     >
-                      <h2>
+                      <h3>
                         Active rules (2)
-                      </h2>
+                      </h3>
                     </div>
                   </EuiText>
                 </div>
@@ -1686,11 +1675,13 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                 search={
                   Object {
                     "box": Object {
+                      "compressed": true,
                       "placeholder": "Search rules",
                       "schema": true,
                     },
                     "filters": Array [
                       Object {
+                        "compressed": true,
                         "field": "category",
                         "multiSelect": "or",
                         "name": "Log type",
@@ -1698,6 +1689,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                         "type": "field_value_selection",
                       },
                       Object {
+                        "compressed": true,
                         "field": "level",
                         "multiSelect": "or",
                         "name": "Rule severity",
@@ -1751,6 +1743,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                         "type": "field_value_selection",
                       },
                       Object {
+                        "compressed": true,
                         "field": "source",
                         "multiSelect": "or",
                         "name": "Source",
@@ -1774,6 +1767,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                   <EuiSearchBar
                     box={
                       Object {
+                        "compressed": true,
                         "placeholder": "Search rules",
                         "schema": Object {
                           "fields": Object {
@@ -1800,6 +1794,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                     filters={
                       Array [
                         Object {
+                          "compressed": true,
                           "field": "category",
                           "multiSelect": "or",
                           "name": "Log type",
@@ -1807,6 +1802,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           "type": "field_value_selection",
                         },
                         Object {
+                          "compressed": true,
                           "field": "level",
                           "multiSelect": "or",
                           "name": "Rule severity",
@@ -1860,6 +1856,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                           "type": "field_value_selection",
                         },
                         Object {
+                          "compressed": true,
                           "field": "source",
                           "multiSelect": "or",
                           "name": "Source",
@@ -1893,6 +1890,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                             className="euiFlexItem euiSearchBar__searchHolder"
                           >
                             <EuiSearchBox
+                              compressed={true}
                               incremental={false}
                               isInvalid={false}
                               onSearch={[Function]}
@@ -1901,7 +1899,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                             >
                               <EuiFieldSearch
                                 aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                compressed={false}
+                                compressed={true}
                                 defaultValue=""
                                 fullWidth={true}
                                 incremental={false}
@@ -1913,13 +1911,13 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                 placeholder="Search rules"
                               >
                                 <EuiFormControlLayout
-                                  compressed={false}
+                                  compressed={true}
                                   fullWidth={true}
                                   icon="search"
                                   isLoading={false}
                                 >
                                   <div
-                                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                   >
                                     <div
                                       className="euiFormControlLayout__childrenWrapper"
@@ -1929,7 +1927,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                       >
                                         <input
                                           aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                                          className="euiFieldSearch euiFieldSearch--fullWidth"
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                                           defaultValue=""
                                           onKeyUp={[Function]}
                                           placeholder="Search rules"
@@ -1937,7 +1935,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                         />
                                       </EuiValidatableControl>
                                       <EuiFormControlLayoutIcons
-                                        compressed={false}
+                                        compressed={true}
                                         icon="search"
                                         isLoading={false}
                                       >
@@ -1945,7 +1943,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                           className="euiFormControlLayoutIcons"
                                         >
                                           <EuiFormControlLayoutCustomIcon
-                                            size="m"
+                                            size="s"
                                             type="search"
                                           >
                                             <span
@@ -1954,7 +1952,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               <EuiIcon
                                                 aria-hidden="true"
                                                 className="euiFormControlLayoutCustomIcon__icon"
-                                                size="m"
+                                                size="s"
                                                 type="search"
                                               >
                                                 EuiIconMock
@@ -1981,6 +1979,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                               filters={
                                 Array [
                                   Object {
+                                    "compressed": true,
                                     "field": "category",
                                     "multiSelect": "or",
                                     "name": "Log type",
@@ -1988,6 +1987,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                     "type": "field_value_selection",
                                   },
                                   Object {
+                                    "compressed": true,
                                     "field": "level",
                                     "multiSelect": "or",
                                     "name": "Rule severity",
@@ -2041,6 +2041,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                     "type": "field_value_selection",
                                   },
                                   Object {
+                                    "compressed": true,
                                     "field": "source",
                                     "multiSelect": "or",
                                     "name": "Source",
@@ -2084,7 +2085,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
-                                        "compressed": undefined,
+                                        "compressed": true,
                                         "field": "category",
                                         "multiSelect": "or",
                                         "name": "Log type",
@@ -2123,6 +2124,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           Log type
                                         </EuiFilterButton>
@@ -2149,6 +2151,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             <EuiButtonEmpty
                                               className="euiFilterButton euiFilterButton--hasIcon"
@@ -2156,6 +2159,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                               textProps={
                                                 Object {
                                                   "className": "",
@@ -2164,7 +2168,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               type="button"
                                             >
                                               <button
-                                                className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 type="button"
@@ -2215,7 +2219,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
-                                        "compressed": undefined,
+                                        "compressed": true,
                                         "field": "level",
                                         "multiSelect": "or",
                                         "name": "Rule severity",
@@ -2300,6 +2304,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           Rule severity
                                         </EuiFilterButton>
@@ -2326,6 +2331,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             <EuiButtonEmpty
                                               className="euiFilterButton euiFilterButton--hasIcon"
@@ -2333,6 +2339,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                               textProps={
                                                 Object {
                                                   "className": "",
@@ -2341,7 +2348,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               type="button"
                                             >
                                               <button
-                                                className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 type="button"
@@ -2392,7 +2399,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
-                                        "compressed": undefined,
+                                        "compressed": true,
                                         "field": "source",
                                         "multiSelect": "or",
                                         "name": "Source",
@@ -2438,6 +2445,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           Source
                                         </EuiFilterButton>
@@ -2464,6 +2472,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             <EuiButtonEmpty
                                               className="euiFilterButton euiFilterButton--hasIcon"
@@ -2471,6 +2480,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                               textProps={
                                                 Object {
                                                   "className": "",
@@ -2479,7 +2489,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                                               type="button"
                                             >
                                               <button
-                                                className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 type="button"

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -19,6 +19,7 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import { BREADCRUMBS, DEFAULT_EMPTY_DATA, ROUTES } from '../../../../utils/constants';
 import DeleteModal from '../../../../components/DeleteModal';
@@ -231,38 +232,6 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
 
     const actions = [
       <EuiSmallButton
-        iconType={'refresh'}
-        onClick={this.getDetectors}
-        data-test-subj={'detectorsRefreshButton'}
-      >
-        Refresh
-      </EuiSmallButton>,
-      <EuiPopover
-        id={'detectorsActionsPopover'}
-        button={
-          <EuiSmallButton
-            isLoading={loadingDetectors}
-            iconType={'arrowDown'}
-            iconSide={'right'}
-            disabled={!selectedItems.length}
-            onClick={this.openActionsButton}
-            data-test-subj={'detectorsActionsButton'}
-          >
-            Actions
-          </EuiSmallButton>
-        }
-        isOpen={isPopoverOpen}
-        closePopover={this.closeActionsPopover}
-        panelPaddingSize={'none'}
-        anchorPosition={'downLeft'}
-        data-test-subj={'detectorsActionsPopover'}
-      >
-        <EuiContextMenuPanel
-          items={this.getActionItems(loadingDetectors, selectedItems)}
-          size="s"
-        />
-      </EuiPopover>,
-      <EuiSmallButton
         href={`#${ROUTES.DETECTORS_CREATE}`}
         fill={true}
         data-test-subj={'detectorsCreateButton'}
@@ -319,7 +288,46 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
         detectorHits.map((detector) => (detector._source.enabled ? 'Active' : 'Inactive'))
       ),
     ];
+
+    const renderActionsRight = () => {
+      return [
+        <EuiSmallButton
+          iconType={'refresh'}
+          onClick={this.getDetectors}
+          data-test-subj={'detectorsRefreshButton'}
+        >
+          Refresh
+        </EuiSmallButton>,
+        <EuiPopover
+          id={'detectorsActionsPopover'}
+          button={
+            <EuiSmallButton
+              isLoading={loadingDetectors}
+              iconType={'arrowDown'}
+              iconSide={'right'}
+              disabled={!selectedItems.length}
+              onClick={this.openActionsButton}
+              data-test-subj={'detectorsActionsButton'}
+            >
+              Actions
+            </EuiSmallButton>
+          }
+          isOpen={isPopoverOpen}
+          closePopover={this.closeActionsPopover}
+          panelPaddingSize={'none'}
+          anchorPosition={'downLeft'}
+          data-test-subj={'detectorsActionsPopover'}
+        >
+          <EuiContextMenuPanel
+            items={this.getActionItems(loadingDetectors, selectedItems)}
+            size="s"
+          />
+        </EuiPopover>,
+      ];
+    };
+
     const search = {
+      toolsRight: renderActionsRight(),
       box: {
         placeholder: 'Search threat detectors',
         schema: true,

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -371,7 +371,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
       },
     };
     return (
-      <EuiFlexGroup direction="column">
+      <EuiFlexGroup direction="column" gutterSize={'m'}>
         <PageHeader
           appRightControls={actions.map((action) => ({
             renderComponent: action,
@@ -396,7 +396,6 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
                 </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
-            <EuiSpacer size={'m'} />
           </EuiFlexItem>
         </PageHeader>
 

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -324,12 +324,14 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
         placeholder: 'Search threat detectors',
         schema: true,
         incremental: true,
+        compressed: true,
       },
       filters: [
         {
           type: 'field_value_selection',
           field: 'status',
           name: 'Status',
+          compressed: true,
           options: statuses.map((status) => ({
             value: status,
             name: capitalizeFirstLetter(status),
@@ -340,6 +342,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
           type: 'field_value_selection',
           field: 'logType',
           name: 'Log type',
+          compressed: true,
           options: getLogTypeFilterOptions(),
           multiSelect: 'or',
         } as FieldValueSelectionFilterConfigType,

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -257,12 +257,18 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
         anchorPosition={'downLeft'}
         data-test-subj={'detectorsActionsPopover'}
       >
-        <EuiContextMenuPanel items={this.getActionItems(loadingDetectors, selectedItems)} size="s"/>
+        <EuiContextMenuPanel
+          items={this.getActionItems(loadingDetectors, selectedItems)}
+          size="s"
+        />
       </EuiPopover>,
       <EuiSmallButton
         href={`#${ROUTES.DETECTORS_CREATE}`}
         fill={true}
         data-test-subj={'detectorsCreateButton'}
+        iconType="plus"
+        iconSide="left"
+        iconGap="s"
       >
         Create detector
       </EuiSmallButton>,

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -186,21 +186,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
   };
 
   getActionItems = (loading: boolean, selectedItems: DetectorHit[]) => {
-    const actionItems = [
-      <EuiContextMenuItem
-        key={'Delete'}
-        icon={'empty'}
-        disabled={selectedItems.length === 0 || loading}
-        onClick={() => {
-          this.closeActionsPopover();
-          this.openDeleteModal();
-        }}
-        data-test-subj={'deleteButton'}
-      >
-        Delete
-      </EuiContextMenuItem>,
-    ];
-
+    const actionItems = [];
     if (selectedItems.length === 1) {
       actionItems.push(
         <EuiContextMenuItem
@@ -289,6 +275,26 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
       ),
     ];
 
+    const renderActionsLeft = (loading: boolean, selectedItems: DetectorHit[]) => {
+      return [
+        <EuiSmallButton
+          color={'danger'}
+          iconType={'trash'}
+          key={'Delete'}
+          disabled={selectedItems.length === 0 || loading}
+          onClick={() => {
+            this.closeActionsPopover();
+            this.openDeleteModal();
+          }}
+          data-test-subj={'deleteButton'}
+        >
+          {selectedItems.length > 0
+            ? `Delete ${selectedItems.length} detectors`
+            : 'Delete detectors'}
+        </EuiSmallButton>,
+      ];
+    };
+
     const renderActionsRight = () => {
       return [
         <EuiSmallButton
@@ -305,7 +311,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
               isLoading={loadingDetectors}
               iconType={'arrowDown'}
               iconSide={'right'}
-              disabled={!selectedItems.length}
+              disabled={selectedItems.length !== 1}
               onClick={this.openActionsButton}
               data-test-subj={'detectorsActionsButton'}
             >
@@ -327,6 +333,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
     };
 
     const search = {
+      toolsLeft: renderActionsLeft(loadingDetectors, selectedItems),
       toolsRight: renderActionsRight(),
       box: {
         placeholder: 'Search threat detectors',

--- a/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
@@ -96,6 +96,9 @@ exports[`<Detectors /> spec renders the component 1`] = `
                 data-test-subj="detectorsCreateButton"
                 fill={true}
                 href="#/create-detector"
+                iconGap="s"
+                iconSide="left"
+                iconType="plus"
               >
                 Create detector
               </EuiSmallButton>,
@@ -344,11 +347,17 @@ exports[`<Detectors /> spec renders the component 1`] = `
                               data-test-subj="detectorsCreateButton"
                               fill={true}
                               href="#/create-detector"
+                              iconGap="s"
+                              iconSide="left"
+                              iconType="plus"
                             >
                               <EuiButton
                                 data-test-subj="detectorsCreateButton"
                                 fill={true}
                                 href="#/create-detector"
+                                iconGap="s"
+                                iconSide="left"
+                                iconType="plus"
                                 size="s"
                               >
                                 <EuiButtonDisplay
@@ -357,6 +366,9 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   element="a"
                                   fill={true}
                                   href="#/create-detector"
+                                  iconGap="s"
+                                  iconSide="left"
+                                  iconType="plus"
                                   isDisabled={false}
                                   rel="noreferrer"
                                   size="s"
@@ -375,8 +387,9 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButton__content"
-                                      iconGap="m"
+                                      iconGap="s"
                                       iconSide="left"
+                                      iconType="plus"
                                       textProps={
                                         Object {
                                           "className": "euiButton__text",
@@ -384,8 +397,16 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                       }
                                     >
                                       <span
-                                        className="euiButtonContent euiButton__content"
+                                        className="euiButtonContent euiButtonContent--smallIconGap euiButton__content"
                                       >
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="plus"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
                                         <span
                                           className="euiButton__text"
                                         >

--- a/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
@@ -33,64 +33,14 @@ exports[`<Detectors /> spec renders the component 1`] = `
 >
   <EuiFlexGroup
     direction="column"
+    gutterSize="m"
   >
     <div
-      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+      className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionColumn euiFlexGroup--responsive"
     >
       <PageHeader
         appRightControls={
           Array [
-            Object {
-              "renderComponent": <EuiSmallButton
-                data-test-subj="detectorsRefreshButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                Refresh
-              </EuiSmallButton>,
-            },
-            Object {
-              "renderComponent": <EuiPopover
-                anchorPosition="downLeft"
-                button={
-                  <EuiSmallButton
-                    data-test-subj="detectorsActionsButton"
-                    disabled={true}
-                    iconSide="right"
-                    iconType="arrowDown"
-                    isLoading={false}
-                    onClick={[Function]}
-                  >
-                    Actions
-                  </EuiSmallButton>
-                }
-                closePopover={[Function]}
-                data-test-subj="detectorsActionsPopover"
-                display="inlineBlock"
-                hasArrow={true}
-                id="detectorsActionsPopover"
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="none"
-              >
-                <EuiContextMenuPanel
-                  hasFocus={true}
-                  items={
-                    Array [
-                      <EuiContextMenuItem
-                        data-test-subj="deleteButton"
-                        disabled={true}
-                        icon="empty"
-                        onClick={[Function]}
-                      >
-                        Delete
-                      </EuiContextMenuItem>,
-                    ]
-                  }
-                  size="s"
-                />
-              </EuiPopover>,
-            },
             Object {
               "renderComponent": <EuiSmallButton
                 data-test-subj="detectorsCreateButton"
@@ -144,201 +94,6 @@ exports[`<Detectors /> spec renders the component 1`] = `
                         <EuiFlexItem
                           grow={false}
                           key="0"
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiSmallButton
-                              data-test-subj="detectorsRefreshButton"
-                              iconType="refresh"
-                              onClick={[Function]}
-                            >
-                              <EuiButton
-                                data-test-subj="detectorsRefreshButton"
-                                iconType="refresh"
-                                onClick={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButton"
-                                  data-test-subj="detectorsRefreshButton"
-                                  disabled={false}
-                                  element="button"
-                                  iconType="refresh"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  type="button"
-                                >
-                                  <button
-                                    className="euiButton euiButton--primary euiButton--small"
-                                    data-test-subj="detectorsRefreshButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                    type="button"
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconGap="m"
-                                      iconSide="left"
-                                      iconType="refresh"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <EuiIcon
-                                          className="euiButtonContent__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="refresh"
-                                        >
-                                          EuiIconMock
-                                        </EuiIcon>
-                                        <span
-                                          className="euiButton__text"
-                                        >
-                                          Refresh
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonDisplay>
-                              </EuiButton>
-                            </EuiSmallButton>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                          key="1"
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiPopover
-                              anchorPosition="downLeft"
-                              button={
-                                <EuiSmallButton
-                                  data-test-subj="detectorsActionsButton"
-                                  disabled={true}
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  isLoading={false}
-                                  onClick={[Function]}
-                                >
-                                  Actions
-                                </EuiSmallButton>
-                              }
-                              closePopover={[Function]}
-                              data-test-subj="detectorsActionsPopover"
-                              display="inlineBlock"
-                              hasArrow={true}
-                              id="detectorsActionsPopover"
-                              isOpen={false}
-                              ownFocus={true}
-                              panelPaddingSize="none"
-                            >
-                              <div
-                                className="euiPopover euiPopover--anchorDownLeft"
-                                data-test-subj="detectorsActionsPopover"
-                                id="detectorsActionsPopover"
-                              >
-                                <div
-                                  className="euiPopover__anchor"
-                                >
-                                  <EuiSmallButton
-                                    data-test-subj="detectorsActionsButton"
-                                    disabled={true}
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isLoading={false}
-                                    onClick={[Function]}
-                                  >
-                                    <EuiButton
-                                      data-test-subj="detectorsActionsButton"
-                                      disabled={true}
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isLoading={false}
-                                      onClick={[Function]}
-                                      size="s"
-                                    >
-                                      <EuiButtonDisplay
-                                        baseClassName="euiButton"
-                                        data-test-subj="detectorsActionsButton"
-                                        disabled={true}
-                                        element="button"
-                                        iconSide="right"
-                                        iconType="arrowDown"
-                                        isDisabled={true}
-                                        isLoading={false}
-                                        onClick={[Function]}
-                                        size="s"
-                                        type="button"
-                                      >
-                                        <button
-                                          className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
-                                          data-test-subj="detectorsActionsButton"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          style={
-                                            Object {
-                                              "minWidth": undefined,
-                                            }
-                                          }
-                                          type="button"
-                                        >
-                                          <EuiButtonContent
-                                            className="euiButton__content"
-                                            iconGap="m"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isLoading={false}
-                                            textProps={
-                                              Object {
-                                                "className": "euiButton__text",
-                                              }
-                                            }
-                                          >
-                                            <span
-                                              className="euiButtonContent euiButtonContent--iconRight euiButton__content"
-                                            >
-                                              <EuiIcon
-                                                className="euiButtonContent__icon"
-                                                color="inherit"
-                                                size="m"
-                                                type="arrowDown"
-                                              >
-                                                EuiIconMock
-                                              </EuiIcon>
-                                              <span
-                                                className="euiButton__text"
-                                              >
-                                                Actions
-                                              </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonDisplay>
-                                    </EuiButton>
-                                  </EuiSmallButton>
-                                </div>
-                              </div>
-                            </EuiPopover>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                          key="2"
                         >
                           <div
                             className="euiFlexItem euiFlexItem--flexGrowZero"
@@ -426,13 +181,6 @@ exports[`<Detectors /> spec renders the component 1`] = `
                 </EuiFlexItem>
               </div>
             </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
           </div>
         </EuiFlexItem>
       </PageHeader>
@@ -710,12 +458,14 @@ exports[`<Detectors /> spec renders the component 1`] = `
                 search={
                   Object {
                     "box": Object {
+                      "compressed": true,
                       "incremental": true,
                       "placeholder": "Search threat detectors",
                       "schema": true,
                     },
                     "filters": Array [
                       Object {
+                        "compressed": true,
                         "field": "status",
                         "multiSelect": "or",
                         "name": "Status",
@@ -728,12 +478,62 @@ exports[`<Detectors /> spec renders the component 1`] = `
                         "type": "field_value_selection",
                       },
                       Object {
+                        "compressed": true,
                         "field": "logType",
                         "multiSelect": "or",
                         "name": "Log type",
                         "options": Array [],
                         "type": "field_value_selection",
                       },
+                    ],
+                    "toolsLeft": Array [
+                      <EuiSmallButton
+                        color="danger"
+                        data-test-subj="deleteButton"
+                        disabled={true}
+                        iconType="trash"
+                        onClick={[Function]}
+                      >
+                        Delete detectors
+                      </EuiSmallButton>,
+                    ],
+                    "toolsRight": Array [
+                      <EuiSmallButton
+                        data-test-subj="detectorsRefreshButton"
+                        iconType="refresh"
+                        onClick={[Function]}
+                      >
+                        Refresh
+                      </EuiSmallButton>,
+                      <EuiPopover
+                        anchorPosition="downLeft"
+                        button={
+                          <EuiSmallButton
+                            data-test-subj="detectorsActionsButton"
+                            disabled={true}
+                            iconSide="right"
+                            iconType="arrowDown"
+                            isLoading={false}
+                            onClick={[Function]}
+                          >
+                            Actions
+                          </EuiSmallButton>
+                        }
+                        closePopover={[Function]}
+                        data-test-subj="detectorsActionsPopover"
+                        display="inlineBlock"
+                        hasArrow={true}
+                        id="detectorsActionsPopover"
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="none"
+                      >
+                        <EuiContextMenuPanel
+                          hasFocus={true}
+                          items={Array []}
+                          size="s"
+                        />
+                      </EuiPopover>,
                     ],
                   }
                 }
@@ -756,6 +556,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                   <EuiSearchBar
                     box={
                       Object {
+                        "compressed": true,
                         "incremental": true,
                         "placeholder": "Search threat detectors",
                         "schema": Object {
@@ -783,6 +584,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                     filters={
                       Array [
                         Object {
+                          "compressed": true,
                           "field": "status",
                           "multiSelect": "or",
                           "name": "Status",
@@ -795,6 +597,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                           "type": "field_value_selection",
                         },
                         Object {
+                          "compressed": true,
                           "field": "logType",
                           "multiSelect": "or",
                           "name": "Log type",
@@ -804,6 +607,59 @@ exports[`<Detectors /> spec renders the component 1`] = `
                       ]
                     }
                     onChange={[Function]}
+                    toolsLeft={
+                      Array [
+                        <EuiSmallButton
+                          color="danger"
+                          data-test-subj="deleteButton"
+                          disabled={true}
+                          iconType="trash"
+                          onClick={[Function]}
+                        >
+                          Delete detectors
+                        </EuiSmallButton>,
+                      ]
+                    }
+                    toolsRight={
+                      Array [
+                        <EuiSmallButton
+                          data-test-subj="detectorsRefreshButton"
+                          iconType="refresh"
+                          onClick={[Function]}
+                        >
+                          Refresh
+                        </EuiSmallButton>,
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiSmallButton
+                              data-test-subj="detectorsActionsButton"
+                              disabled={true}
+                              iconSide="right"
+                              iconType="arrowDown"
+                              isLoading={false}
+                              onClick={[Function]}
+                            >
+                              Actions
+                            </EuiSmallButton>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="detectorsActionsPopover"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          id="detectorsActionsPopover"
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="none"
+                        >
+                          <EuiContextMenuPanel
+                            hasFocus={true}
+                            items={Array []}
+                            size="s"
+                          />
+                        </EuiPopover>,
+                      ]
+                    }
                   >
                     <EuiFlexGroup
                       alignItems="center"
@@ -814,6 +670,88 @@ exports[`<Detectors /> spec renders the component 1`] = `
                         className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                       >
                         <EuiFlexItem
+                          grow={false}
+                          key="Delete"
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiSmallButton
+                              color="danger"
+                              data-test-subj="deleteButton"
+                              disabled={true}
+                              iconType="trash"
+                              key="Delete"
+                              onClick={[Function]}
+                            >
+                              <EuiButton
+                                color="danger"
+                                data-test-subj="deleteButton"
+                                disabled={true}
+                                iconType="trash"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <EuiButtonDisplay
+                                  baseClassName="euiButton"
+                                  color="danger"
+                                  data-test-subj="deleteButton"
+                                  disabled={true}
+                                  element="button"
+                                  iconType="trash"
+                                  isDisabled={true}
+                                  onClick={[Function]}
+                                  size="s"
+                                  type="button"
+                                >
+                                  <button
+                                    className="euiButton euiButton--danger euiButton--small euiButton-isDisabled"
+                                    data-test-subj="deleteButton"
+                                    disabled={true}
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                    type="button"
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconGap="m"
+                                      iconSide="left"
+                                      iconType="trash"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="trash"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Delete detectors
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonDisplay>
+                              </EuiButton>
+                            </EuiSmallButton>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
                           className="euiSearchBar__searchHolder"
                           grow={true}
                         >
@@ -821,6 +759,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                             className="euiFlexItem euiSearchBar__searchHolder"
                           >
                             <EuiSearchBox
+                              compressed={true}
                               incremental={true}
                               isInvalid={false}
                               onSearch={[Function]}
@@ -829,7 +768,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                             >
                               <EuiFieldSearch
                                 aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
-                                compressed={false}
+                                compressed={true}
                                 defaultValue=""
                                 fullWidth={true}
                                 incremental={true}
@@ -841,13 +780,13 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                 placeholder="Search threat detectors"
                               >
                                 <EuiFormControlLayout
-                                  compressed={false}
+                                  compressed={true}
                                   fullWidth={true}
                                   icon="search"
                                   isLoading={false}
                                 >
                                   <div
-                                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                   >
                                     <div
                                       className="euiFormControlLayout__childrenWrapper"
@@ -857,7 +796,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                       >
                                         <input
                                           aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
-                                          className="euiFieldSearch euiFieldSearch--fullWidth"
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                                           defaultValue=""
                                           onKeyUp={[Function]}
                                           placeholder="Search threat detectors"
@@ -865,7 +804,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                         />
                                       </EuiValidatableControl>
                                       <EuiFormControlLayoutIcons
-                                        compressed={false}
+                                        compressed={true}
                                         icon="search"
                                         isLoading={false}
                                       >
@@ -873,7 +812,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                           className="euiFormControlLayoutIcons"
                                         >
                                           <EuiFormControlLayoutCustomIcon
-                                            size="m"
+                                            size="s"
                                             type="search"
                                           >
                                             <span
@@ -882,7 +821,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                               <EuiIcon
                                                 aria-hidden="true"
                                                 className="euiFormControlLayoutCustomIcon__icon"
-                                                size="m"
+                                                size="s"
                                                 type="search"
                                               >
                                                 EuiIconMock
@@ -909,6 +848,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                               filters={
                                 Array [
                                   Object {
+                                    "compressed": true,
                                     "field": "status",
                                     "multiSelect": "or",
                                     "name": "Status",
@@ -921,6 +861,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                     "type": "field_value_selection",
                                   },
                                   Object {
+                                    "compressed": true,
                                     "field": "logType",
                                     "multiSelect": "or",
                                     "name": "Log type",
@@ -957,7 +898,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
-                                        "compressed": undefined,
+                                        "compressed": true,
                                         "field": "status",
                                         "multiSelect": "or",
                                         "name": "Status",
@@ -1001,6 +942,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           Status
                                         </EuiFilterButton>
@@ -1027,6 +969,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             <EuiButtonEmpty
                                               className="euiFilterButton euiFilterButton--hasIcon"
@@ -1034,6 +977,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                               textProps={
                                                 Object {
                                                   "className": "",
@@ -1042,7 +986,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                               type="button"
                                             >
                                               <button
-                                                className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 type="button"
@@ -1093,7 +1037,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
-                                        "compressed": undefined,
+                                        "compressed": true,
                                         "field": "logType",
                                         "multiSelect": "or",
                                         "name": "Log type",
@@ -1132,6 +1076,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                           iconSide="right"
                                           iconType="arrowDown"
                                           onClick={[Function]}
+                                          size="s"
                                         >
                                           Log type
                                         </EuiFilterButton>
@@ -1158,6 +1103,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                             iconSide="right"
                                             iconType="arrowDown"
                                             onClick={[Function]}
+                                            size="s"
                                           >
                                             <EuiButtonEmpty
                                               className="euiFilterButton euiFilterButton--hasIcon"
@@ -1165,6 +1111,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                               iconSide="right"
                                               iconType="arrowDown"
                                               onClick={[Function]}
+                                              size="s"
                                               textProps={
                                                 Object {
                                                   "className": "",
@@ -1173,7 +1120,7 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                               type="button"
                                             >
                                               <button
-                                                className="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 type="button"
@@ -1224,6 +1171,199 @@ exports[`<Detectors /> spec renders the component 1`] = `
                                 </div>
                               </EuiFilterGroup>
                             </EuiSearchFilters>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiSmallButton
+                              data-test-subj="detectorsRefreshButton"
+                              iconType="refresh"
+                              onClick={[Function]}
+                            >
+                              <EuiButton
+                                data-test-subj="detectorsRefreshButton"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <EuiButtonDisplay
+                                  baseClassName="euiButton"
+                                  data-test-subj="detectorsRefreshButton"
+                                  disabled={false}
+                                  element="button"
+                                  iconType="refresh"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  type="button"
+                                >
+                                  <button
+                                    className="euiButton euiButton--primary euiButton--small"
+                                    data-test-subj="detectorsRefreshButton"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                    type="button"
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconGap="m"
+                                      iconSide="left"
+                                      iconType="refresh"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="refresh"
+                                        >
+                                          EuiIconMock
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButton__text"
+                                        >
+                                          Refresh
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonDisplay>
+                              </EuiButton>
+                            </EuiSmallButton>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiPopover
+                              anchorPosition="downLeft"
+                              button={
+                                <EuiSmallButton
+                                  data-test-subj="detectorsActionsButton"
+                                  disabled={true}
+                                  iconSide="right"
+                                  iconType="arrowDown"
+                                  isLoading={false}
+                                  onClick={[Function]}
+                                >
+                                  Actions
+                                </EuiSmallButton>
+                              }
+                              closePopover={[Function]}
+                              data-test-subj="detectorsActionsPopover"
+                              display="inlineBlock"
+                              hasArrow={true}
+                              id="detectorsActionsPopover"
+                              isOpen={false}
+                              ownFocus={true}
+                              panelPaddingSize="none"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorDownLeft"
+                                data-test-subj="detectorsActionsPopover"
+                                id="detectorsActionsPopover"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <EuiSmallButton
+                                    data-test-subj="detectorsActionsButton"
+                                    disabled={true}
+                                    iconSide="right"
+                                    iconType="arrowDown"
+                                    isLoading={false}
+                                    onClick={[Function]}
+                                  >
+                                    <EuiButton
+                                      data-test-subj="detectorsActionsButton"
+                                      disabled={true}
+                                      iconSide="right"
+                                      iconType="arrowDown"
+                                      isLoading={false}
+                                      onClick={[Function]}
+                                      size="s"
+                                    >
+                                      <EuiButtonDisplay
+                                        baseClassName="euiButton"
+                                        data-test-subj="detectorsActionsButton"
+                                        disabled={true}
+                                        element="button"
+                                        iconSide="right"
+                                        iconType="arrowDown"
+                                        isDisabled={true}
+                                        isLoading={false}
+                                        onClick={[Function]}
+                                        size="s"
+                                        type="button"
+                                      >
+                                        <button
+                                          className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
+                                          data-test-subj="detectorsActionsButton"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          style={
+                                            Object {
+                                              "minWidth": undefined,
+                                            }
+                                          }
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButton__content"
+                                            iconGap="m"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isLoading={false}
+                                            textProps={
+                                              Object {
+                                                "className": "euiButton__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                                            >
+                                              <EuiIcon
+                                                className="euiButtonContent__icon"
+                                                color="inherit"
+                                                size="m"
+                                                type="arrowDown"
+                                              >
+                                                EuiIconMock
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButton__text"
+                                              >
+                                                Actions
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonDisplay>
+                                    </EuiButton>
+                                  </EuiSmallButton>
+                                </div>
+                              </div>
+                            </EuiPopover>
                           </div>
                         </EuiFlexItem>
                       </div>

--- a/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/FindingsTable.tsx
@@ -271,12 +271,14 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
       box: {
         placeholder: 'Search findings',
         schema: true,
+        compressed: true,
       },
       filters: [
         {
           type: 'field_value_selection',
           field: 'ruleSeverity',
           name: 'Severity',
+          compressed: true,
           options: Array.from(severities).map((severity) => {
             const name =
               parseAlertSeverityToOption(severity)?.label || capitalizeFirstLetter(severity);
@@ -288,6 +290,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
           type: 'field_value_selection',
           field: 'logType',
           name: 'Log type',
+          compressed: true,
           options: Array.from(logTypes).map((type) => ({
             value: type,
             name: formatRuleType(type),
@@ -298,6 +301,7 @@ export default class FindingsTable extends Component<FindingsTableProps, Finding
           type: 'field_value_selection',
           field: 'detectionType',
           name: 'Detection type',
+          compressed: true,
           options: [
             {
               value: 'Detection rules',

--- a/public/pages/Findings/components/FindingsTable/ThreatIntelFindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/ThreatIntelFindingsTable.tsx
@@ -68,5 +68,11 @@ export const ThreatIntelFindingsTable: React.FC<ThreatIntelFindingsTableProps> =
     },
   ];
 
-  return <EuiInMemoryTable columns={columns} items={findingItems} pagination search />;
+  const search = {
+    box: {
+      compressed: true,
+    },
+  };
+
+  return <EuiInMemoryTable columns={columns} items={findingItems} pagination search={search} />;
 };

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -625,7 +625,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
     );
 
     return (
-      <EuiFlexGroup direction="column">
+      <EuiFlexGroup direction="column" gutterSize={'m'}>
         <PageHeader
           appRightControls={[
             {
@@ -642,7 +642,6 @@ class Findings extends Component<FindingsProps, FindingsState> {
               </EuiFlexItem>
               <EuiFlexItem grow={false}>{datePicker}</EuiFlexItem>
             </EuiFlexGroup>
-            <EuiSpacer size={'m'} />
           </EuiFlexItem>
         </PageHeader>
 

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -565,31 +565,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
         content: (
           <>
             <EuiSpacer size={'m'} />
-            <EuiPanel>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                  {this.createGroupByControl()}
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  {!findings || findings.length === 0 ? (
-                    <EuiEmptyPrompt
-                      title={
-                        <EuiText size="s">
-                          <h2>No findings</h2>
-                        </EuiText>
-                      }
-                      body={
-                        <EuiText size="s">
-                          {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}
-                        </EuiText>
-                      }
-                    />
-                  ) : (
-                    <ChartContainer chartViewId={'findings-view'} loading={loading} />
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPanel>
+            {this.getFindingsGraph(findings, loading)}
             <EuiSpacer size={'m'} />
             <ContentPanel title={'Findings'}>
               <FindingsTable
@@ -624,31 +600,7 @@ class Findings extends Component<FindingsProps, FindingsState> {
         content: (
           <>
             <EuiSpacer size={'m'} />
-            <EuiPanel>
-              <EuiFlexGroup direction="column">
-                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                  {this.createGroupByControl()}
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  {!findings || findings.length === 0 ? (
-                    <EuiEmptyPrompt
-                      title={
-                        <EuiText size="s">
-                          <h2>No findings</h2>
-                        </EuiText>
-                      }
-                      body={
-                        <EuiText size="s">
-                          {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}
-                        </EuiText>
-                      }
-                    />
-                  ) : (
-                    <ChartContainer chartViewId={'findings-view'} loading={loading} />
-                  )}
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPanel>
+            {this.getFindingsGraph(findings, loading)}
             <EuiSpacer size={'m'} />
             <ContentPanel title={'Findings'}>
               <ThreatIntelFindingsTable
@@ -705,6 +657,34 @@ class Findings extends Component<FindingsProps, FindingsState> {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
+    );
+  }
+
+  private getFindingsGraph(findings: ThreatIntelFinding[] | FindingItemType[], loading: boolean) {
+    return (
+      <EuiPanel>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem style={{ alignSelf: 'flex-end' }}>{this.createGroupByControl()}</EuiFlexItem>
+          <EuiFlexItem>
+            {!findings || findings.length === 0 ? (
+              <EuiEmptyPrompt
+                title={
+                  <EuiText size="s">
+                    <h2>No findings</h2>
+                  </EuiText>
+                }
+                body={
+                  <EuiText size="s">
+                    {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}
+                  </EuiText>
+                }
+              />
+            ) : (
+              <ChartContainer chartViewId={'findings-view'} loading={loading} />
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
     );
   }
 }

--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -564,22 +564,50 @@ class Findings extends Component<FindingsProps, FindingsState> {
         ),
         content: (
           <>
-            <EuiSpacer />
-            <FindingsTable
-              {...this.props}
-              history={this.props.history}
-              findings={findings as FindingItemType[]}
-              loading={loading}
-              rules={rules}
-              startTime={dateTimeFilter.startTime}
-              endTime={dateTimeFilter.endTime}
-              onRefresh={this.onRefresh}
-              notificationChannels={parseNotificationChannelsToOptions(notificationChannels)}
-              refreshNotificationChannels={this.getNotificationChannels}
-              onFindingsFiltered={this.onFindingsFiltered}
-              hasNotificationsPlugin={getIsNotificationPluginInstalled()}
-              correlationService={this.props.correlationService}
-            />
+            <EuiSpacer size={'m'} />
+            <EuiPanel>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
+                  {this.createGroupByControl()}
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  {!findings || findings.length === 0 ? (
+                    <EuiEmptyPrompt
+                      title={
+                        <EuiText size="s">
+                          <h2>No findings</h2>
+                        </EuiText>
+                      }
+                      body={
+                        <EuiText size="s">
+                          {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}
+                        </EuiText>
+                      }
+                    />
+                  ) : (
+                    <ChartContainer chartViewId={'findings-view'} loading={loading} />
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size={'m'} />
+            <ContentPanel title={'Findings'}>
+              <FindingsTable
+                {...this.props}
+                history={this.props.history}
+                findings={findings as FindingItemType[]}
+                loading={loading}
+                rules={rules}
+                startTime={dateTimeFilter.startTime}
+                endTime={dateTimeFilter.endTime}
+                onRefresh={this.onRefresh}
+                notificationChannels={parseNotificationChannelsToOptions(notificationChannels)}
+                refreshNotificationChannels={this.getNotificationChannels}
+                onFindingsFiltered={this.onFindingsFiltered}
+                hasNotificationsPlugin={getIsNotificationPluginInstalled()}
+                correlationService={this.props.correlationService}
+              />
+            </ContentPanel>
           </>
         ),
       },
@@ -595,10 +623,38 @@ class Findings extends Component<FindingsProps, FindingsState> {
         ),
         content: (
           <>
-            <EuiSpacer />
-            <ThreatIntelFindingsTable
-              findingItems={findingStateByTabId[FindingTabId.ThreatIntel].findings}
-            />
+            <EuiSpacer size={'m'} />
+            <EuiPanel>
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
+                  {this.createGroupByControl()}
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  {!findings || findings.length === 0 ? (
+                    <EuiEmptyPrompt
+                      title={
+                        <EuiText size="s">
+                          <h2>No findings</h2>
+                        </EuiText>
+                      }
+                      body={
+                        <EuiText size="s">
+                          {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}
+                        </EuiText>
+                      }
+                    />
+                  ) : (
+                    <ChartContainer chartViewId={'findings-view'} loading={loading} />
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size={'m'} />
+            <ContentPanel title={'Findings'}>
+              <ThreatIntelFindingsTable
+                findingItems={findingStateByTabId[FindingTabId.ThreatIntel].findings}
+              />
+            </ContentPanel>
           </>
         ),
       },
@@ -637,47 +693,16 @@ class Findings extends Component<FindingsProps, FindingsState> {
             <EuiSpacer size={'m'} />
           </EuiFlexItem>
         </PageHeader>
-        <EuiFlexItem>
-          <EuiPanel>
-            <EuiFlexGroup direction="column">
-              <EuiFlexItem style={{ alignSelf: 'flex-end' }}>
-                {this.createGroupByControl()}
-              </EuiFlexItem>
-              <EuiFlexItem>
-                {!findings || findings.length === 0 ? (
-                  <EuiEmptyPrompt
-                    title={
-                      <EuiText size="s">
-                        <h2>No findings</h2>
-                      </EuiText>
-                    }
-                    body={
-                      <EuiText size="s">
-                        {this.state.findingStateByTabId[this.state.selectedTabId].emptyPromptBody}
-                      </EuiText>
-                    }
-                  />
-                ) : (
-                  <ChartContainer chartViewId={'findings-view'} loading={loading} />
-                )}
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPanel>
-
-          <EuiSpacer size={'xxl'} />
-        </EuiFlexItem>
 
         <EuiFlexItem>
-          <ContentPanel title={'Findings'}>
-            <EuiTabbedContent
-              tabs={tabs}
-              size="s"
-              initialSelectedTab={tabs.find(({ id }) => id === selectedTabId) ?? tabs[0]}
-              onTabClick={(tab) => {
-                this.setState({ selectedTabId: tab.id as FindingTabId });
-              }}
-            />
-          </ContentPanel>
+          <EuiTabbedContent
+            tabs={tabs}
+            size="s"
+            initialSelectedTab={tabs.find(({ id }) => id === selectedTabId) ?? tabs[0]}
+            onTabClick={(tab) => {
+              this.setState({ selectedTabId: tab.id as FindingTabId });
+            }}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/pages/LogTypes/utils/helpers.tsx
+++ b/public/pages/LogTypes/utils/helpers.tsx
@@ -65,12 +65,14 @@ export const getLogTypesTableSearchConfig = (): Search => {
     box: {
       placeholder: 'Search log types',
       schema: true,
+      compressed: true,
     },
     filters: [
       {
         type: 'field_value_selection',
         field: 'category',
         name: 'Category',
+        compressed: true,
         multiSelect: 'or',
         options: logTypeCategories.map((category) => ({
           value: category,
@@ -80,6 +82,7 @@ export const getLogTypesTableSearchConfig = (): Search => {
         type: 'field_value_selection',
         field: 'source',
         name: 'Source',
+        compressed: true,
         multiSelect: 'or',
         options: ruleSource.map((source: string) => ({
           value: source,

--- a/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiSmallButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton } from '@elastic/eui';
 import { ROUTES, SortDirection } from '../../../../utils/constants';
 import React, { useEffect, useState } from 'react';
 import { TableWidget } from './TableWidget';
 import { WidgetContainer } from './WidgetContainer';
-import { getAlertSeverityBadge, renderTime } from '../../../../utils/helpers';
+import { getAlertSeverityBadge, getEuiEmptyPrompt, renderTime } from '../../../../utils/helpers';
 import { OverviewAlertItem } from '../../../../../types';
 
 const columns: EuiBasicTableColumn<OverviewAlertItem>[] = [
@@ -62,19 +62,7 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
   return (
     <WidgetContainer title={'Recent threat alerts'} actions={actions}>
       {alertItems.length === 0 ? (
-        <EuiEmptyPrompt
-          style={{ position: 'relative' }}
-          body={
-            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
-              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
-                <EuiText size="s">
-                  <span style={{ display: 'block' }}>No recent alerts.</span>Adjust the time range
-                  to see more results.
-                </EuiText>
-              </p>
-            </div>
-          }
-        />
+        getEuiEmptyPrompt('No recent alerts.')
       ) : (
         <TableWidget
           columns={columns}

--- a/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
@@ -65,7 +65,7 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
         <EuiEmptyPrompt
           style={{ position: 'relative' }}
           body={
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
               <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
                 <EuiText size="s">
                   <span style={{ display: 'block' }}>No recent alerts.</span>Adjust the time range

--- a/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentAlertsWidget.tsx
@@ -44,9 +44,6 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
   loading = false,
 }) => {
   const [alertItems, setAlertItems] = useState<OverviewAlertItem[]>([]);
-  const [widgetEmptyMessage, setwidgetEmptyMessage] = useState<React.ReactNode | undefined>(
-    undefined
-  );
 
   useEffect(() => {
     items.sort((a, b) => {
@@ -55,18 +52,6 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
       return timeB - timeA;
     });
     setAlertItems(items.slice(0, 20));
-    setwidgetEmptyMessage(
-      items.length > 0 ? undefined : (
-        <EuiEmptyPrompt
-          body={
-            <EuiText size="s">
-              <span style={{ display: 'block' }}>No recent alerts.</span>Adjust the time range to
-              see more results.
-            </EuiText>
-          }
-        />
-      )
-    );
   }, [items]);
 
   const actions = React.useMemo(
@@ -76,14 +61,28 @@ export const RecentAlertsWidget: React.FC<RecentAlertsWidgetProps> = ({
 
   return (
     <WidgetContainer title={'Recent threat alerts'} actions={actions}>
-      <TableWidget
-        columns={columns}
-        items={alertItems}
-        sorting={{ sort: { field: 'time', direction: SortDirection.DESC } }}
-        loading={loading}
-        message={widgetEmptyMessage}
-        className={widgetEmptyMessage ? 'sa-overview-widget-empty' : undefined}
-      />
+      {alertItems.length === 0 ? (
+        <EuiEmptyPrompt
+          style={{ position: 'relative' }}
+          body={
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
+                <EuiText size="s">
+                  <span style={{ display: 'block' }}>No recent alerts.</span>Adjust the time range
+                  to see more results.
+                </EuiText>
+              </p>
+            </div>
+          }
+        />
+      ) : (
+        <TableWidget
+          columns={columns}
+          items={alertItems}
+          sorting={{ sort: { field: 'time', direction: SortDirection.DESC } }}
+          loading={loading}
+        />
+      )}
     </WidgetContainer>
   );
 };

--- a/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
@@ -53,27 +53,12 @@ export const RecentFindingsWidget: React.FC<RecentFindingsWidgetProps> = ({
   loading = false,
 }) => {
   const [findingItems, setFindingItems] = useState<OverviewFindingItem[]>([]);
-  const [widgetEmptyMessage, setWidgetEmptyMessage] = useState<React.ReactNode | undefined>(
-    undefined
-  );
 
   useEffect(() => {
     items.sort((a, b) => {
       return b.time - a.time;
     });
     setFindingItems(items.slice(0, 20));
-    setWidgetEmptyMessage(
-      items.length > 0 ? undefined : (
-        <EuiEmptyPrompt
-          body={
-            <EuiText size="s">
-              <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range to
-              see more results.
-            </EuiText>
-          }
-        />
-      )
-    );
   }, [items]);
 
   const actions = React.useMemo(() => {
@@ -83,14 +68,28 @@ export const RecentFindingsWidget: React.FC<RecentFindingsWidgetProps> = ({
 
   return (
     <WidgetContainer title={'Recent detection rule findings'} actions={actions}>
-      <TableWidget
-        columns={columns}
-        items={findingItems}
-        sorting={{ sort: { field: 'time', direction: SortDirection.DESC } }}
-        loading={loading}
-        message={widgetEmptyMessage}
-        className={widgetEmptyMessage ? 'sa-overview-widget-empty' : undefined}
-      />
+      {findingItems.length === 0 ? (
+        <EuiEmptyPrompt
+          style={{ position: 'relative' }}
+          body={
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
+                <EuiText size="s">
+                  <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range
+                  to see more results.
+                </EuiText>
+              </p>
+            </div>
+          }
+        />
+      ) : (
+        <TableWidget
+          columns={columns}
+          items={findingItems}
+          sorting={{ sort: { field: 'time', direction: SortDirection.DESC } }}
+          loading={loading}
+        />
+      )}
     </WidgetContainer>
   );
 };

--- a/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
@@ -72,7 +72,7 @@ export const RecentFindingsWidget: React.FC<RecentFindingsWidgetProps> = ({
         <EuiEmptyPrompt
           style={{ position: 'relative' }}
           body={
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
               <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
                 <EuiText size="s">
                   <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range

--- a/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentFindingsWidget.tsx
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiSmallButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton } from '@elastic/eui';
 import { FINDINGS_NAV_ID, ROUTES, SortDirection } from '../../../../utils/constants';
 import React, { useEffect, useState } from 'react';
 import { TableWidget } from './TableWidget';
 import { WidgetContainer } from './WidgetContainer';
-import { renderTime, getSeverityBadge } from '../../../../utils/helpers';
+import { renderTime, getSeverityBadge, getEuiEmptyPrompt } from '../../../../utils/helpers';
 import { OverviewFindingItem } from '../../../../../types';
 import { getApplication, getUseUpdatedUx } from '../../../../services/utils/constants';
 
@@ -69,19 +69,7 @@ export const RecentFindingsWidget: React.FC<RecentFindingsWidgetProps> = ({
   return (
     <WidgetContainer title={'Recent detection rule findings'} actions={actions}>
       {findingItems.length === 0 ? (
-        <EuiEmptyPrompt
-          style={{ position: 'relative' }}
-          body={
-            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
-              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
-                <EuiText size="s">
-                  <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range
-                  to see more results.
-                </EuiText>
-              </p>
-            </div>
-          }
-        />
+        getEuiEmptyPrompt('No recent findings.')
       ) : (
         <TableWidget
           columns={columns}

--- a/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
@@ -81,7 +81,7 @@ export const RecentThreatIntelFindingsWidget: React.FC<RecentThreatIntelFindings
         <EuiEmptyPrompt
           style={{ position: 'relative' }}
           body={
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
               <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
                 <EuiText size="s">
                   <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range

--- a/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTableColumn, EuiSmallButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSmallButton } from '@elastic/eui';
 import {
   DEFAULT_EMPTY_DATA,
   FINDINGS_NAV_ID,
@@ -14,7 +14,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import { TableWidget } from './TableWidget';
 import { WidgetContainer } from './WidgetContainer';
-import { renderTime } from '../../../../utils/helpers';
+import { getEuiEmptyPrompt, renderTime } from '../../../../utils/helpers';
 import { ThreatIntelFinding } from '../../../../../types';
 import { getApplication } from '../../../../services/utils/constants';
 import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
@@ -78,19 +78,7 @@ export const RecentThreatIntelFindingsWidget: React.FC<RecentThreatIntelFindings
   return (
     <WidgetContainer title={'Recent threat intel findings'} actions={actions}>
       {findingItems.length === 0 ? (
-        <EuiEmptyPrompt
-          style={{ position: 'relative' }}
-          body={
-            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
-              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
-                <EuiText size="s">
-                  <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range
-                  to see more results.
-                </EuiText>
-              </p>
-            </div>
-          }
-        />
+        getEuiEmptyPrompt('No recent findings.')
       ) : (
         <TableWidget
           columns={columns}

--- a/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
@@ -55,27 +55,12 @@ export const RecentThreatIntelFindingsWidget: React.FC<RecentThreatIntelFindings
   loading = false,
 }) => {
   const [findingItems, setFindingItems] = useState<ThreatIntelFinding[]>([]);
-  const [widgetEmptyMessage, setWidgetEmptyMessage] = useState<React.ReactNode | undefined>(
-    undefined
-  );
 
   useEffect(() => {
     items.sort((a, b) => {
       return b.timestamp - a.timestamp;
     });
     setFindingItems(items.slice(0, 20));
-    setWidgetEmptyMessage(
-      items.length > 0 ? undefined : (
-        <EuiEmptyPrompt
-          body={
-            <EuiText size="s">
-              <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range to
-              see more results.
-            </EuiText>
-          }
-        />
-      )
-    );
   }, [items]);
 
   const threatIntelFindingsUrl = `${getApplication().getUrlForApp(FINDINGS_NAV_ID, {
@@ -92,14 +77,28 @@ export const RecentThreatIntelFindingsWidget: React.FC<RecentThreatIntelFindings
 
   return (
     <WidgetContainer title={'Recent threat intel findings'} actions={actions}>
-      <TableWidget
-        columns={columns}
-        items={findingItems}
-        sorting={{ sort: { field: 'timestamp', direction: SortDirection.DESC } }}
-        loading={loading}
-        message={widgetEmptyMessage}
-        className={widgetEmptyMessage ? 'sa-overview-widget-empty' : undefined}
-      />
+      {findingItems.length === 0 ? (
+        <EuiEmptyPrompt
+          style={{ position: 'relative' }}
+          body={
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
+                <EuiText size="s">
+                  <span style={{ display: 'block' }}>No recent findings.</span>Adjust the time range
+                  to see more results.
+                </EuiText>
+              </p>
+            </div>
+          }
+        />
+      ) : (
+        <TableWidget
+          columns={columns}
+          items={findingItems}
+          sorting={{ sort: { field: 'timestamp', direction: SortDirection.DESC } }}
+          loading={loading}
+        />
+      )}
     </WidgetContainer>
   );
 };

--- a/public/pages/Overview/components/Widgets/Summary.tsx
+++ b/public/pages/Overview/components/Widgets/Summary.tsx
@@ -170,12 +170,16 @@ export const Summary: React.FC<SummaryProps> = ({
         <EuiFlexItem>
           {activeAlerts === 0 && totalFindings === 0 ? (
             <EuiEmptyPrompt
-              title={<EuiText size="s"><h2>No alerts and findings found</h2></EuiText>}
+              title={
+                <EuiText size="s">
+                  <h2>No alerts and findings found</h2>
+                </EuiText>
+              }
               body={
                 <>
                   <p>
                     <EuiText size="s">
-                      Adjust the time range to see more results or create a <br/>
+                      Adjust the time range to see more results or create a <br />
                       detector to generate findings.
                     </EuiText>
                   </p>
@@ -183,6 +187,9 @@ export const Summary: React.FC<SummaryProps> = ({
                     href={`#${ROUTES.DETECTORS_CREATE}`}
                     fill={true}
                     data-test-subj={'detectorsCreateButton'}
+                    iconType="plus"
+                    iconSide="left"
+                    iconGap="s"
                   >
                     Create a detector
                   </EuiSmallButton>

--- a/public/pages/Overview/components/Widgets/TopRulesWidget.tsx
+++ b/public/pages/Overview/components/Widgets/TopRulesWidget.tsx
@@ -40,10 +40,10 @@ export const TopRulesWidget: React.FC<TopRulesWidgetProps> = ({ findings, loadin
         <EuiEmptyPrompt
           style={{ position: 'relative' }}
           body={
-            <div style={{ display: 'flex', justifyContent: 'center' }}>
-              <p style={{position: 'absolute', top: 'calc(50% - 20px)'}}>
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
+              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
                 <EuiText size="s">
-                  <span style={{display: 'block'}}>No findings with detection rules.</span>Adjust
+                  <span style={{ display: 'block' }}>No findings with detection rules.</span>Adjust
                   the time range to see more results.
                 </EuiText>
               </p>
@@ -51,7 +51,7 @@ export const TopRulesWidget: React.FC<TopRulesWidgetProps> = ({ findings, loadin
           }
         />
       ) : (
-        <ChartContainer chartViewId={'top-rules-view'} loading={loading}/>
+        <ChartContainer chartViewId={'top-rules-view'} loading={loading} />
       )}
     </WidgetContainer>
   );

--- a/public/pages/Overview/components/Widgets/TopRulesWidget.tsx
+++ b/public/pages/Overview/components/Widgets/TopRulesWidget.tsx
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { renderVisualization } from '../../../../utils/helpers';
+import { getEuiEmptyPrompt, renderVisualization } from '../../../../utils/helpers';
 import React, { useEffect } from 'react';
 import { WidgetContainer } from './WidgetContainer';
 import { getTopRulesVisualizationSpec } from '../../utils/helpers';
 import { ChartContainer } from '../../../../components/Charts/ChartContainer';
-import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import { OverviewFindingItem } from '../../../../../types';
 
 export interface TopRulesWidgetProps {
@@ -37,19 +36,7 @@ export const TopRulesWidget: React.FC<TopRulesWidgetProps> = ({ findings, loadin
   return (
     <WidgetContainer title="Most frequent detection rules">
       {findings.length === 0 ? (
-        <EuiEmptyPrompt
-          style={{ position: 'relative' }}
-          body={
-            <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
-              <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
-                <EuiText size="s">
-                  <span style={{ display: 'block' }}>No findings with detection rules.</span>Adjust
-                  the time range to see more results.
-                </EuiText>
-              </p>
-            </div>
-          }
-        />
+        getEuiEmptyPrompt('No findings with detection rules.')
       ) : (
         <ChartContainer chartViewId={'top-rules-view'} loading={loading} />
       )}

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -216,6 +216,9 @@ export const Overview: React.FC<OverviewProps> = (props) => {
       href={`#${ROUTES.DETECTORS_CREATE}`}
       fill={true}
       data-test-subj={'detectorsCreateButton'}
+      iconType="plus"
+      iconSide="left"
+      iconGap="s"
     >
       Create detector
     </EuiSmallButton>

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -261,7 +261,6 @@ export const Overview: React.FC<OverviewProps> = (props) => {
             <EuiFlexItem grow={false}>{datePicker}</EuiFlexItem>
             <EuiFlexItem grow={false}>{createDetectorAction}</EuiFlexItem>
           </EuiFlexGroup>
-          <EuiSpacer size={'m'} />
         </EuiFlexItem>
       </PageHeader>
       {getUseUpdatedUx() && (

--- a/public/pages/Overview/containers/Overview/Overview.tsx
+++ b/public/pages/Overview/containers/Overview/Overview.tsx
@@ -243,7 +243,7 @@ export const Overview: React.FC<OverviewProps> = (props) => {
   };
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize={'m'}>
       <PageHeader
         appRightControls={[
           { renderComponent: datePicker },

--- a/public/pages/Overview/utils/constants.ts
+++ b/public/pages/Overview/utils/constants.ts
@@ -98,7 +98,7 @@ export const getOverviewStatsProps = ({
   return [
     {
       title: alerts,
-      description: 'Total active alerts',
+      description: 'Total active threat alerts',
     },
     {
       title: correlations,

--- a/public/pages/Overview/utils/constants.ts
+++ b/public/pages/Overview/utils/constants.ts
@@ -7,7 +7,7 @@ import { EuiCardProps, EuiStatProps } from '@elastic/eui';
 import {
   CORRELATIONS_RULE_NAV_ID,
   DETECTORS_NAV_ID,
-  GETTING_STARTED_NAV_ID,
+  GET_STARTED_NAV_ID,
   THREAT_ALERTS_NAV_ID,
   THREAT_INTEL_NAV_ID,
 } from '../../../utils/constants';
@@ -26,7 +26,7 @@ export const getOverviewsCardsProps = (): EuiCardProps[] => [
     description: 'Set up tools and components to get started.',
     selectable: {
       onClick: () => {
-        getApplication().navigateToApp(GETTING_STARTED_NAV_ID);
+        getApplication().navigateToApp(GET_STARTED_NAV_ID);
       },
       children: 'Getting started guide',
       isDisabled: false,

--- a/public/pages/Overview/utils/constants.ts
+++ b/public/pages/Overview/utils/constants.ts
@@ -67,7 +67,7 @@ export const getOverviewsCardsProps = (): EuiCardProps[] => [
   },
   {
     title: 'Correlate events',
-    description: 'Detect multi-system threats with correlation rule builder',
+    description: 'Detect multi-system threats with correlation rule builder.',
     selectable: {
       onClick: () => {
         getApplication().navigateToApp(CORRELATIONS_RULE_NAV_ID);

--- a/public/pages/Rules/components/RulesTable/__snapshots__/RulesTable.test.tsx.snap
+++ b/public/pages/Rules/components/RulesTable/__snapshots__/RulesTable.test.tsx.snap
@@ -13,14 +13,14 @@ Object {
             class="euiFlexItem euiSearchBar__searchHolder"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                  class="euiFieldSearch euiFieldSearch--fullWidth"
+                  class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                   placeholder="Search rules"
                   type="search"
                   value=""
@@ -51,7 +51,7 @@ Object {
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                     type="button"
                   >
                     <span
@@ -81,7 +81,7 @@ Object {
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                     type="button"
                   >
                     <span
@@ -111,7 +111,7 @@ Object {
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                     type="button"
                   >
                     <span
@@ -353,14 +353,14 @@ Object {
           class="euiFlexItem euiSearchBar__searchHolder"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
               <input
                 aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                class="euiFieldSearch euiFieldSearch--fullWidth"
+                class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                 placeholder="Search rules"
                 type="search"
                 value=""
@@ -391,7 +391,7 @@ Object {
                 class="euiPopover__anchor"
               >
                 <button
-                  class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                   type="button"
                 >
                   <span
@@ -421,7 +421,7 @@ Object {
                 class="euiPopover__anchor"
               >
                 <button
-                  class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                   type="button"
                 >
                   <span
@@ -451,7 +451,7 @@ Object {
                 class="euiPopover__anchor"
               >
                 <button
-                  class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon"
                   type="button"
                 >
                   <span

--- a/public/pages/Rules/containers/Rules/Rules.tsx
+++ b/public/pages/Rules/containers/Rules/Rules.tsx
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSmallButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiSmallButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { RulesTable } from '../../components/RulesTable/RulesTable';
@@ -93,7 +100,7 @@ export const Rules: React.FC<RulesProps> = (props) => {
           notifications={props.notifications}
         />
       ) : null}
-      <EuiFlexGroup direction="column">
+      <EuiFlexGroup direction="column" gutterSize={'m'}>
         <PageHeader
           appRightControls={headerActions.map((action) => ({
             renderComponent: action,
@@ -116,7 +123,6 @@ export const Rules: React.FC<RulesProps> = (props) => {
                 </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
-            <EuiSpacer size={'m'} />
           </EuiFlexItem>
         </PageHeader>
         <EuiFlexItem>

--- a/public/pages/Rules/utils/helpers.tsx
+++ b/public/pages/Rules/utils/helpers.tsx
@@ -107,12 +107,14 @@ export const getRulesTableSearchConfig = (): Search => {
     box: {
       placeholder: 'Search rules',
       schema: true,
+      compressed: true,
     },
     filters: [
       {
         type: 'field_value_selection',
         field: 'category',
         name: 'Log type',
+        compressed: true,
         multiSelect: 'or',
         options: getLogTypeFilterOptions(),
       },
@@ -120,6 +122,7 @@ export const getRulesTableSearchConfig = (): Search => {
         type: 'field_value_selection',
         field: 'level',
         name: 'Rule severity',
+        compressed: true,
         multiSelect: 'or',
         options: ruleSeverity,
       },
@@ -127,6 +130,7 @@ export const getRulesTableSearchConfig = (): Search => {
         type: 'field_value_selection',
         field: 'source',
         name: 'Source',
+        compressed: true,
         multiSelect: 'or',
         options: ruleSource.map((source: string) => ({
           value: source,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -19,7 +19,7 @@ import {
   DETECTORS_NAV_ID,
   DETECTION_RULE_NAV_ID,
   FINDINGS_NAV_ID,
-  GETTING_STARTED_NAV_ID,
+  GET_STARTED_NAV_ID,
   LOG_TYPES_NAV_ID,
   OVERVIEW_NAV_ID,
   PLUGIN_NAME,
@@ -122,8 +122,8 @@ export class SecurityAnalyticsPlugin
       });
 
       core.application.register({
-        id: GETTING_STARTED_NAV_ID,
-        title: 'Getting started',
+        id: GET_STARTED_NAV_ID,
+        title: 'Get started',
         order: 1,
         updater$: this.appStateUpdater,
         mount: async (params: AppMountParameters) => {
@@ -227,7 +227,7 @@ export class SecurityAnalyticsPlugin
 
       const navlinks = [
         { id: OVERVIEW_NAV_ID, showInAllNavGroup: true },
-        { id: GETTING_STARTED_NAV_ID, showInAllNavGroup: true },
+        { id: GET_STARTED_NAV_ID, showInAllNavGroup: true },
         { id: THREAT_ALERTS_NAV_ID, showInAllNavGroup: true },
         { id: FINDINGS_NAV_ID, showInAllNavGroup: true },
         { id: CORRELATIONS_NAV_ID },

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -23,7 +23,7 @@ export const OS_NOTIFICATION_PLUGIN = 'opensearch-notifications';
 
 export const DEFAULT_EMPTY_DATA = '-';
 export const OVERVIEW_NAV_ID = `sa_overview`;
-export const GETTING_STARTED_NAV_ID = `getting_started`;
+export const GET_STARTED_NAV_ID = `get_started`;
 export const THREAT_ALERTS_NAV_ID = `threat_alerts`;
 export const FINDINGS_NAV_ID = `findings`;
 export const CORRELATIONS_NAV_ID = `correlations`;

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -81,7 +81,7 @@ export const getNotificationDetailsHref = (channelId: string) =>
 export const BREADCRUMBS = Object.freeze({
   SECURITY_ANALYTICS: { text: 'Security Analytics', href: '#/' },
   OVERVIEW: { text: 'Overview', href: `#${ROUTES.OVERVIEW}` },
-  GETTING_STARTED: { text: 'Getting started', href: `#${ROUTES.GETTING_STARTED}` },
+  GETTING_STARTED: { text: 'Get started', href: `#${ROUTES.GETTING_STARTED}` },
   FINDINGS: { text: 'Findings', href: `#${ROUTES.FINDINGS}` },
   DETECTORS: { text: 'Threat detectors', href: `#${ROUTES.DETECTORS}` },
   DETECTORS_CREATE: { text: 'Create detector', href: `#${ROUTES.DETECTORS_CREATE}` },

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -14,6 +14,7 @@ import {
   EuiText,
   EuiBadge,
   euiPaletteColorBlind,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import moment from 'moment';
 import { PeriodSchedule } from '../../models/interfaces';
@@ -702,6 +703,24 @@ export function registerThreatAlertsCard() {
       ),
     }),
   });
+}
+
+export function getEuiEmptyPrompt(message: string) {
+  return (
+    <EuiEmptyPrompt
+      style={{ position: 'relative' }}
+      body={
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '32px' }}>
+          <p style={{ position: 'absolute', top: 'calc(50% - 20px)' }}>
+            <EuiText size="s">
+              <p style={{ margin: 0 }}>{message}</p>
+              <p style={{ margin: 0 }}>Adjust the time range to see more results.</p>
+            </EuiText>
+          </p>
+        </div>
+      }
+    />
+  );
 }
 
 export function initializeServices(coreStart: CoreStart, indexPattern: CoreIndexPatternsService) {


### PR DESCRIPTION
### Description
Addresses the fit and finish UX changes. Changes in this PR include:
- Add a delete detector bulk action button to the left of the search bar instead of under actions
![Screenshot 2024-09-27 at 2 28 32 PM](https://github.com/user-attachments/assets/15cba328-43aa-4b8e-ba92-7e4e758aa4bc)

- Change getting started to get started
![Screenshot 2024-09-27 at 2 28 44 PM](https://github.com/user-attachments/assets/04d9d6c3-003d-4142-a6a2-259b15aca995)

- Move refresh and action buttons inside the table on threat detectors page
![Screenshot 2024-09-27 at 2 29 12 PM](https://github.com/user-attachments/assets/968d21bf-728f-43c2-b532-3d9bd98d3dee)

- Move the tabs to the top of the page for findings and alerts pages
![Screenshot 2024-09-27 at 2 29 29 PM](https://github.com/user-attachments/assets/b6aa3d9b-b9f2-4ad0-95c2-8e25702782d0)
![Screenshot 2024-09-27 at 2 29 39 PM](https://github.com/user-attachments/assets/119057f2-3a7b-4e10-8e77-219d568ac8e0)

- Add plus icon to left of create detector button
![Screenshot 2024-09-27 at 2 23 14 PM](https://github.com/user-attachments/assets/ee498ce6-6524-46ee-9846-6fb26e16da07)

- Make search bar and filters compressed
![Screenshot 2024-09-27 at 2 30 32 PM](https://github.com/user-attachments/assets/e5c6f82a-8caf-4ad6-bb0f-79ed509919d9)

- Change content panel title from H2 small to H3 small
![Screenshot 2024-09-27 at 2 31 07 PM](https://github.com/user-attachments/assets/d126845a-4386-48a1-95b9-da693f2f1269)


- Fix spacing between all pages sections (16px)
![Screenshot 2024-09-27 at 2 25 22 PM](https://github.com/user-attachments/assets/4be8e852-b719-4a7c-bc1a-c9794acb8384)

- Remove hover state from empty message for Overview page widgets
![Screenshot 2024-09-27 at 2 25 58 PM](https://github.com/user-attachments/assets/326facfd-f5c0-403a-8a8e-77cb4be1e36b)

- Change "total active alerts" to "total active threat alerts"
![Screenshot 2024-09-27 at 2 26 37 PM](https://github.com/user-attachments/assets/84d68f19-e453-43bb-a1ab-c5507477f05c)

- Fix padding to 16px for all content panels
![Screenshot 2024-09-27 at 2 26 56 PM](https://github.com/user-attachments/assets/918ac418-741c-473d-9b88-61543d5fd05a)

- Add period to end of correlate events description
![Screenshot 2024-09-27 at 2 27 32 PM](https://github.com/user-attachments/assets/7ab1c429-7929-4e6f-bf94-ef7598ec5935)

- Fixes spacing from header to content when newHomePage isn't enabled
<img width="1365" alt="Screenshot 2024-09-27 at 4 25 00 PM" src="https://github.com/user-attachments/assets/3e54da38-30fd-4c75-8c51-d6142ea0818e">


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).