### PR TITLE
Upgrade github cypress cache actions to v4

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Get Cypress version
         id: cypress_version
         run: |
+          export NODE_OPTIONS=--max_old_space_size=8192
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
           echo "::set-output name=cypress_version::$(cat ./package.json | jq '.dependencies.cypress' | tr -d '"')"
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ matrix.cypress_cache_folder }}
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -130,10 +130,9 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          command: yarn run cypress run --browser firefox
+          command: yarn run cypress run
           wait-on: 'http://localhost:5601'
           wait-on-timeout: 300
-          browser: firefox
         env:
           CYPRESS_CACHE_FOLDER: ${{ matrix.cypress_cache_folder }}
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -98,7 +98,9 @@ jobs:
 
       - name: Sleep until OSD server starts - non-windows
         if: ${{ matrix.os != 'windows-latest' }}
-        run: sleep 450
+        run: |
+          export NODE_OPTIONS=--max_old_space_size=8192
+          sleep 450
         shell: bash
 
       - name: Install Cypress
@@ -112,7 +114,6 @@ jobs:
       - name: Get Cypress version
         id: cypress_version
         run: |
-          export NODE_OPTIONS=--max_old_space_size=8192
           cd OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
           echo "::set-output name=cypress_version::$(cat ./package.json | jq '.dependencies.cypress' | tr -d '"')"
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,10 +2,10 @@ name: Cypress integration tests workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
-      - "*"
+      - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
   SECURITY_ANALYTICS_BRANCH: '2.x'
@@ -129,10 +129,10 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          command: yarn run cypress run
+          command: yarn run cypress run --browser firefox
           wait-on: 'http://localhost:5601'
           wait-on-timeout: 300
-          browser: chrome
+          browser: firefox
         env:
           CYPRESS_CACHE_FOLDER: ${{ matrix.cypress_cache_folder }}
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -127,7 +127,7 @@ jobs:
 
       # for now just chrome, use matrix to do all browsers later
       - name: Cypress tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v4
         with:
           working-directory: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
           command: yarn run cypress run


### PR DESCRIPTION
### Description
Upgrades the version of github cypress cache actions to v4 to fix cypress tests on 2.19

### Issues Resolved
Fix CI failures in 2.19

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).