### PR TITLE
Replace deprecated safeDump with dump

### DIFF
--- a/public/store/RulesStore.ts
+++ b/public/store/RulesStore.ts
@@ -4,7 +4,7 @@
  */
 
 import { RuleService } from '../services';
-import { load, safeDump } from 'js-yaml';
+import { load, dump } from 'js-yaml';
 import { RuleItemInfoBase, IRulesStore, IRulesCache, Rule } from '../../types';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { errorNotificationToast } from '../utils/helpers';
@@ -209,7 +209,7 @@ export class RulesStore implements IRulesStore {
 
       try {
         const detectionJson = load(ruleInfo._source.rule).detection;
-        detectionYaml = safeDump(detectionJson);
+        detectionYaml = dump(detectionJson);
       } catch (_error: any) {}
 
       return {

--- a/server/services/RuleService.ts
+++ b/server/services/RuleService.ts
@@ -22,7 +22,7 @@ import {
 } from '../models/interfaces';
 import { CLIENT_RULE_METHODS } from '../utils/constants';
 import { ServerResponse } from '../models/types';
-import { load, safeDump } from 'js-yaml';
+import { load, dump } from 'js-yaml';
 import moment from 'moment';
 import { Rule } from '../../types';
 import { DEFAULT_RULE_UUID } from '../../common/constants';
@@ -75,7 +75,7 @@ export default class RulesService extends MDSEnabledClientService {
       if (false_positives.length > 0) {
         jsonPayload['falsepositives'] = false_positives.map((falsePos) => falsePos.value);
       }
-      const ruleYamlPayload = safeDump(jsonPayload);
+      const ruleYamlPayload = dump(jsonPayload);
 
       const params: CreateRuleParams = {
         body: ruleYamlPayload,
@@ -217,7 +217,7 @@ export default class RulesService extends MDSEnabledClientService {
         jsonPayload['falsepositives'] = false_positives.map((falsePos) => falsePos.value);
       }
 
-      const ruleYamlPayload = safeDump(jsonPayload);
+      const ruleYamlPayload = dump(jsonPayload);
       const params: UpdateRuleParams = { body: ruleYamlPayload, category, ruleId };
       const client = this.getClient(request, context);
       const createRuleResponse: UpdateRuleResponse = await client(


### PR DESCRIPTION
### Description
This PR replaces the deprecated `safeDump` from js-yaml with `dump`. Integration tests in functional test repository are failing because of this.

Image is not very clear, but the error message is something like Function yaml.safeDump is removed. Use yaml.dump instead.
![image](https://github.com/user-attachments/assets/97d9c9db-5a42-4a71-b340-89b937014bea)


### Issues Resolved
Fixes integration test in functional test repository.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).