### PR TITLE
[MDS] Do not decode datasource id from url; update global state on datasource change

### DIFF
--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -25,6 +25,7 @@ import {
   DATE_TIME_FILTER_KEY,
   ROUTES,
   dataSourceObservable,
+  OS_NOTIFICATION_PLUGIN,
 } from '../../utils/constants';
 import { CoreServicesConsumer } from '../../components/core_services';
 import Findings from '../Findings';
@@ -66,9 +67,15 @@ import { ThreatIntelOverview } from '../ThreatIntel/containers/Overview/ThreatIn
 import { AddThreatIntelSource } from '../ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource';
 import { ThreatIntelScanConfigForm } from '../ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm';
 import { ThreatIntelSource } from '../ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource';
-import queryString from 'query-string';
-import { dataSourceFilterFn } from '../../utils/helpers';
+import { parse } from 'query-string';
+import {
+  dataSourceFilterFn,
+  getPlugins,
+  setIsNotificationPluginInstalled,
+} from '../../utils/helpers';
 import { GettingStartedContent } from '../Overview/components/GettingStarted/GettingStartedContent';
+import { BrowserServices } from '../../models/interfaces';
+import { CHANNEL_TYPES } from '../CreateDetector/components/ConfigureAlerts/utils/constants';
 
 enum Navigation {
   SecurityAnalytics = 'Security Analytics',
@@ -108,6 +115,7 @@ interface MainProps extends RouteComponentProps {
   setActionMenu: AppMountParameters['setHeaderActionMenu'];
   multiDataSourceEnabled: boolean;
   dataSourceManagement?: DataSourceManagementPluginSetup;
+  services: BrowserServices;
 }
 
 interface MainState {
@@ -150,7 +158,7 @@ export default class Main extends Component<MainProps, MainState> {
       const {
         dataSourceId: parsedDataSourceId,
         dataSourceLabel: parsedDataSourceLabel,
-      } = queryString.parse(this.props.location.search) as {
+      } = parse(this.props.location.search, { decode: false }) as {
         dataSourceId: string;
         dataSourceLabel: string;
       };
@@ -263,6 +271,7 @@ export default class Main extends Component<MainProps, MainState> {
 
   onDataSourceSelected = (sources: DataSourceOption[]) => {
     const { selectedDataSource: dataSource, dataSourceLoading } = this.state;
+    const { services } = this.props;
     if (
       sources[0] &&
       (dataSource?.id !== sources[0].id || dataSource?.label !== sources[0].label)
@@ -271,16 +280,25 @@ export default class Main extends Component<MainProps, MainState> {
       this.setState({
         selectedDataSource: { ...sources[0] },
       });
-      dataSourceObservable.next(
-        dataSourceInfo.activeDataSource
-      );
+      dataSourceObservable.next(dataSourceInfo.activeDataSource);
+
+      services.notificationsService.getServerFeatures().then((response) => {
+        if (response.ok) {
+          CHANNEL_TYPES.splice(0, CHANNEL_TYPES.length, ...response.response);
+        }
+      });
+
+      getPlugins(services.opensearchService).then((plugins): void => {
+        setIsNotificationPluginInstalled(plugins.includes(OS_NOTIFICATION_PLUGIN));
+      });
+
+      DataStore.logTypes.getLogTypes();
     }
 
     if (dataSourceLoading) {
       this.setState({ dataSourceLoading: false });
     }
   };
-
 
   setDataSourceMenuReadOnly = (readOnly: boolean) => {
     this.setState({ dataSourceMenuReadOnly: readOnly });

--- a/public/security_analytics_app.tsx
+++ b/public/security_analytics_app.tsx
@@ -87,6 +87,7 @@ export function renderApp(
                     <CoreServicesContext.Provider value={coreStart}>
                       <Main
                         {...props}
+                        services={services}
                         landingPage={landingPage}
                         multiDataSourceEnabled={!!depsStart.dataSource}
                         dataSourceManagement={dataSourceManagement}


### PR DESCRIPTION
### Description
This PR fixes two issues:
- When a data source is changed, the corresponding global state like Channel types, installed plugins and log types should get updated in this plugin
- The datasource Id passed in the url should be used as is and not decoded when parsing the url

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).