### PR TITLE
bug fix to switch to default datasource instead of local cluster when initial loading

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -156,10 +156,6 @@ export default class Main extends Component<MainProps, MainState> {
       };
       dataSourceId = parsedDataSourceId;
       dataSourceLabel = parsedDataSourceLabel || '';
-
-      if (dataSourceId) {
-        dataSourceObservable.next({ id: dataSourceId, label: dataSourceLabel });
-      }
     }
 
     this.state = {
@@ -275,16 +271,16 @@ export default class Main extends Component<MainProps, MainState> {
       this.setState({
         selectedDataSource: { ...sources[0] },
       });
-      DataStore.logTypes.getLogTypes();
+      dataSourceObservable.next(
+        dataSourceInfo.activeDataSource
+      );
     }
-    dataSourceObservable.next({
-      id: this.state.selectedDataSource.id,
-      label: this.state.selectedDataSource.label,
-    });
+
     if (dataSourceLoading) {
       this.setState({ dataSourceLoading: false });
     }
   };
+
 
   setDataSourceMenuReadOnly = (readOnly: boolean) => {
     this.setState({ dataSourceMenuReadOnly: readOnly });

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -75,10 +75,19 @@ export class SecurityAnalyticsPlugin
   ) {}
 
   private updateDefaultRouteOfManagementApplications: AppUpdater = () => {
-    const hash = `#/?dataSourceId=${dataSourceObservable.value?.id || ''}`;
+    const dataSourceValue = dataSourceObservable.value?.id;
+    let hash = `#/`;
+    /***
+     When data source value is undefined,
+     it means the data source picker has not determined which data source to use(local or default data source)
+     so we should not append any data source id into hash to avoid impacting the data source picker.
+     **/
+    if (dataSourceValue !== undefined) {
+      hash = `#/?dataSourceId=${dataSourceValue}`;
+    }
     return {
-      defaultPath: hash,
-    };
+      defaultPath: hash
+    }
   };
 
   private appStateUpdater = new BehaviorSubject<AppUpdater>(

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -316,6 +316,9 @@ const LocalCluster: DataSourceOption = {
   id: '',
 };
 
-export const dataSourceObservable = new BehaviorSubject<DataSourceOption>(LocalCluster);
+// We should use empty object for default value as local cluster may be disabled
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>({});
 
 export const DATA_SOURCE_NOT_SET_ERROR = 'Data source is not set';
+
+


### PR DESCRIPTION
### Description
* bug fix to switch to default datasource instead of local cluster when initial loading

### Issues Resolved

https://github.com/user-attachments/assets/702cfd44-ab8d-4a77-8490-55c0f2efa2ca


### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).