### PR TITLE
Fix edit trigger for detectors

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/AlertConditionPanel.tsx
@@ -73,6 +73,24 @@ export default class AlertConditionPanel extends Component<
     this.prepareMessage(false /* updateMessage */, true /* onMount */);
   }
 
+  componentDidUpdate(
+    prevProps: Readonly<AlertConditionPanelProps>,
+    _prevState: Readonly<AlertConditionPanelState>
+  ): void {
+    const { rulesOptions, alertCondition } = this.props;
+
+    if (prevProps.rulesOptions !== rulesOptions) {
+      const selectedNames: EuiComboBoxOptionOption<string>[] = [];
+      alertCondition.ids.forEach((ruleId) => {
+        const rule = rulesOptions.find((option) => option.id === ruleId);
+        if (rule) {
+          selectedNames.push({ label: rule.name, value: ruleId });
+        }
+      });
+      this.setState({ selectedNames });
+    }
+  }
+
   onDetectionTypeChange(detectionType: 'rules' | 'threat_intel', enabled: boolean) {
     const detectionTypes = new Set(this.props.alertCondition.detection_types);
     enabled ? detectionTypes.add(detectionType) : detectionTypes.delete(detectionType);


### PR DESCRIPTION
### Description
When editing an existing trigger inside a detector, the selected rules as part of the filter don't show up. This happens because the initial state on mount is not populated using detector config. Another issue we see is that all the rules show up as filter options which is not correct since not all of them have been enabled previously

This PR fixes these issues.

1. Rule shows up in the filter
<img width="891" alt="image" src="https://github.com/user-attachments/assets/f7bc33ff-c936-4487-8b9d-3f4329df5b2e" />

2. Only enabled rules are shown as options in the dropdown on Edit
<img width="891" alt="image" src="https://github.com/user-attachments/assets/bc464bac-55de-4e28-afed-2944a542fe3c" />



### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).