### PR TITLE
[Backport 2.x] Updating Preview Message functionality while setting notifications in detector alerts #1241

### DIFF
--- a/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
+++ b/public/pages/CreateDetector/components/ConfigureAlerts/components/AlertCondition/__snapshots__/AlertConditionPanel.test.tsx.snap
@@ -838,28 +838,22 @@ Object {
                     class="euiFlexItem"
                   >
                     <div
-                      class="euiFormRow euiFormRow--compressed"
-                      id="some_html_id-row"
+                      class="euiCheckbox euiCheckbox--compressed"
                     >
+                      <input
+                        class="euiCheckbox__input"
+                        id="notification-message-preview-checkbox"
+                        type="checkbox"
+                      />
                       <div
-                        class="euiFormRow__fieldWrapper"
+                        class="euiCheckbox__square"
+                      />
+                      <label
+                        class="euiCheckbox__label"
+                        for="notification-message-preview-checkbox"
                       >
-                        <button
-                          class="euiButton euiButton--primary euiButton--small"
-                          id="some_html_id"
-                          type="button"
-                        >
-                          <span
-                            class="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              class="euiButton__text"
-                            >
-                              Generate message
-                            </span>
-                          </span>
-                        </button>
-                      </div>
+                        Preview message
+                      </label>
                     </div>
                   </div>
                 </div>
@@ -1707,28 +1701,22 @@ Object {
                   class="euiFlexItem"
                 >
                   <div
-                    class="euiFormRow euiFormRow--compressed"
-                    id="some_html_id-row"
+                    class="euiCheckbox euiCheckbox--compressed"
                   >
+                    <input
+                      class="euiCheckbox__input"
+                      id="notification-message-preview-checkbox"
+                      type="checkbox"
+                    />
                     <div
-                      class="euiFormRow__fieldWrapper"
+                      class="euiCheckbox__square"
+                    />
+                    <label
+                      class="euiCheckbox__label"
+                      for="notification-message-preview-checkbox"
                     >
-                      <button
-                        class="euiButton euiButton--primary euiButton--small"
-                        id="some_html_id"
-                        type="button"
-                      >
-                        <span
-                          class="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            class="euiButton__text"
-                          >
-                            Generate message
-                          </span>
-                        </span>
-                      </button>
-                    </div>
+                      Preview message
+                    </label>
                   </div>
                 </div>
               </div>

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -320,3 +320,12 @@ const LocalCluster: DataSourceOption = {
 export const dataSourceObservable = new BehaviorSubject<DataSourceOption>({});
 
 export const DATA_SOURCE_NOT_SET_ERROR = 'Data source is not set';
+
+export const DEFAULT_MESSAGE_SOURCE = {
+  MESSAGE_BODY: `- Triggered alert condition: {{ctx.trigger.name}}
+ - Severity: {{ctx.trigger.severity}}
+ - Threat detector: {{ctx.detector.name}}
+ - Description: {{ctx.detector.description}}
+ - Detector data sources: {{ctx.detector.datasources}}`,
+  MESSAGE_SUBJECT: `Triggered alert condition:  {{ctx.trigger.name}} - Severity: {{ctx.trigger.severity}} - Threat detector: {{ctx.detector.name}}`,
+};

--- a/types/Alert.ts
+++ b/types/Alert.ts
@@ -43,6 +43,20 @@ export interface TriggerAction {
   };
 }
 
+export interface TriggerContext {
+  ctx: {
+    trigger: {
+      name: string;
+      severity: string;
+    };
+    detector: {
+      name: string;
+      description: string;
+      datasources: string;
+    };
+  };
+}
+
 /**
  * API interfaces
  */


### PR DESCRIPTION
### Description
This PR updates the message preview feature while setting notifications for detector triggers. The user can click on Preview message check box and view the notification content. The user can also update the message subject and body which will be updated in the notification content.

Current behaviour
<img width="1512" alt="existingDet" src="https://github.com/user-attachments/assets/8c9f950d-7007-43b5-8094-8728a3d93f50" />


Updated Preview
<img width="637" alt="updatedDetector" src="https://github.com/user-attachments/assets/b8c16d0d-4d44-4a41-b6e9-0e702c1a9052" />



### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).