### PR TITLE
fix: data source picker remount multiple times

### DIFF
--- a/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
+++ b/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   EuiBasicTable,
   EuiBasicTableColumn,
@@ -46,7 +46,13 @@ export const DataSourceThreatAlertsCard: React.FC<DataSourceAlertsCardProps> = (
   getDataSourceMenu,
   detectorService,
 }) => {
-  const DataSourceSelector = getDataSourceMenu?.();
+  const DataSourceSelector = useMemo(() => {
+    if (getDataSourceMenu) {
+      return getDataSourceMenu();
+    }
+
+    return null;
+  }, [getDataSourceMenu]);
   const notifications = getNotifications();
   const [loading, setLoading] = useState(false);
   const [dataSource, setDataSource] = useState<DataSourceOption>({


### PR DESCRIPTION
### Description
The DataSourceSelector is generated in every render and React recognizes the component as a new component thus unmount the old element and mount an new element with the new DataSourceSelector.

This PR is to fix this behavior by adding a useMemo to ensure only single instance of DataSourceSelector will be generated.

![image](https://github.com/user-attachments/assets/465e137e-09a2-4705-952a-87173ec195cf)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).