### PR TITLE
Bug fixes for threat intel, duplicate findings, and breadcrumbs path

### DIFF
--- a/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
@@ -16,7 +16,7 @@ import { TableWidget } from './TableWidget';
 import { WidgetContainer } from './WidgetContainer';
 import { renderTime } from '../../../../utils/helpers';
 import { ThreatIntelFinding } from '../../../../../types';
-import { getApplication } from '../../../../services/utils/constants';
+import { getApplication, getUseUpdatedUx } from '../../../../services/utils/constants';
 import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
 
 const columns: EuiBasicTableColumn<ThreatIntelFinding>[] = [
@@ -78,17 +78,16 @@ export const RecentThreatIntelFindingsWidget: React.FC<RecentThreatIntelFindings
     );
   }, [items]);
 
-  const threatIntelFindingsUrl = `${getApplication().getUrlForApp(FINDINGS_NAV_ID, {
-    path: `#${ROUTES.FINDINGS}`,
-  })}?detectionType=${FindingTabId.ThreatIntel}`;
-  const actions = React.useMemo(
-    () => [
-      <EuiSmallButton onClick={() => getApplication().navigateToUrl(threatIntelFindingsUrl)}>
+  const actions = React.useMemo(() => {
+    const baseUrl = getUseUpdatedUx() ? getApplication().getUrlForApp(FINDINGS_NAV_ID) : '';
+    return [
+      <EuiSmallButton
+        href={`${baseUrl}#${ROUTES.FINDINGS}?detectionType=${FindingTabId.ThreatIntel}`}
+      >
         View all
       </EuiSmallButton>,
-    ],
-    []
-  );
+    ];
+  }, []);
 
   return (
     <WidgetContainer title={'Recent threat intel findings'} actions={actions}>

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -333,12 +333,12 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
               </>
             )}
             {type === 'URL_DOWNLOAD' && (
-              <EuiFormRow label="Source URL">
-                <EuiFieldText
+              <EuiCompressedFormRow label="Source URL">
+                <EuiCompressedFieldText
                   readOnly={isReadOnly}
                   value={(sourceItem.source as URLDownloadSource).url_download?.url}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             )}
             <EuiCompressedFormRow label="Types of malicious indicators">
               <>
@@ -374,7 +374,12 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
                 <EuiSmallButton onClick={onDiscard}>Discard</EuiSmallButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiSmallButton isLoading={saveInProgress} fill onClick={onSave} disabled={saveDisabled}>
+                <EuiSmallButton
+                  isLoading={saveInProgress}
+                  fill
+                  onClick={onSave}
+                  disabled={saveDisabled}
+                >
                   Save
                 </EuiSmallButton>
               </EuiFlexItem>

--- a/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
@@ -34,7 +34,6 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
 }) => {
   return (
     <EuiPanel>
-      <EuiSpacer size="m" />
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiTitle size="s">
@@ -97,7 +96,11 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
       </EuiFlexGroup>
       {threatIntelSources.length === 0 && (
         <EuiEmptyPrompt
-          title={<EuiText size="s"><h2>No threat intel source present</h2></EuiText>}
+          title={
+            <EuiText size="s">
+              <h2>No threat intel source present</h2>
+            </EuiText>
+          }
           actions={[
             <EuiSmallButton
               fill

--- a/public/store/FindingsStore.ts
+++ b/public/store/FindingsStore.ts
@@ -132,6 +132,10 @@ export class FindingsStore implements IFindingsStore {
 
     const firstGetFindingsRes = await this.service.getFindings(getFindingsQueryParams);
 
+    if (signal.aborted) {
+      return allFindings;
+    }
+
     if (firstGetFindingsRes.ok) {
       const extendedFindings = this.extendFindings(firstGetFindingsRes.response.findings, detector);
       onPartialFindingsFetched?.(extendedFindings);

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -79,7 +79,7 @@ export const getNotificationDetailsHref = (channelId: string) =>
   `notifications-dashboards#/channels-details/${channelId}`;
 
 export const BREADCRUMBS = Object.freeze({
-  SECURITY_ANALYTICS: { text: 'Security Analytics', href: '#/' },
+  SECURITY_ANALYTICS: { text: 'Security Analytics', href: `#${ROUTES.OVERVIEW}` },
   OVERVIEW: { text: 'Overview', href: `#${ROUTES.OVERVIEW}` },
   GETTING_STARTED: { text: 'Getting started', href: `#${ROUTES.GETTING_STARTED}` },
   FINDINGS: { text: 'Findings', href: `#${ROUTES.FINDINGS}` },


### PR DESCRIPTION
### Description
- Fixes the spacing for threat intel sources
<img width="484" alt="Screenshot 2024-10-01 at 2 39 52 PM" src="https://github.com/user-attachments/assets/6a62e36a-a925-414b-8714-1546d516102e">

- Fixes the alienvault source details page crash
Before:
<img width="1702" alt="Screenshot 2024-10-01 at 2 48 34 PM" src="https://github.com/user-attachments/assets/7c4720ec-d394-498d-b956-863058405161">

After:
<img width="1685" alt="Screenshot 2024-10-01 at 2 50 42 PM" src="https://github.com/user-attachments/assets/72510173-f0f3-4041-b094-ed882a01044a">

- Fixes the threat intel view all all url crash
Before:
<img width="831" alt="Screenshot 2024-10-01 at 2 48 53 PM" src="https://github.com/user-attachments/assets/c3d4450b-c048-405b-8695-afa6a412ff05">

After:
<img width="1752" alt="Screenshot 2024-10-01 at 2 51 31 PM" src="https://github.com/user-attachments/assets/79133459-e237-4ebf-8e5b-bfe8d8e38fe3">

- Fixes the Security Analytics breadcrumb link crash so it links to the overview page now
Before:
<img width="1791" alt="Screenshot 2024-10-01 at 2 48 06 PM" src="https://github.com/user-attachments/assets/0d5bf9b6-3d4c-486f-838c-7bf3e106ae5b">

After:
<img width="1857" alt="Screenshot 2024-10-01 at 2 41 37 PM" src="https://github.com/user-attachments/assets/5d3f5bd2-6fe1-4cce-8cc9-f05f5acfda46">

- Fixes duplicate findings showing up on the dashboard

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).