### PR TITLE
Resolve CVE-2026-33750 by bumping brace-expansion to ^5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "async": "^3.2.3",
     "json5": "^2.2.3",
     "@babel/core": "^7.20.12",
-    "@babel/traverse": "^7.20.12"
+    "@babel/traverse": "^7.20.12",
+    "brace-expansion": "^5.0.5"
   },
   "devDependencies": {
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-33750 (MEDIUM severity) by adding `brace-expansion@^5.0.5` to yarn resolutions in `package.json`.

## Details
A brace pattern with a zero step value (e.g., `{1..2..0}`) causes the sequence generation loop to run indefinitely, making the process hang for seconds and allocate heaps of memory. The increment is computed as `Math.abs(0) = 0`, so the loop variable never advances. On a test machine, the process hangs for about 3.5 seconds and allocates roughly 1.9 GB of memory before throwing a `RangeError`. Setting `max` to any value has no effect because the limit is only checked at the output combination step, not during sequence generation.

This affects any application that passes untrusted strings to `expand()`, or by error sets a step value of 0. That includes tools built on minimatch/glob that resolve patterns from CLI arguments or config files. The input needed is just 10 bytes.

## Impact
A brace pattern with a zero step value (e.g., `{1..2..0}`) causes the sequence generation loop to run indefinitely, making the process hang for seconds and allocate heaps of memory.

## Fix
- Added `brace-expansion: ^5.0.5` to yarn resolutions in `package.json`
- In version 5.0.5+, a step increment of 0 is now sanitized to 1, which matches bash behavior

## Test Plan
- [ ] Verify `brace-expansion` resolves to `>=5.0.5` after `yarn install`
- [ ] Verify no regressions in build or tests