### PR TITLE
Add support for custom ioc schema in threat intel source

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -5,16 +5,8 @@
 
 export const DEFAULT_RULE_UUID = '25b9c01c-350d-4b95-bed1-836d04a4f324';
 
-export enum ThreatIntelIocType {
-  Domain = 'domain-name',
-  FileHash = 'hashes',
-  IPV4 = 'ipv4-addr',
-  IPV6 = 'ipv6-addr',
+export enum ThreatIntelIocSourceType {
+  S3_CUSTOM = 'S3_CUSTOM',
+  IOC_UPLOAD = 'IOC_UPLOAD',
+  URL_DOWNLOAD = 'URL_DOWNLOAD',
 }
-
-export const IocLabel: { [k in ThreatIntelIocType]: string } = {
-  [ThreatIntelIocType.IPV4]: 'IPV4-Address',
-  [ThreatIntelIocType.IPV6]: 'IPV6-Address',
-  [ThreatIntelIocType.Domain]: 'Domains',
-  [ThreatIntelIocType.FileHash]: 'File hash',
-};

--- a/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertFlyout/ThreatIntelAlertFlyout.tsx
@@ -23,10 +23,8 @@ import React, { useEffect, useState } from 'react';
 import { ThreatIntelAlert, ThreatIntelFinding } from '../../../../../types';
 import { DescriptionGroup } from '../../../../components/Utility/DescriptionGroup';
 import { capitalize } from 'lodash';
-import { renderTime } from '../../../../utils/helpers';
-import { IocLabel } from '../../../../../common/constants';
+import { renderIoCType, renderTime } from '../../../../utils/helpers';
 import { DataStore } from '../../../../store/DataStore';
-import { DEFAULT_EMPTY_DATA } from '../../../../utils/constants';
 import { ContentPanel } from '../../../../components/ContentPanel';
 
 export interface ThreatIntelAlertFlyoutProps {
@@ -84,17 +82,16 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
         name: 'Finding ID',
         sortable: true,
         dataType: 'string',
-        render: (id: string, finding: ThreatIntelFinding) =>
-          (
-            <EuiLink
-              onClick={() => {
-                DataStore.findings.openThreatIntelFindingFlyout(finding, backButton);
-              }}
-              data-test-subj={'finding-details-flyout-button'}
-            >
-              {id.length > 7 ? `${id.slice(0, 7)}...` : id}
-            </EuiLink>
-          ) || DEFAULT_EMPTY_DATA,
+        render: (id: string, finding: ThreatIntelFinding) => (
+          <EuiLink
+            onClick={() => {
+              DataStore.findings.openThreatIntelFindingFlyout(finding, backButton);
+            }}
+            data-test-subj={'finding-details-flyout-button'}
+          >
+            {id.length > 7 ? `${id.slice(0, 7)}...` : id}
+          </EuiLink>
+        ),
       },
       {
         field: 'ioc_feed_ids',
@@ -123,7 +120,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
       <EuiFlyoutHeader hasBorder={true}>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={2}>
-            <EuiText size='s'>
+            <EuiText size="s">
               <h2>Alert details</h2>
             </EuiText>
           </EuiFlexItem>
@@ -173,7 +170,7 @@ export const ThreatIntelAlertFlyout: React.FC<ThreatIntelAlertFlyoutProps> = ({
           listItems={[
             { title: 'Start time', description: renderTime(alertItem.start_time) },
             { title: 'Last updated time', description: renderTime(alertItem.last_updated_time) },
-            { title: 'Indicator type', description: IocLabel[alertItem.ioc_type] },
+            { title: 'Indicator type', description: renderIoCType(alertItem.ioc_type) },
           ]}
         />
         <EuiSpacer />

--- a/public/pages/Alerts/components/ThreatIntelAlertsTable/ThreatIntelAlertsTable.tsx
+++ b/public/pages/Alerts/components/ThreatIntelAlertsTable/ThreatIntelAlertsTable.tsx
@@ -16,7 +16,6 @@ import { renderIoCType, renderTime } from '../../../../utils/helpers';
 import { ALERT_STATE, DEFAULT_EMPTY_DATA } from '../../../../utils/constants';
 import { parseAlertSeverityToOption } from '../../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { DISABLE_ACKNOWLEDGED_ALERT_HELP_TEXT } from '../../utils/constants';
-import { ThreatIntelIocType } from '../../../../../common/constants';
 import {
   ThreatIntelAlertFlyout,
   ThreatIntelAlertFlyoutProps,
@@ -55,13 +54,17 @@ export const ThreatIntelAlertsTable: React.FC<ThreatIntelAlertsTableProps> = ({
       render: (startTime: number) => renderTime(startTime),
     },
     {
+      field: 'trigger_name',
+      name: 'Alert trigger name',
+    },
+    {
       field: 'ioc_value',
       name: 'Indicator of compromise',
     },
     {
       field: 'ioc_type',
       name: 'Indicator type',
-      render: (iocType: ThreatIntelIocType) => renderIoCType(iocType),
+      render: (iocType: string) => renderIoCType(iocType),
     },
     { field: 'state', name: 'Status', render: (state: string) => state || DEFAULT_EMPTY_DATA },
     {

--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
     OpenSearchService {
       "getDocuments": [Function],
       "getIndexPatterns": [Function],
+      "getIocTypes": [Function],
       "getPlugins": [Function],
       "httpClient": [MockFunction],
       "savedObjectsClient": Object {
@@ -74,6 +75,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
         "post": [MockFunction],
         "put": [MockFunction],
       },
+      "search": undefined,
     }
   }
   ruleService={
@@ -185,6 +187,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
       OpenSearchService {
         "getDocuments": [Function],
         "getIndexPatterns": [Function],
+        "getIocTypes": [Function],
         "getPlugins": [Function],
         "httpClient": [MockFunction],
         "savedObjectsClient": Object {
@@ -194,6 +197,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
           "post": [MockFunction],
           "put": [MockFunction],
         },
+        "search": undefined,
       }
     }
     ruleService={

--- a/public/pages/Findings/components/FindingsTable/ThreatIntelFindingsTable.tsx
+++ b/public/pages/Findings/components/FindingsTable/ThreatIntelFindingsTable.tsx
@@ -11,10 +11,9 @@ import {
 } from '@elastic/eui';
 import { ThreatIntelFinding } from '../../../../../types';
 import React from 'react';
-import { renderTime } from '../../../../utils/helpers';
+import { renderIoCType, renderTime } from '../../../../utils/helpers';
 import { DEFAULT_EMPTY_DATA } from '../../../../utils/constants';
 import { DataStore } from '../../../../store/DataStore';
-import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
 
 export interface ThreatIntelFindingsTableProps {
   findingItems: ThreatIntelFinding[];
@@ -36,7 +35,7 @@ export const ThreatIntelFindingsTable: React.FC<ThreatIntelFindingsTableProps> =
     {
       name: 'Indicator type',
       field: 'ioc_type',
-      render: (iocType: ThreatIntelIocType) => IocLabel[iocType],
+      render: (iocType: string) => renderIoCType(iocType),
     },
     {
       name: 'Threat intel source',

--- a/public/pages/Findings/components/ThreatIntelFindingDetailsFlyout.tsx
+++ b/public/pages/Findings/components/ThreatIntelFindingDetailsFlyout.tsx
@@ -29,8 +29,7 @@ import {
   ThreatIntelIocData,
 } from '../../../../types';
 import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
-import { renderTime } from '../../../utils/helpers';
-import { IocLabel } from '../../../../common/constants';
+import { renderIoCType, renderTime } from '../../../utils/helpers';
 import { DescriptionGroup } from '../../../components/Utility/DescriptionGroup';
 
 interface ThreatIntelFindingDetailsFlyoutState {
@@ -239,7 +238,7 @@ export class ThreatIntelFindingDetailsFlyout extends React.Component<
             listItems={[
               { title: 'Finding ID', description: id || DEFAULT_EMPTY_DATA },
               { title: 'Finding time', description: renderTime(timestamp) || DEFAULT_EMPTY_DATA },
-              { title: 'Indicator type', description: IocLabel[ioc_type] || DEFAULT_EMPTY_DATA },
+              { title: 'Indicator type', description: renderIoCType(ioc_type) },
             ]}
           />
           <EuiSpacer />

--- a/public/pages/ThreatIntel/components/ConfigureThreatIntelAlertTriggers/ConfigureThreatIntelAlertTriggers.tsx
+++ b/public/pages/ThreatIntel/components/ConfigureThreatIntelAlertTriggers/ConfigureThreatIntelAlertTriggers.tsx
@@ -12,13 +12,12 @@ import {
 } from '../../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { NotificationsService } from '../../../../services';
 import { EuiSmallButton, EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
-import { ThreatIntelIocType } from '../../../../../common/constants';
 import { getEmptyThreatIntelAlertTrigger } from '../../utils/helpers';
 
 export interface ConfigureThreatIntelAlertTriggersProps {
   alertTriggers: ThreatIntelAlertTrigger[];
   notificationsService: NotificationsService;
-  enabledIocTypes: ThreatIntelIocType[];
+  enabledIocTypes: string[];
   logSources: string[];
   getNextTriggerName: () => string;
   updateTriggers: (alertTriggers: ThreatIntelAlertTrigger[]) => void;

--- a/public/pages/ThreatIntel/components/IoCsTable/IoCsTable.tsx
+++ b/public/pages/ThreatIntel/components/IoCsTable/IoCsTable.tsx
@@ -15,8 +15,7 @@ import {
   EuiSearchBar,
 } from '@elastic/eui';
 import { ThreatIntelIocData } from '../../../../../types';
-import { renderTime } from '../../../../utils/helpers';
-import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
+import { renderIoCType, renderTime } from '../../../../utils/helpers';
 import { ThreatIntelService } from '../../../../services';
 
 export interface IoCsTableProps {
@@ -48,7 +47,7 @@ export const IoCsTable: React.FC<IoCsTableProps> = ({
     {
       name: 'Type',
       field: 'type',
-      render: (type: string) => IocLabel[type as ThreatIntelIocType],
+      render: (type: string) => renderIoCType(type),
     },
     {
       name: 'IoC matches',

--- a/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
+++ b/public/pages/ThreatIntel/components/SelectLogSourcesForm/SelectThreatIntelLogSourcesForm.tsx
@@ -19,11 +19,10 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
 import React, { useCallback, useEffect, useState } from 'react';
 import { LogSourceIocConfig, ThreatIntelLogSource } from '../../../../../types';
 import { Interval } from '../../../CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval';
-import { getDataSources, getFieldsForIndex } from '../../../../utils/helpers';
+import { getDataSources, getFieldsForIndex, renderIoCType } from '../../../../utils/helpers';
 import { useContext } from 'react';
 import { SecurityAnalyticsContext } from '../../../../services';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -54,17 +53,30 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
   const [iocInfoWithAddFieldOpen, setIocInfoWithAddFieldOpen] = useState<
     { sourceName: string; ioc: string; selectedFields: string[] } | undefined
   >(undefined);
+  const [iocTypes, setIocTypes] = useState<string[]>([]);
 
   const getLogFields = useCallback(
-    async (indexName: string) => {
-      if (saContext && !fieldsByIndexName[indexName]) {
-        getFieldsForIndex(saContext.services.fieldMappingService, indexName).then((fields) => {
-          setFieldsByIndexName({
-            ...fieldsByIndexName,
-            [indexName]: fields,
-          });
-        });
-      }
+    async (indices: string[]) => {
+      const newFieldsByIndexName = {
+        ...fieldsByIndexName,
+      };
+      const getFieldsRequests: Promise<{ label: string; value: string }[]>[] = [];
+      const indicesWithRequest: string[] = [];
+      indices.forEach(async (indexName) => {
+        if (saContext && !fieldsByIndexName[indexName]) {
+          getFieldsRequests.push(
+            getFieldsForIndex(saContext.services.fieldMappingService, indexName)
+          );
+          indicesWithRequest.push(indexName);
+        }
+      });
+
+      const getFieldsResponses = await Promise.all(getFieldsRequests);
+      indicesWithRequest.forEach((indexName, idx) => {
+        newFieldsByIndexName[indexName] = getFieldsResponses[idx];
+      });
+
+      setFieldsByIndexName(newFieldsByIndexName);
     },
     [saContext, fieldsByIndexName]
   );
@@ -84,28 +96,31 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
       }
     };
 
+    const loadIocTypes = async () => {
+      if (saContext) {
+        const iocTypesRes: string[] = await saContext.services.opensearchService.getIocTypes();
+        setIocTypes(iocTypesRes);
+      }
+    };
+
     getLogSourceOptions();
+    loadIocTypes();
   }, [saContext]);
 
   useEffect(() => {
     const selectedSourcesByName: Map<string, ThreatIntelLogSource> = new Map();
     sources.forEach((source) => {
       selectedSourcesByName.set(source.name, source);
-      getLogFields(source.name);
     });
+    getLogFields(sources.map(({ name }) => name));
     setSelectedSourcesMap(selectedSourcesByName);
   }, [sources]);
 
-  const onIocToggle = (
-    source: ThreatIntelLogSource,
-    toggledIoc: ThreatIntelIocType,
-    enabled: boolean
-  ) => {
+  const onIocToggle = (source: ThreatIntelLogSource, toggledIoc: string, enabled: boolean) => {
     const newSelectedSourcesMap = new Map(selectedSourcesMap);
     newSelectedSourcesMap.get(source.name)!.iocConfigMap = {
       ...source.iocConfigMap,
       [toggledIoc]: {
-        fieldAliases: [],
         ...source.iocConfigMap[toggledIoc],
         enabled,
       },
@@ -115,21 +130,20 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
     updateSources?.(Array.from(newSelectedSourcesMap.values()));
   };
 
-  const onFieldAliasRemove = (
-    source: ThreatIntelLogSource,
-    ioc: ThreatIntelIocType,
-    alias: string
-  ) => {
+  const onFieldAliasRemove = (source: ThreatIntelLogSource, ioc: string, alias: string) => {
     const aliasesSet = new Set(source.iocConfigMap[ioc]?.fieldAliases || []);
     aliasesSet.delete(alias);
 
     updateAliases(source, ioc, Array.from(aliasesSet));
   };
 
-  const onFieldAliasesAdd = (source: ThreatIntelLogSource, ioc: ThreatIntelIocType) => {
+  const onFieldAliasesAdd = (source: ThreatIntelLogSource, ioc: string) => {
     const newFieldAliasesSet = new Set([...(source.iocConfigMap[ioc]?.fieldAliases || [])]);
-    iocInfoWithAddFieldOpen?.selectedFields.forEach((field) => newFieldAliasesSet.add(field));
-    updateAliases(source, ioc, Array.from(newFieldAliasesSet));
+    if (iocInfoWithAddFieldOpen && iocInfoWithAddFieldOpen.selectedFields.length > 0) {
+      iocInfoWithAddFieldOpen.selectedFields.forEach((field) => newFieldAliasesSet.add(field));
+      updateAliases(source, ioc, Array.from(newFieldAliasesSet));
+    }
+
     setIocInfoWithAddFieldOpen(undefined);
   };
 
@@ -140,11 +154,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
     });
   };
 
-  const updateAliases = (
-    source: ThreatIntelLogSource,
-    ioc: ThreatIntelIocType,
-    fieldAliases: string[]
-  ) => {
+  const updateAliases = (source: ThreatIntelLogSource, ioc: string, fieldAliases: string[]) => {
     const newSelectedSourcesMap = new Map(selectedSourcesMap);
     newSelectedSourcesMap.get(source.name)!.iocConfigMap = {
       ...source.iocConfigMap,
@@ -171,8 +181,9 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
           iocConfigMap: {},
         });
       }
-      getLogFields(label);
     });
+
+    getLogFields(options.map(({ label }) => label));
 
     setSelectedSourcesMap(newSelectedSourcesMap);
     updateSources?.(Array.from(newSelectedSourcesMap.values()));
@@ -213,11 +224,22 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
         />
       </EuiCompressedFormRow>
       <EuiSpacer size="xxl" />
-      <EuiTitle size="s">
-        <h4>Select fields to scan</h4>
-      </EuiTitle>
+      <EuiFlexGroup gutterSize="none" justifyContent="flexStart" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h4>Select fields to scan</h4>
+          </EuiTitle>
+        </EuiFlexItem>
+        {sources.length > 0 && (
+          <EuiFlexItem>
+            <EuiText size="s">
+              <i>&nbsp; - Required</i>
+            </EuiText>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
       <EuiText color="subdued">
-        <p>Add log fields that map to at least one IoC type to perform threat intel scan.</p>
+        <p>Map at least one IoC type with a log field to perform threat intel scan.</p>
       </EuiText>
       <EuiSpacer />
 
@@ -233,10 +255,6 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
           const fieldOptionsSet = new Set(
             (fieldsByIndexName[name] || []).map(({ label }) => label)
           );
-          Object.values(ThreatIntelIocType).forEach((iocType) => {
-            const selectedFields = iocConfigMap[iocType as ThreatIntelIocType]?.fieldAliases || [];
-            selectedFields.forEach((f) => fieldOptionsSet.delete(f));
-          });
 
           return (
             <>
@@ -248,11 +266,11 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                 paddingSize="l"
               >
                 <div style={{ marginTop: -20 }}>
-                  {Object.values(ThreatIntelIocType).map((iocType) => {
-                    const iocEnabled = iocConfigMap[iocType as ThreatIntelIocType]?.enabled;
-                    const [ioc, config]: [ThreatIntelIocType, LogSourceIocConfig] = [
-                      iocType as ThreatIntelIocType,
-                      iocConfigMap[iocType as ThreatIntelIocType] ?? {
+                  {iocTypes.map((iocType) => {
+                    const iocEnabled = iocConfigMap[iocType]?.enabled;
+                    const [ioc, config]: [string, LogSourceIocConfig] = [
+                      iocType,
+                      iocConfigMap[iocType] ?? {
                         enabled: false,
                         fieldAliases: [],
                       },
@@ -270,7 +288,7 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                               />
                             </EuiFlexItem>
                             <EuiFlexItem grow={false}>
-                              <EuiText>{IocLabel[ioc]}</EuiText>
+                              <EuiText>{renderIoCType(ioc)}</EuiText>
                             </EuiFlexItem>
                           </EuiFlexGroup>
                         </EuiFlexItem>
@@ -332,7 +350,9 @@ export const SelectThreatIntelLogSources: React.FC<SelectThreatIntelLogSourcesPr
                                     />
                                   </EuiFlexItem>
                                   <EuiFlexItem grow={false}>
-                                    <EuiSmallButtonEmpty onClick={() => onFieldAliasesAdd(source, ioc)}>
+                                    <EuiSmallButtonEmpty
+                                      onClick={() => onFieldAliasesAdd(source, ioc)}
+                                    >
                                       Done
                                     </EuiSmallButtonEmpty>
                                   </EuiFlexItem>

--- a/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelAlertTriggerForm/ThreatIntelAlertTriggerForm.tsx
@@ -15,17 +15,17 @@ import {
 import { NotificationChannelTypeOptions, ThreatIntelAlertTrigger } from '../../../../../types';
 import React from 'react';
 import { NotificationForm } from '../../../../components/Notifications/NotificationForm';
-import { ThreatIntelIocType } from '../../../../../common/constants';
 import { parseAlertSeverityToOption } from '../../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { AlertSeverity } from '../../../Alerts/utils/constants';
 import { getEmptyThreatIntelAlertTriggerAction } from '../../utils/helpers';
+import { renderIoCType } from '../../../../utils/helpers';
 import { ALERT_SEVERITY_OPTIONS } from '../../../../utils/constants';
 
 export interface ThreatIntelAlertTriggerProps {
   allNotificationChannels: NotificationChannelTypeOptions[];
   loadingNotifications: boolean;
   trigger: ThreatIntelAlertTrigger;
-  enabledIocTypes: ThreatIntelIocType[];
+  enabledIocTypes: string[];
   logSources: string[];
   onDeleteTrgger: () => void;
   refreshNotificationChannels: () => void;
@@ -122,12 +122,18 @@ export const ThreatIntelAlertTriggerForm: React.FC<ThreatIntelAlertTriggerProps>
         <EuiCompressedFormRow label="Indicator type(s)">
           <EuiCompressedComboBox
             placeholder="Any"
-            options={enabledIocTypes.map((ioc) => ({ label: ioc }))}
-            selectedOptions={trigger.ioc_types.map((iocType) => ({ label: iocType }))}
+            options={enabledIocTypes.map((iocType) => ({
+              label: renderIoCType(iocType),
+              value: iocType,
+            }))}
+            selectedOptions={trigger.ioc_types.map((iocType) => ({
+              label: renderIoCType(iocType),
+              value: iocType,
+            }))}
             onChange={(options) => {
               updateTrigger({
                 ...trigger,
-                ioc_types: options.map(({ label }) => label),
+                ioc_types: options.map(({ value }) => value!),
               });
             }}
           />

--- a/public/pages/ThreatIntel/components/ThreatIntelAlertTriggersFlyout/ThreatIntelAlertTriggersFlyout.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelAlertTriggersFlyout/ThreatIntelAlertTriggersFlyout.tsx
@@ -14,7 +14,6 @@ import {
 } from '@elastic/eui';
 import { ThreatIntelAlertTrigger, ThreatIntelAlertTriggerAction } from '../../../../../types';
 import React, { useCallback } from 'react';
-import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
 import {
   DescriptionGroup,
   DescriptionGroupProps,
@@ -23,6 +22,7 @@ import { getThreatIntelALertSeverityLabel } from '../../utils/helpers';
 import { AlertSeverity } from '../../../Alerts/utils/constants';
 import { ConfigActionButton } from '../Utility/ConfigActionButton';
 import { DEFAULT_EMPTY_DATA } from '../../../../utils/constants';
+import { renderIoCType } from '../../../../utils/helpers';
 
 export interface ThreatIntelAlertTriggersProps {
   triggers: ThreatIntelAlertTrigger[];
@@ -100,7 +100,7 @@ export const ThreatIntelAlertTriggersFlyout: React.FC<ThreatIntelAlertTriggersPr
         const iocTriggerCondition =
           ioc_types.length === 0
             ? 'All types of indicators'
-            : ioc_types.map((iocType) => IocLabel[iocType as ThreatIntelIocType]).join(', ');
+            : ioc_types.map((iocType) => renderIoCType(iocType)).join(', ');
 
         return (
           <EuiAccordion

--- a/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelLogScanConfig/ThreatIntelLogScanConfig.tsx
@@ -26,12 +26,12 @@ import {
 import React, { useState } from 'react';
 import { ThreatIntelScanConfig } from '../../../../../types';
 import { deriveFormModelFromConfig } from '../../utils/helpers';
-import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
 import { Interval } from '../../../CreateDetector/components/DefineDetector/components/DetectorSchedule/Interval';
 import { ThreatIntelLogSourcesFlyout } from '../ThreatIntelLogSourcesFlyout/ThreatIntelLogSourcesFlyout';
 import { ThreatIntelAlertTriggersFlyout } from '../ThreatIntelAlertTriggersFlyout/ThreatIntelAlertTriggersFlyout';
 import DeleteModal from '../../../../components/DeleteModal';
 import { ThreatIntelService } from '../../../../services';
+import { renderIoCType } from '../../../../utils/helpers';
 
 export interface ThreatIntelLogScanConfigProps {
   scanConfig?: ThreatIntelScanConfig;
@@ -162,7 +162,7 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
               anchorPosition={'downLeft'}
               data-test-subj={'detectorsActionsPopover'}
             >
-              <EuiContextMenuPanel items={getActionItems()} size="s"/>
+              <EuiContextMenuPanel items={getActionItems()} size="s" />
             </EuiPopover>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -200,7 +200,7 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
                             {
                               title: source.name,
                               description: Object.keys(source.iocConfigMap)
-                                .map((iocType) => IocLabel[iocType as ThreatIntelIocType])
+                                .map((iocType) => renderIoCType(iocType))
                                 .join(', '),
                             },
                           ]}
@@ -282,9 +282,7 @@ export const ThreatIntelLogScanConfig: React.FC<ThreatIntelLogScanConfigProps> =
                     const iocTriggerCondition =
                       ioc_types.length === 0
                         ? 'All types of indicators'
-                        : ioc_types
-                            .map((iocType) => IocLabel[iocType as ThreatIntelIocType])
-                            .join(', ');
+                        : ioc_types.map((iocType) => renderIoCType(iocType)).join(', ');
 
                     return (
                       <EuiFlexItem key={name}>

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -7,9 +7,7 @@ import React, { useEffect, useState } from 'react';
 import {
   EuiBottomBar,
   EuiSmallButton,
-  EuiCompressedCheckboxGroup,
   EuiCompressedFieldText,
-  EuiCompressedFilePicker,
   EuiCodeEditor,
   EuiFlexGroup,
   EuiFlexItem,

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -82,6 +82,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
   const [saveInProgress, setSaveInProgress] = useState(false);
   const [saveDisabled, setSaveDisabled] = useState(false);
   const [inputErrors, setInputErrors] = useState<ThreatIntelSourceFormInputErrors>({});
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
 
   const setFieldError = (fieldErrors: ThreatIntelSourceFormInputErrors) => {
     setInputErrors({
@@ -94,9 +95,9 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
     let shouldDisableSave = false;
     if (
       !isReadOnly &&
-      ((type === ThreatIntelIocSourceType.IOC_UPLOAD &&
-        fileUploadSource.ioc_upload?.iocs.length === 0 &&
-        customSchemaFileUploadSource.custom_schema_ioc_upload?.iocs.length === 0) ||
+      ((type === ThreatIntelIocSourceType.IOC_UPLOAD && !uploadedFile) ||
+        (fileUploadSource.ioc_upload?.iocs.length === 0 &&
+          customSchemaFileUploadSource.custom_schema_ioc_upload?.iocs.length === 0) ||
         hasErrorInThreatIntelSourceFormInputs(inputErrors, {
           enabled,
           hasCustomIocSchema,
@@ -174,6 +175,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
       },
     });
     if (!!files?.item(0)) {
+      setUploadedFile(files[0]);
       readIocsFromFile(files[0], (response) => {
         if (response.ok) {
           setFileUploadSource(response.sourceData);
@@ -186,6 +188,8 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
           });
         }
       });
+    } else {
+      setUploadedFile(null);
     }
   };
 
@@ -213,6 +217,7 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
       const reader = new FileReader();
       reader.readAsText(file);
       reader.onload = function () {
+        setUploadedFile(files[0]);
         setCustomSchemaFileUploadSource({
           custom_schema_ioc_upload: {
             file_name: files[0].name,
@@ -220,6 +225,8 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
           },
         });
       };
+    } else {
+      setUploadedFile(null);
     }
   };
 

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetails.tsx
@@ -113,8 +113,10 @@ export const ThreatIntelSourceDetails: React.FC<ThreatIntelSourceDetailsProps> =
       shouldDisableSave = false;
     }
 
-    setSaveDisabled(shouldDisableSave || !iocSchema || !!validateCustomSchema(iocSchema));
-  }, [fileUploadSource, customSchemaFileUploadSource, isReadOnly, type, iocSchema]);
+    setSaveDisabled(
+      shouldDisableSave || (hasCustomIocSchema && (!iocSchema || !!validateCustomSchema(iocSchema)))
+    );
+  }, [fileUploadSource, customSchemaFileUploadSource, isReadOnly, type, iocSchema, inputErrors]);
 
   const onNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const name = event.target.value;

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetailsFileUploader.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetailsFileUploader.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import React from 'react';
+import {
+  ThreatIntelSourceFileUploader,
+  ThreatIntelSourceFileUploaderProps,
+} from '../ThreatIntelSourceFileUploader/ThreatIntelSourceFileUploader';
+
+export interface ThreatIntelSourceDetailsFileUploaderProps {
+  isReadOnly: boolean;
+  fileName?: string;
+  fileError: string;
+  helperText: React.ReactNode;
+  onFileUploadChange: ThreatIntelSourceFileUploaderProps['onFileUploadChange'];
+}
+
+export const ThreatIntelSourceDetailsFileUploader: React.FC<ThreatIntelSourceDetailsFileUploaderProps> = ({
+  isReadOnly,
+  fileName,
+  fileError,
+  helperText,
+  onFileUploadChange,
+}) => {
+  return (
+    <>
+      {isReadOnly && (
+        <EuiFormRow label="Uploaded file">
+          <EuiFieldText readOnly={isReadOnly} value={fileName} icon={'download'} />
+        </EuiFormRow>
+      )}
+      {!isReadOnly && (
+        <ThreatIntelSourceFileUploader
+          onFileUploadChange={onFileUploadChange}
+          formLabel="Upload file"
+          formHelperText={helperText}
+          uploaderError={fileError}
+        />
+      )}
+    </>
+  );
+};

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetailsFileUploader.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceDetails/ThreatIntelSourceDetailsFileUploader.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React from 'react';
 import {
   ThreatIntelSourceFileUploader,
@@ -28,9 +28,9 @@ export const ThreatIntelSourceDetailsFileUploader: React.FC<ThreatIntelSourceDet
   return (
     <>
       {isReadOnly && (
-        <EuiFormRow label="Uploaded file">
-          <EuiFieldText readOnly={isReadOnly} value={fileName} icon={'download'} />
-        </EuiFormRow>
+        <EuiCompressedFormRow label="Uploaded file">
+          <EuiCompressedFieldText readOnly={isReadOnly} value={fileName} icon={'download'} />
+        </EuiCompressedFormRow>
       )}
       {!isReadOnly && (
         <ThreatIntelSourceFileUploader

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceFileUploader/ThreatIntelSourceFileUploader.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceFileUploader/ThreatIntelSourceFileUploader.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiFilePicker, EuiFilePickerProps, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
+import React from 'react';
+
+export interface ThreatIntelSourceFileUploaderProps {
+  showHeader?: boolean;
+  formLabel: string;
+  formHelperText: React.ReactNode;
+  uploaderError?: string;
+  onFileUploadChange: EuiFilePickerProps['onChange'];
+}
+
+export const ThreatIntelSourceFileUploader: React.FC<ThreatIntelSourceFileUploaderProps> = ({
+  showHeader = false,
+  formLabel,
+  formHelperText,
+  uploaderError,
+  onFileUploadChange,
+}) => {
+  return (
+    <>
+      {showHeader && (
+        <>
+          <EuiText>
+            <h4>Upload a file</h4>
+          </EuiText>
+          <EuiSpacer />
+        </>
+      )}
+      <EuiFormRow
+        label={formLabel}
+        helpText={formHelperText}
+        isInvalid={!!uploaderError}
+        error={uploaderError}
+      >
+        <EuiFilePicker
+          id={'filePickerId'}
+          fullWidth
+          initialPromptText="Select or drag and drop a file"
+          onChange={onFileUploadChange}
+          display={'large'}
+          multiple={false}
+          aria-label="ioc file picker"
+          isInvalid={!!uploaderError}
+          data-test-subj="import_ioc_file"
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+    </>
+  );
+};

--- a/public/pages/ThreatIntel/components/ThreatIntelSourceFileUploader/ThreatIntelSourceFileUploader.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourceFileUploader/ThreatIntelSourceFileUploader.tsx
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFilePicker, EuiFilePickerProps, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiCompressedFilePicker,
+  EuiFilePickerProps,
+  EuiCompressedFormRow,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import React from 'react';
 
 export interface ThreatIntelSourceFileUploaderProps {
@@ -31,13 +37,13 @@ export const ThreatIntelSourceFileUploader: React.FC<ThreatIntelSourceFileUpload
           <EuiSpacer />
         </>
       )}
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={formLabel}
         helpText={formHelperText}
         isInvalid={!!uploaderError}
         error={uploaderError}
       >
-        <EuiFilePicker
+        <EuiCompressedFilePicker
           id={'filePickerId'}
           fullWidth
           initialPromptText="Select or drag and drop a file"
@@ -48,7 +54,7 @@ export const ThreatIntelSourceFileUploader: React.FC<ThreatIntelSourceFileUpload
           isInvalid={!!uploaderError}
           data-test-subj="import_ioc_file"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer />
     </>
   );

--- a/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
+++ b/public/pages/ThreatIntel/components/ThreatIntelSourcesList/ThreatIntelSourcesList.tsx
@@ -21,7 +21,7 @@ import {
 import { ROUTES } from '../../../../utils/constants';
 import { ThreatIntelSourceItem } from '../../../../../types';
 import { RouteComponentProps } from 'react-router-dom';
-import { IocLabel } from '../../../../../common/constants';
+import { renderIoCType } from '../../../../utils/helpers';
 
 export interface ThreatIntelSourcesListProps {
   threatIntelSources: ThreatIntelSourceItem[];
@@ -87,7 +87,7 @@ export const ThreatIntelSourcesList: React.FC<ThreatIntelSourcesListProps> = ({
                 }
               >
                 {source.ioc_types.map((iocType) => (
-                  <EuiBadge key={iocType}>{IocLabel[iocType]}</EuiBadge>
+                  <EuiBadge key={iocType}>{renderIoCType(iocType)}</EuiBadge>
                 ))}
               </EuiCard>
             </EuiFlexItem>

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.tsx
@@ -56,6 +56,8 @@ import {
   IOC_UPLOAD_MAX_FILE_SIZE,
 } from '../../utils/constants';
 import { ThreatIntelSourceFileUploader } from '../../components/ThreatIntelSourceFileUploader/ThreatIntelSourceFileUploader';
+import { setBreadcrumbs } from '../../../../utils/helpers';
+import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 
 export interface AddThreatIntelSourceProps extends RouteComponentProps {
   threatIntelService: ThreatIntelService;
@@ -353,7 +355,7 @@ export const AddThreatIntelSource: React.FC<AddThreatIntelSourceProps> = ({
         };
         if (useCustomSchemaByType.S3_CUSTOM) {
           payload.ioc_schema = {
-            json_path_schema: JSON.parse(customSchema),
+            json_path_schema: parseCustomSchema(),
           };
         }
         break;

--- a/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
+++ b/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
@@ -303,6 +303,10 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
     setConfigureInProgress(false);
   };
 
+  const isNextDisabled = () => {
+    return !stepDataValid[currentStep] || configureScanFormInputs.logSources.length === 0;
+  };
+
   return (
     <>
       <EuiFlexGroup>
@@ -348,7 +352,7 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
 
         {currentStep === ConfigureThreatIntelScanStep.SelectLogSources && (
           <EuiFlexItem grow={false}>
-            <EuiSmallButton fill={true} onClick={onNextClick} disabled={!stepDataValid[currentStep]}>
+            <EuiSmallButton fill={true} onClick={onNextClick} disabled={isNextDisabled()}>
               Next
             </EuiSmallButton>
           </EuiFlexItem>

--- a/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
+++ b/public/pages/ThreatIntel/containers/ThreatIntelSource/ThreatIntelSource.tsx
@@ -25,13 +25,14 @@ import {
 import { DescriptionGroup } from '../../../../components/Utility/DescriptionGroup';
 import { IoCsTable } from '../../components/IoCsTable/IoCsTable';
 import { ThreatIntelSourceDetails } from '../../components/ThreatIntelSourceDetails/ThreatIntelSourceDetails';
-import { IocLabel } from '../../../../../common/constants';
+import { ThreatIntelIocSourceType } from '../../../../../common/constants';
 import { ThreatIntelService } from '../../../../services';
 import {
   errorNotificationToast,
   parseSchedule,
   renderTime,
   setBreadcrumbs,
+  renderIoCType,
 } from '../../../../utils/helpers';
 import DeleteModal from '../../../../components/DeleteModal';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -154,7 +155,7 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
     enabled,
     enabled_for_scan,
   } = source;
-  const schedule = type === 'S3_CUSTOM' ? source.schedule : undefined;
+  const schedule = type === ThreatIntelIocSourceType.S3_CUSTOM ? source.schedule : undefined;
   const showActivateControls = 'enabled_for_scan' in source;
 
   const headerControls = [];
@@ -249,12 +250,15 @@ export const ThreatIntelSource: React.FC<ThreatIntelSource> = ({
               title: 'Last updated',
               description: renderTime(last_update_time),
             },
-            { title: 'Ioc types', description: ioc_types.map((ioc) => IocLabel[ioc]).join(', ') },
+            {
+              title: 'Ioc types',
+              description: ioc_types.map((ioc) => renderIoCType(ioc)).join(', '),
+            },
           ]}
         />
       </EuiPanel>
       <EuiSpacer />
-      <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} size="s"/>
+      <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} size="s" />
       {showDeleteModal && (
         <DeleteModal
           type="threat intel source"

--- a/public/pages/ThreatIntel/utils/constants.ts
+++ b/public/pages/ThreatIntel/utils/constants.ts
@@ -3,28 +3,71 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IocLabel, ThreatIntelIocType } from '../../../../common/constants';
+import { ThreatIntelSourceFormInputFieldsTouched } from '../../../../types';
 
 export enum ConfigureThreatIntelScanStep {
   SelectLogSources = 'SelectLogSources',
   SetupAlertTriggers = 'SetupAlertTriggers',
 }
 
-export const checkboxes: { id: ThreatIntelIocType; label: string }[] = [
-  {
-    id: ThreatIntelIocType.IPV4,
-    label: IocLabel[ThreatIntelIocType.IPV4],
+export const IOC_UPLOAD_MAX_FILE_SIZE = 512000;
+
+export const IOC_SCHEMA_CODE_EDITOR_MAX_LINES = 25;
+
+export const CUSTOM_SCHEMA_PLACEHOLDER = {
+  type: {
+    json_path: '[place your JSON path here] -- required',
   },
-  {
-    id: ThreatIntelIocType.IPV6,
-    label: IocLabel[ThreatIntelIocType.IPV6],
+  value: {
+    json_path: '[place your JSON path here] -- required',
   },
-  {
-    id: ThreatIntelIocType.Domain,
-    label: IocLabel[ThreatIntelIocType.Domain],
+  id: {
+    json_path: '[place your JSON path here] -- optional',
   },
-  {
-    id: ThreatIntelIocType.FileHash,
-    label: IocLabel[ThreatIntelIocType.FileHash],
+  name: {
+    json_path: '[place your JSON path here] -- optional',
   },
-];
+  severity: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  created: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  modified: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  description: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  labels: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  spec_version: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  feed_id: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+  feed_name: {
+    json_path: '[place your JSON path here] -- optional',
+  },
+};
+
+export const defaultInputTouched: ThreatIntelSourceFormInputFieldsTouched = {
+  name: false,
+  description: false,
+  schedule: false,
+  customSchema: false,
+  customSchemaIocFileUpload: {
+    file: false,
+  },
+  iocFileUpload: {
+    file: false,
+  },
+  s3: {
+    role_arn: false,
+    bucket_name: false,
+    object_key: false,
+    region: false,
+  },
+};

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -86,8 +86,8 @@ export class SecurityAnalyticsPlugin
       hash = `#/?dataSourceId=${dataSourceValue}`;
     }
     return {
-      defaultPath: hash
-    }
+      defaultPath: hash,
+    };
   };
 
   private appStateUpdater = new BehaviorSubject<AppUpdater>(
@@ -281,7 +281,7 @@ export class SecurityAnalyticsPlugin
     setContentManagement(contentManagement);
     setNotifications(core.notifications);
     setSavedObjectsClient(core.savedObjects.client);
-    initializeServices(core, data.indexPatterns);
+    initializeServices(core, data.indexPatterns, data.search);
     registerThreatAlertsCard();
 
     return {};

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -58,7 +58,6 @@ import { LogCategoryOptionView } from '../components/Utility/LogCategoryOption';
 import { getLogTypeLabel } from '../pages/LogTypes/utils/helpers';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import dateMath from '@elastic/datemath';
-import { IocLabel, ThreatIntelIocType } from '../../common/constants';
 import { parse, View } from 'vega/build-es5/vega.js';
 import { compile } from 'vega-lite';
 import { Handler } from 'vega-tooltip';
@@ -647,8 +646,9 @@ export async function getFieldsForIndex(
   return fields;
 }
 
-export function renderIoCType(iocType: ThreatIntelIocType) {
-  return IocLabel[iocType] || DEFAULT_EMPTY_DATA;
+export function renderIoCType(iocType: string) {
+  const val = _.capitalize(iocType) || DEFAULT_EMPTY_DATA;
+  return val;
 }
 
 export function setBreadcrumbs(crumbs: ChromeBreadcrumb[]) {

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -84,7 +84,7 @@ import semver from 'semver';
 import * as pluginManifest from '../../opensearch_dashboards.json';
 import { DataSourceThreatAlertsCard } from '../components/DataSourceThreatAlertsCard/DataSourceThreatAlertsCard';
 import { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
-import { RouteComponentProps } from 'react-router-dom';
+import { ISearchStart } from '../../../../src/plugins/data/public';
 
 export const parseStringsToOptions = (strings: string[]) => {
   return strings.map((str) => ({ id: str, label: str }));
@@ -735,14 +735,18 @@ export function getEuiEmptyPrompt(message: string) {
   );
 }
 
-export function initializeServices(coreStart: CoreStart, indexPattern: CoreIndexPatternsService) {
+export function initializeServices(
+  coreStart: CoreStart,
+  indexPattern: CoreIndexPatternsService,
+  search: ISearchStart
+) {
   const { http, savedObjects } = coreStart;
 
   const detectorsService = new DetectorsService(http);
   const correlationsService = new CorrelationService(http);
   const indexService = new IndexService(http);
   const findingsService = new FindingsService(http, coreStart.notifications);
-  const opensearchService = new OpenSearchService(http, savedObjects.client);
+  const opensearchService = new OpenSearchService(http, savedObjects.client, search);
   const fieldMappingService = new FieldMappingService(http);
   const alertsService = new AlertsService(http, coreStart.notifications);
   const ruleService = new RuleService(http);


### PR DESCRIPTION
### Description
This PR adds support for providing custom schema for IOCs when creating threat intel source.

- For S3 source
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/4ef7c574-e8bb-4c2f-bde6-30ab584cfa36" />

- For IOC file upload
<img width="936" alt="image" src="https://github.com/user-attachments/assets/70010dd0-497a-4f19-8543-c1414bbfde86" />


### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).