### PR TITLE
Update API call to get IOC types

### DIFF
--- a/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
+++ b/public/pages/Alerts/containers/Alerts/__snapshots__/Alerts.test.tsx.snap
@@ -961,6 +961,7 @@ exports[`<Alerts /> spec renders the component 1`] = `
                 }
               }
               onTabClick={[Function]}
+              preserveTabContent={false}
               size="s"
               tabs={
                 Array [

--- a/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
+++ b/public/pages/ThreatIntel/containers/ScanConfiguration/ThreatIntelScanConfigForm.tsx
@@ -249,6 +249,7 @@ export const ThreatIntelScanConfigForm: React.FC<ThreatIntelScanConfigFormProps>
             notifications={notifications}
             updateSources={onSourcesChange}
             updateSchedule={onScheduleChange}
+            threatIntelService={threatIntelService}
           />
         );
       case ConfigureThreatIntelScanStep.SetupAlertTriggers:


### PR DESCRIPTION
### Description
Update API call to fetch threat intel IOC types. Use searchThreatIntelSource API call and then collect all the IOC types instead of making a _search call to .opensearch-sap-ioc*

### Issues Resolved
Removed dependency on `_search` call to fetch IOC types.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).