### PR TITLE
[Bug fix] Fix empty severity column bug.

### DIFF
--- a/public/pages/Findings/containers/Findings/Findings.tsx
+++ b/public/pages/Findings/containers/Findings/Findings.tsx
@@ -248,16 +248,16 @@ class Findings extends Component<FindingsProps, FindingsState> {
     }: { tabId: T; field: F; value: FindingsState['findingStateByTabId'][T][F] },
     otherState?: Partial<Pick<FindingsState, keyof Omit<FindingsState, 'findingStateByTabId'>>>
   ) {
-    this.setState({
+    this.setState((prevState) => ({
       ...(otherState as any),
       findingStateByTabId: {
-        ...this.state.findingStateByTabId,
+        ...prevState.findingStateByTabId,
         [tabId]: {
-          ...this.state.findingStateByTabId[tabId],
+          ...prevState.findingStateByTabId[tabId],
           [field]: value,
         },
       },
-    });
+    }));
   }
 
   onStreamingFindings = async (findings: FindingItemType[]) => {


### PR DESCRIPTION
### Description
The `4_findings.spec.js/Findings -- displays findings based on recently ingested data` cypress test was failing because the severity column in the findings table was not properly displaying the severity for findings; it was just displaying `-`.

This bug is only present in 3.x versions; it resulted from the removal of the visualization assets in 3.x. This bug could potentially exist in older versions, but the functions used to prepare the visualizations are pulling the needed information to populate the table.

### Testing
Confirmed issue is fixed using the 3.6 RC that's in progress.
<img width="716" height="533" alt="Screenshot 2026-03-27 at 5 00 53 PM" src="https://github.com/user-attachments/assets/59a118ce-bdde-429e-895d-90690cc36743" />


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).