### PR TITLE
Fix integ tests

### DIFF
--- a/.cypress/integration/1_detectors.spec.js
+++ b/.cypress/integration/1_detectors.spec.js
@@ -103,15 +103,18 @@ const validateAutomaticFieldMappingsPanel = (mappings) =>
   });
 
 const validatePendingFieldMappingsPanel = (mappings) => {
-  cy.get('.editFieldMappings').within(() => {
-    // Pending field mappings
-    cy.getElementByText('.euiText', 'Pending field mappings')
-      .parents('.euiPanel')
-      .within(() => {
-        cy.getElementByTestSubject('pending-mapped-fields-table')
-          .find('.euiBasicTable')
-          .validateTable(mappings);
-      });
+  cy.get('.editFieldMappings').each(($element) => {
+    cy.wrap($element).within(() => {
+      // Pending field mappings
+      cy.getElementByText('.euiText', 'Pending field mappings')
+        .parents('.euiPanel')
+        .first()
+        .within(() => {
+          cy.getElementByTestSubject('pending-mapped-fields-table')
+            .find('.euiBasicTable')
+            .validateTable(mappings);
+        });
+    });
   });
 };
 
@@ -312,7 +315,7 @@ describe('Detectors', () => {
         .blur()
         .parentsUntil('.euiFormRow__fieldWrapper')
         .siblings()
-        .contains('Select an input source.');
+        .contains('Select an input source for the detector.');
 
       getDataSourceField().selectComboboxItem(cypressIndexDns);
       getDataSourceField()

--- a/.cypress/integration/2_rules.spec.js
+++ b/.cypress/integration/2_rules.spec.js
@@ -288,7 +288,8 @@ describe('Rules', () => {
 
     it('...should validate log type field', () => {
       getLogTypeField().should('be.empty');
-      getLogTypeField().focus().blur();
+      cy.get('[data-test-subj="comboBoxInput"]').first().click();
+      cy.get('[data-test-subj="comboBoxInput"]').eq(1).click();
       getLogTypeField().containsError('Log type is required');
 
       getLogTypeField().selectComboboxItem(getLogTypeLabel(SAMPLE_RULE.logType));
@@ -296,8 +297,8 @@ describe('Rules', () => {
     });
 
     it('...should validate rule level field', () => {
-      getRuleLevelField().should('be.empty');
-      getRuleLevelField().focus().blur();
+      cy.get('[data-test-subj="comboBoxInput"]').eq(1).click();
+      cy.get('[data-test-subj="comboBoxInput"]').first().click();
       getRuleLevelField().containsError('Rule level is required');
 
       getRuleLevelField().selectComboboxItem(SAMPLE_RULE.severity);
@@ -309,7 +310,8 @@ describe('Rules', () => {
       getRuleStatusField().focus().blur().shouldNotHaveError();
 
       getRuleStatusField().clearCombobox();
-      getRuleStatusField().focus().blur();
+      cy.get('[data-test-subj="comboBoxInput"]').eq(2).click();
+      cy.get('[data-test-subj="comboBoxInput"]').first().click();
       getRuleStatusField().containsError('Rule status is required');
     });
 

--- a/.cypress/support/helpers.js
+++ b/.cypress/support/helpers.js
@@ -226,16 +226,15 @@ Cypress.Commands.add(
         const length = data.length;
         length && cy.get($tr).should('have.length', length);
 
-        cy.get($tr).within(($tr) => {
-          data.map((rowData) => {
-            rowData.forEach((tdData) => {
-              if (typeof tdData === 'string') {
-                tdData && cy.get($tr).find('td').contains(`${tdData}`);
-              } else {
-                // if rule is an object then use path
-                tdData && cy.get($tr).find('td').contains(`${tdData.path}`);
+        data.forEach((rowData) => {
+          rowData.forEach((tdData) => {
+            if (typeof tdData === 'string') {
+              if (tdData) {
+                cy.get($tr).contains(tdData).should('exist').and('be.visible');
               }
-            });
+            } else if (tdData && tdData.path) {
+              cy.get($tr).contains(tdData.path).should('exist').and('be.visible');
+            }
           });
         });
       });

--- a/.cypress/support/typings.js
+++ b/.cypress/support/typings.js
@@ -9,7 +9,7 @@ Cypress.Commands.add(
     prevSubject: true,
   },
   (subject, text) => {
-    return cy.get(subject).clear().ospType(text).realPress('Enter');
+    return cy.get(subject).clear().ospType(text).type('{enter}');
   }
 );
 
@@ -34,7 +34,7 @@ Cypress.Commands.add(
     prevSubject: true,
   },
   (subject, text) => {
-    return cy.get(subject).wait(10).focus().realType(text);
+    return cy.get(subject).wait(10).focus().type(text);
   }
 );
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,10 +2,10 @@ name: Cypress integration tests workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
-      - "*"
+      - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
   OPENSEARCH_VERSION: '3.0.0-beta1-SNAPSHOT'
@@ -132,10 +132,10 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          command: yarn run cypress run
+          command: yarn run cypress run --browser firefox
           wait-on: 'http://localhost:5601'
           wait-on-timeout: 300
-          browser: chrome
+          browser: firefox
         env:
           CYPRESS_CACHE_FOLDER: ${{ matrix.cypress_cache_folder }}
 


### PR DESCRIPTION
### Description
Change the browser used to run cypress tests to `firefox`. With the current cypress version, the chrome and electron browsers installed have a memory management issue and the browser crashes frequently when running the tests. So, change the browser to `firefox`. Also, fix the failing integ tests.

### Issues Resolved
[[AUTOCUT] Integration Test Failed for securityAnalyticsDashboards-3.0.0](https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/1273)

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).