### PR TITLE
[MDS] Use datasource id when getting client for threat alerts

### DIFF
--- a/server/services/AlertService.ts
+++ b/server/services/AlertService.ts
@@ -127,10 +127,15 @@ export default class AlertService extends MDSEnabledClientService {
     response: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<ServerResponse<any> | ResponseError>> => {
     try {
-      const params: any = request.query;
-      // Delete the dataSourceId since this query param is not supported by the alerts API
-      delete params['dataSourceId'];
+      const { sortOrder, size, startIndex, startTime, endTime } = request.query;
 
+      const params: any = {
+        sortOrder,
+        size,
+        startIndex,
+        startTime,
+        endTime,
+      };
       const client = this.getClient(request, context);
       const getAlertsResponse: GetAlertsResponse = await client(
         CLIENT_THREAT_INTEL_METHODS.GET_THREAT_INTEL_ALERTS,
@@ -167,11 +172,10 @@ export default class AlertService extends MDSEnabledClientService {
     response: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<ServerResponse<any> | ResponseError>> => {
     try {
-      const params: any = request.query;
-      // Delete the dataSourceId since this query param is not supported by the alerts API
-      delete params['dataSourceId'];
-
+      const { state, alert_ids } = request.query;
+      const params: any = { state, alert_ids };
       const client = this.getClient(request, context);
+
       const updateStatusResponse: GetAlertsResponse = await client(
         CLIENT_THREAT_INTEL_METHODS.UPDATE_THREAT_INTEL_ALERTS_STATE,
         params


### PR DESCRIPTION
### Description
Currently when getting threat intel alerts, the data sourceId is not passed when getting client to make the API call which causes a `No living connections` error. This PR fixes the issue.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).