### PR TITLE
ACTIVE to ACKNOWLEDGE state update delay due to backend index update

### DIFF
--- a/public/pages/Alerts/containers/Alerts/Alerts.tsx
+++ b/public/pages/Alerts/containers/Alerts/Alerts.tsx
@@ -801,6 +801,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
   };
 
   onAcknowledgeCorrelationAlert = async (selectedItems: CorrelationAlertTableItem[] = []) => {
+    const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
     const { correlationService, notifications } = this.props;
     let successCount = 0;
     try {
@@ -824,6 +825,7 @@ export class Alerts extends Component<AlertsProps, AlertsState> {
     if (successCount)
       successNotificationToast(notifications, 'acknowledged', `${successCount} alerts`);
     this.setState({ selectedCorrelationsAlertItems: [] });
+    await delay(500); // 500 ms because correlationAlert system index update takes a little bit of time
     this.onRefresh();
   };
 


### PR DESCRIPTION
### Description
* When acknowledging a correlation alert, a write-after-read scenario occurs because the system index updates with some delay, and the API call to fetch the correlation alert is made before the update completes. To address this, a 500ms delay has been added before calling refresh when the acknowledgment is clicked. Additionally, it is necessary to investigate why the system index update is taking longer than expected.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).