### PR TITLE
Avoid showing unhelpful error toast when datasource is not yet selected

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -275,6 +275,7 @@ export default class Main extends Component<MainProps, MainState> {
       this.setState({
         selectedDataSource: { ...sources[0] },
       });
+      DataStore.logTypes.getLogTypes();
     }
     dataSourceObservable.next({
       id: this.state.selectedDataSource.id,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -53,7 +53,7 @@ import { BehaviorSubject } from 'rxjs';
 
 export interface SecurityAnalyticsPluginSetupDeps {
   data: DataPublicPluginSetup;
-  dataSourceManagement: DataSourceManagementPluginSetup;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
 }
 export interface SecurityAnalyticsPluginStartDeps {
   data: DataPublicPluginStart;
@@ -232,7 +232,13 @@ export class SecurityAnalyticsPlugin
         { id: THREAT_ALERTS_NAV_ID, showInAllNavGroup: true },
         { id: FINDINGS_NAV_ID, showInAllNavGroup: true },
         { id: CORRELATIONS_NAV_ID, showInAllNavGroup: true },
-        { id: PLUGIN_NAME, category: DEFAULT_APP_CATEGORIES.configure, title: 'Threat detection', showInAllNavGroup: true, order: 600 },
+        {
+          id: PLUGIN_NAME,
+          category: DEFAULT_APP_CATEGORIES.configure,
+          title: 'Threat detection',
+          showInAllNavGroup: true,
+          order: 600,
+        },
         { id: DETECTORS_NAV_ID, parentNavLinkId: PLUGIN_NAME, showInAllNavGroup: true },
         { id: DETECTION_RULE_NAV_ID, parentNavLinkId: PLUGIN_NAME, showInAllNavGroup: true },
         { id: CORRELATIONS_RULE_NAV_ID, showInAllNavGroup: true },

--- a/public/security_analytics_app.tsx
+++ b/public/security_analytics_app.tsx
@@ -35,81 +35,86 @@ export function renderApp(
   const services = getBrowserServices();
   const metrics = new MetricsContext(services.metricsService);
 
-  DataStore.logTypes.getLogTypes().then((logTypes: LogType[]) => {
-    ReactDOM.render(
-      <Router>
-        <Route
-          render={(props) => {
-            const originalMethods = {
-              push: props.history.push,
-              replace: props.history.replace,
-            };
-            const wrapper = (method: 'push' | 'replace') => (
-              ...args: Parameters<History['push']>
-            ) => {
-              if (typeof args[0] === 'string') {
-                const url = new URL(args[0], window.location.origin);
-                const searchParams = url.searchParams;
-                searchParams.set('dataSourceId', dataSourceInfo.activeDataSource.id);
-                originalMethods[method](
-                  {
-                    pathname: url.pathname,
-                    search: searchParams.toString(),
-                  },
-                  ...args.slice(1)
-                );
-              } else if (typeof args[0] === 'object') {
-                const searchParams = new URLSearchParams(args[0].search);
-                searchParams.set('dataSourceId', dataSourceInfo.activeDataSource.id);
-                originalMethods[method](
-                  {
-                    ...args[0],
-                    search: searchParams.toString(),
-                  },
-                  ...args.slice(1)
-                );
-              } else {
-                originalMethods[method](...args);
-              }
-            };
+  DataStore.logTypes
+    .getLogTypes()
+    .then((logTypes: LogType[]) => {
+      ReactDOM.render(
+        <Router>
+          <Route
+            render={(props) => {
+              const originalMethods = {
+                push: props.history.push,
+                replace: props.history.replace,
+              };
+              const wrapper = (method: 'push' | 'replace') => (
+                ...args: Parameters<History['push']>
+              ) => {
+                if (typeof args[0] === 'string') {
+                  const url = new URL(args[0], window.location.origin);
+                  const searchParams = url.searchParams;
+                  searchParams.set('dataSourceId', dataSourceInfo.activeDataSource.id);
+                  originalMethods[method](
+                    {
+                      pathname: url.pathname,
+                      search: searchParams.toString(),
+                    },
+                    ...args.slice(1)
+                  );
+                } else if (typeof args[0] === 'object') {
+                  const searchParams = new URLSearchParams(args[0].search);
+                  searchParams.set('dataSourceId', dataSourceInfo.activeDataSource.id);
+                  originalMethods[method](
+                    {
+                      ...args[0],
+                      search: searchParams.toString(),
+                    },
+                    ...args.slice(1)
+                  );
+                } else {
+                  originalMethods[method](...args);
+                }
+              };
 
-            props.history = {
-              ...props.history,
-              push: wrapper('push'),
-              replace: wrapper('replace'),
-            };
+              props.history = {
+                ...props.history,
+                push: wrapper('push'),
+                replace: wrapper('replace'),
+              };
 
-            return (
-              <DarkModeContext.Provider value={isDarkMode}>
-                <SecurityAnalyticsContext.Provider value={{ services, metrics }}>
-                  <CoreServicesContext.Provider value={coreStart}>
-                    <Main
-                      {...props}
-                      landingPage={landingPage}
-                      multiDataSourceEnabled={!!depsStart.dataSource}
-                      dataSourceManagement={dataSourceManagement}
-                      setActionMenu={params.setHeaderActionMenu}
-                    />
-                  </CoreServicesContext.Provider>
-                </SecurityAnalyticsContext.Provider>
-              </DarkModeContext.Provider>
-            );
-          }}
-        />
-      </Router>,
-      params.element
-    );
+              return (
+                <DarkModeContext.Provider value={isDarkMode}>
+                  <SecurityAnalyticsContext.Provider value={{ services, metrics }}>
+                    <CoreServicesContext.Provider value={coreStart}>
+                      <Main
+                        {...props}
+                        landingPage={landingPage}
+                        multiDataSourceEnabled={!!depsStart.dataSource}
+                        dataSourceManagement={dataSourceManagement}
+                        setActionMenu={params.setHeaderActionMenu}
+                      />
+                    </CoreServicesContext.Provider>
+                  </SecurityAnalyticsContext.Provider>
+                </DarkModeContext.Provider>
+              );
+            }}
+          />
+        </Router>,
+        params.element
+      );
 
-    services.notificationsService.getServerFeatures().then((response) => {
-      if (response.ok) {
-        CHANNEL_TYPES.splice(0, CHANNEL_TYPES.length, ...response.response);
-      }
+      services.notificationsService.getServerFeatures().then((response) => {
+        if (response.ok) {
+          CHANNEL_TYPES.splice(0, CHANNEL_TYPES.length, ...response.response);
+        }
+      });
+
+      getPlugins(services.opensearchService).then((plugins): void => {
+        setIsNotificationPluginInstalled(plugins.includes(OS_NOTIFICATION_PLUGIN));
+      });
+    })
+    .catch((error) => {
+      console.error(error.message ?? error);
     });
-
-    getPlugins(services.opensearchService).then((plugins): void => {
-      setIsNotificationPluginInstalled(plugins.includes(OS_NOTIFICATION_PLUGIN));
-    });
-  });
 
   return () => ReactDOM.unmountComponentAtNode(params.element);
 }

--- a/public/services/utils/constants.ts
+++ b/public/services/utils/constants.ts
@@ -36,9 +36,7 @@ export const [getBreadCrumbsSetter, setBreadCrumbsSetter] = createGetterSetter<
   CoreStart['chrome']['setBreadcrumbs']
 >('breadCrumbSetter');
 
-export const [getChrome, setChrome] = createGetterSetter<
-  CoreStart['chrome']
->('chrome');
+export const [getChrome, setChrome] = createGetterSetter<CoreStart['chrome']>('chrome');
 
 export const [getContentManagement, setContentManagement] = createGetterSetter<
   ContentManagementPluginStart
@@ -59,4 +57,4 @@ export const [getSavedObjectsClient, setSavedObjectsClient] = createGetterSetter
 export const [
   getDataSourceManagementPlugin,
   setDataSourceManagementPlugin,
-] = createNullableGetterSetter<DataSourceManagementPluginSetup>();
+] = createNullableGetterSetter<DataSourceManagementPluginSetup | undefined>();

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -317,3 +317,5 @@ const LocalCluster: DataSourceOption = {
 };
 
 export const dataSourceObservable = new BehaviorSubject<DataSourceOption>(LocalCluster);
+
+export const DATA_SOURCE_NOT_SET_ERROR = 'Data source is not set';

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -331,6 +331,9 @@ export const errorNotificationToast = (
   errorMessage: string = '',
   displayTime: number = 5000 // 5 seconds; default is 10 seconds
 ) => {
+  if (errorMessage.toLowerCase().includes('no living connections')) {
+    return;
+  }
   const message = `Failed to ${actionName} ${objectName}:`;
   console.error(message, errorMessage);
   notifications?.toasts.addDanger({


### PR DESCRIPTION
### Description
Avoid showing unhelpful error toast when datasource is not yet selected

### Issues Resolved
Currently we see a bunch of error toasts when loading overview page if there isn't a valid data source selected yet. The error in the toasts is not actionable for the users since the correct data source will get selected eventually.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).