### PR TITLE
Fix data source picker for threat alerts card

### DIFF
--- a/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
+++ b/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
@@ -28,7 +28,6 @@ import {
 } from '../../utils/helpers';
 import { THREAT_ALERTS_NAV_ID } from '../../utils/constants';
 import {
-  dataSourceInfo,
   getApplication,
   getNotifications,
   getSavedObjectsClient,

--- a/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
+++ b/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
@@ -72,13 +72,11 @@ export const DataSourceThreatAlertsCard: React.FC<DataSourceAlertsCardProps> = (
         });
 
         let alerts: any[] = [];
-        const abortController = new AbortController();
 
         for (let id of detectorIds) {
-          const alertsRes = await DataStore.alerts.getAlertsByDetector(
+          const alertsRes = await DataStore.alerts.getAlertsForThreatAlertsCard(
             id,
             detectors[id].name,
-            abortController.signal,
             undefined,
             undefined,
             25,

--- a/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
+++ b/public/components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../utils/helpers';
 import { THREAT_ALERTS_NAV_ID } from '../../utils/constants';
 import {
+  dataSourceInfo,
   getApplication,
   getNotifications,
   getSavedObjectsClient,
@@ -63,7 +64,7 @@ export const DataSourceThreatAlertsCard: React.FC<DataSourceAlertsCardProps> = (
 
   const getAlerts = async () => {
     try {
-      const detectorsRes = await detectorService.getDetectors();
+      const detectorsRes = await detectorService.getDetectors(dataSource);
       if (detectorsRes.ok) {
         const detectors: any = {};
         const detectorIds = detectorsRes.response.hits.hits.map((hit: any) => {
@@ -81,7 +82,8 @@ export const DataSourceThreatAlertsCard: React.FC<DataSourceAlertsCardProps> = (
             abortController.signal,
             undefined,
             undefined,
-            25
+            25,
+            dataSource
           );
           alerts = alerts.concat(alertsRes);
         }
@@ -106,7 +108,7 @@ export const DataSourceThreatAlertsCard: React.FC<DataSourceAlertsCardProps> = (
 
   const onDataSourceSelected = useCallback(
     (options: any[]) => {
-      if (dataSource?.id !== undefined && dataSource?.id !== options[0]?.id) {
+      if (dataSource?.id === undefined || dataSource?.id !== options[0]?.id) {
         setDataSource(options[0]);
       }
     },

--- a/public/services/AlertsService.ts
+++ b/public/services/AlertsService.ts
@@ -30,12 +30,13 @@ export default class AlertsService {
       startIndex,
       startTime,
       endTime,
+      dataSource,
     } = getAlertsParams;
     const baseQuery = {
       sortOrder: sortOrder || 'desc',
       size: size || 10000,
       startIndex: startIndex || 0,
-      dataSourceId: dataSourceInfo.activeDataSource.id,
+      dataSourceId: dataSource?.id || dataSourceInfo.activeDataSource.id,
       startTime,
       endTime,
     };

--- a/public/services/DetectorService.ts
+++ b/public/services/DetectorService.ts
@@ -30,8 +30,10 @@ export default class DetectorsService implements IDetectorService {
     return response;
   };
 
-  getDetectors = async (): Promise<ServerResponse<SearchDetectorsResponse>> => {
+  getDetectors = async (dataSource?: any): Promise<ServerResponse<SearchDetectorsResponse>> => {
     const url = `..${API.SEARCH_DETECTORS}`;
+    const dataSourceId = dataSource?.id || dataSourceInfo.activeDataSource.id;
+
     const res = (await this.httpClient.post(url, {
       body: JSON.stringify({
         query: {
@@ -39,7 +41,7 @@ export default class DetectorsService implements IDetectorService {
         },
       }),
       query: {
-        dataSourceId: dataSourceInfo.activeDataSource.id,
+        dataSourceId: dataSourceId,
       },
     })) as ServerResponse<SearchDetectorsResponse>;
 

--- a/public/store/AlertsStore.ts
+++ b/public/store/AlertsStore.ts
@@ -20,7 +20,8 @@ export class AlertsStore {
     signal: AbortSignal,
     duration?: Duration,
     onPartialAlertsFetched?: (alerts: AlertResponse[]) => void,
-    alertCount?: number
+    alertCount?: number,
+    dataSource?: any
   ) {
     let allAlerts: any[] = [];
     const maxAlertsReturned = alertCount ?? 10000;
@@ -38,6 +39,7 @@ export class AlertsStore {
         size: maxAlertsReturned,
         startTime: duration?.startTime,
         endTime: duration?.endTime,
+        dataSource,
       });
 
       if (signal.aborted) {
@@ -58,7 +60,7 @@ export class AlertsStore {
     } while (
       // If we get 10,000 alerts as part of the previous call then there might be more alerts to fetch,
       // hence we make another call until the number of alerts is less then 10,000
-      alertsCount === maxAlertsReturned
+      alertsCount > maxAlertsReturned
     );
 
     return allAlerts;

--- a/types/Alert.ts
+++ b/types/Alert.ts
@@ -53,6 +53,7 @@ export type GetAlertsParams = {
   startIndex?: number;
   startTime?: number;
   endTime?: number;
+  dataSource?: any;
 } & (
   | {
       detector_id: string;
@@ -105,10 +106,9 @@ export interface CorrelationAlertItem {
   acknowledged_time: string | null;
 }
 
-export interface CorrelationAlertTableItem extends CorrelationAlertItem{
+export interface CorrelationAlertTableItem extends CorrelationAlertItem {
   correlation_rule_categories: string[];
 }
-
 
 export interface AlertResponse extends AlertItem {
   version: number;


### PR DESCRIPTION
### Description
- Fixes the data source picker for the threat alerts card so it loads alerts from different selected clusters
- Loads the default cluster by default

https://github.com/user-attachments/assets/73cc6343-9765-4a2b-aaa9-8570166f2691

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).