### PR TITLE
Remove correlated findings bar chart that uses vega

### DIFF
--- a/public/pages/Correlations/containers/CorrelationsTableView.tsx
+++ b/public/pages/Correlations/containers/CorrelationsTableView.tsx
@@ -3,20 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React from 'react';
-import {
-  EuiLoadingChart,
-  EuiPanel,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiTitle,
-  EuiSpacer,
-  EuiEmptyPrompt,
-  EuiSmallButton,
-  EuiText,
-} from '@elastic/eui';
-import { ChartContainer } from '../../../components/Charts/ChartContainer';
+import { EuiLoadingChart } from '@elastic/eui';
 import { DEFAULT_DATE_RANGE, ROUTES } from '../../../utils/constants';
-import { renderVisualization } from '../../../utils/helpers';
 import { getChartTimeUnit, getDomainRange } from '../../Overview/utils/helpers';
 import { getCorrelatedFindingsVisualizationSpec } from '../utils/helpers';
 import { CorrelationsTableData } from './CorrelationsContainer';
@@ -157,52 +145,6 @@ export class CorrelationsTableView extends React.Component<
     );
   };
 
-  private renderCorrelatedFindingsChart = () => {
-    renderVisualization(
-      this.generateVisualizationSpec(this.props.connectedFindings),
-      'correlated-findings-view'
-    );
-    return this.props.connectedFindings.length > 0 ? (
-      <>
-        <EuiPanel>
-          <EuiFlexGroup direction="column" gutterSize="m">
-            <EuiFlexItem>
-              <EuiFlexGroup justifyContent="spaceBetween">
-                <EuiFlexItem grow={false}>
-                  <EuiTitle size="s">
-                    <h3>Correlated Findings</h3>
-                  </EuiTitle>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <ChartContainer chartViewId="correlated-findings-view" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiPanel>
-        <EuiSpacer />
-      </>
-    ) : (
-      <EuiEmptyPrompt
-        title={
-          <EuiText size="s">
-            <h2>No correlations found</h2>
-          </EuiText>
-        }
-        body={
-          <EuiText size="s">
-            <p>There are no correlated findings in the system.</p>
-          </EuiText>
-        }
-        actions={[
-          <EuiSmallButton fill={true} color="primary" href={`#${ROUTES.CORRELATION_RULE_CREATE}`}>
-            Create correlation rule
-          </EuiSmallButton>,
-        ]}
-      />
-    );
-  };
-
   private getFilteredTableData = (tableData: CorrelationsTableData[]): CorrelationsTableData[] => {
     const { logTypeFilterOptions, severityFilterOptions, searchTerm } = this.props;
     const alertSeverityMap: { [key: string]: string } = {
@@ -284,7 +226,7 @@ export class CorrelationsTableView extends React.Component<
   render() {
     return (
       <>
-        {this.renderCorrelatedFindingsChart()}
+        {/* {this.renderCorrelatedFindingsChart()} */}
         {this.renderCorrelationsTable(this.props.loadingTableData)}
         {this.state.isFlyoutOpen && (
           <CorrelationsTableFlyout


### PR DESCRIPTION
### Description
This PR aims to fix the correlations page by removing the bar chart showing the count of correlated findings over time which uses vega.

### Issues Resolved
Broken correlations page.

### Screenshots
<img width="1728" height="786" alt="Screenshot 2025-07-23 at 12 22 45 AM" src="https://github.com/user-attachments/assets/c574caf7-b2b7-4e29-9499-952584d34ede" />
<img width="1728" height="1041" alt="Screenshot 2025-07-23 at 12 23 03 AM" src="https://github.com/user-attachments/assets/f96a3fb0-405e-4699-b141-83b1a3474873" />


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).