### PR TITLE
Make data source default cluster for threat alerts card

### DIFF
--- a/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
+++ b/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
@@ -55,10 +55,7 @@ export const DataSourceThreatAlertsCard: React.FC<DataSourceAlertsCardProps> = (
   }, [getDataSourceMenu]);
   const notifications = getNotifications();
   const [loading, setLoading] = useState(false);
-  const [dataSource, setDataSource] = useState<DataSourceOption>({
-    label: 'Local cluster',
-    id: '',
-  });
+  const [dataSource, setDataSource] = useState<DataSourceOption>();
   const [alerts, setAlerts] = useState<any[]>([]);
 
   const getAlerts = async () => {


### PR DESCRIPTION
### Description
- Make the data source the default instead of local cluster by default for the threat alerts card
![Screenshot 2024-10-28 at 10 33 42 AM](https://github.com/user-attachments/assets/8217ec4a-e2ea-4d7d-b72f-fd1a05048495)


https://github.com/user-attachments/assets/a6724dee-dfba-4549-8247-795e8dd9c16a


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).