### PR TITLE
Bug-Fix: Display alerts when a configured correlation rule is opened

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,6 @@ on:
       - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.x'
   SECURITY_ANALYTICS_BRANCH: '2.x'
   GRADLE_VERSION: '7.6.1'
 jobs:
@@ -50,7 +49,7 @@ jobs:
       - name: Run opensearch with plugin
         run: |
           cd security-analytics
-          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
+          ./gradlew run &
           sleep 300
         shell: bash
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -129,10 +129,10 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin
-          command: yarn run cypress run
+          command: yarn run cypress run --browser firefox
           wait-on: 'http://localhost:5601'
           wait-on-timeout: 300
-          browser: chrome
+          browser: firefox
         env:
           CYPRESS_CACHE_FOLDER: ${{ matrix.cypress_cache_folder }}
 

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,10 +2,10 @@ name: Cypress integration tests workflow
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
-      - "*"
+      - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
   SECURITY_ANALYTICS_BRANCH: '2.x'
@@ -117,7 +117,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ matrix.cypress_cache_folder }}
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,11 +8,14 @@ on:
       - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_VERSION: '2.x'
   SECURITY_ANALYTICS_BRANCH: '2.x'
+  GRADLE_VERSION: '7.6.1'
 jobs:
   tests:
     name: Run Cypress E2E tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         include:
@@ -31,7 +34,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           # TODO: Parse this from security analytics plugin (https://github.com/opensearch-project/security-analytics/issues/170)
-          java-version: 17
+          java-version: 21
 
       - name: Enable longer filenames
         if: ${{ matrix.os == 'windows-latest' }}
@@ -47,7 +50,7 @@ jobs:
       - name: Run opensearch with plugin
         run: |
           cd security-analytics
-          ./gradlew run &
+          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
           sleep 300
         shell: bash
 
@@ -120,9 +123,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ matrix.cypress_cache_folder }}
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin/package.json') }}
           restore-keys: |
-            cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+            cypress-cache-v2-${{ runner.os }}-${{ hashFiles('OpenSearch-Dashboards/plugins/security-analytics-dashboards-plugin/package.json') }}
 
       # for now just chrome, use matrix to do all browsers later
       - name: Cypress tests

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           # TODO: Parse this from security analytics plugin (https://github.com/opensearch-project/security-analytics/issues/170)
-          java-version: 21
+          java-version: 17
 
       - name: Enable longer filenames
         if: ${{ matrix.os == 'windows-latest' }}

--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -906,6 +906,12 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
             props.resetForm();
           }
 
+          useEffect(() => {
+            if (trigger?.id) {
+              setShowForm(true);
+            }
+          }, [trigger?.id]);
+
           return (
             <Form>
               <ContentPanel
@@ -1010,15 +1016,17 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
                   <p>Get an alert on the correlation between the findings.</p>
                 </EuiText>
                 <EuiSpacer size="m" />
-                <EuiCompressedFormRow>
-                  <EuiFlexGroup>
-                    <EuiFlexItem grow={false}>
-                      <EuiSmallButton onClick={() => setShowForm(!showForm)}>
-                        Add Alert Trigger
-                      </EuiSmallButton>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiCompressedFormRow>
+                {!showForm && (
+                  <EuiCompressedFormRow>
+                    <EuiFlexGroup>
+                      <EuiFlexItem grow={false}>
+                        <EuiSmallButton onClick={() => setShowForm(!showForm)}>
+                          Add Alert Trigger
+                        </EuiSmallButton>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiCompressedFormRow>
+                )}
                 {showForm && (
                   <>
                     <EuiSpacer size="m" />


### PR DESCRIPTION
### Description
This PR fixes the bug - When the user clicks on a existing correlation rule and lands on edit correlation rule page, the alerts trigger must be shown instead of the `Add alerts trigger` button.

### Issues Resolved
No issue created.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).