### PR TITLE
Resolve CVE-2026-33750 by bumping brace-expansion to ^5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "ws": "^7.5.10",
     "elliptic": "^6.6.1",
     "pbkdf2": "^3.1.3",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "brace-expansion": "^5.0.5"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-33750 (MEDIUM severity) by adding `brace-expansion@^5.0.5` to yarn resolutions in `package.json`.

## Details
A brace pattern with a zero step value (e.g., `{1..2..0}`) causes the sequence generation loop to run indefinitely, making the process hang for seconds and allocate heaps of memory. The increment is computed as `Math.abs(0) = 0`, so the loop variable never advances. On a test machine, the process hangs for about 3.5 seconds and allocates roughly 1.9 GB of memory before throwing a `RangeError`. Setting `max` to any value has no effect because the limit is only checked at the output combination step, not during sequence generation.

This affects any application that passes untrusted strings to `expand()`, or by error sets a step value of 0. That includes tools built on minimatch/glob that resolve patterns from CLI arguments or config files. The input needed is just 10 bytes.

## Impact
A brace pattern with a zero step value (e.g., `{1..2..0}`) causes the sequence generation loop to run indefinitely, making the process hang for seconds and allocate heaps of memory.

## Fix
- Added `brace-expansion: ^5.0.5` to yarn resolutions in `package.json`
- In version 5.0.5+, a step increment of 0 is now sanitized to 1, which matches bash behavior

## Test Plan
- [ ] Verify `brace-expansion` resolves to `>=5.0.5` after `yarn install`
- [ ] Verify no regressions in build or tests