### PR TITLE
Resolved CVE-2026-27904, CVE-2026-33532, and CVE-2026-33672.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
     "sha.js": "^2.4.12",
     "form-data": "4.0.4",
     "brace-expansion": "^5.0.5",
-    "lodash-es": "^4.18.0"
+    "lodash-es": "^4.18.0",
+    "minimatch": "^3.1.4",
+    "yaml": "^1.10.3",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-27904 (HIGH severity) by bumping the `minimatch` yarn resolution to `^3.1.4` in `package.json`.

## Details
Nested `*()` extglobs produce regexps with nested unbounded quantifiers (e.g. `(?:(?:a|b)*)*`), which exhibit catastrophic backtracking in V8. With a 12-byte pattern `*(*(*(a|b)))` and an 18-byte non-matching input, `minimatch()` stalls for over 7 seconds. Adding a single nesting level or a few input characters pushes this to minutes.

This is triggered by the default `minimatch()` API with no special options, and the minimum viable pattern is only 12 bytes. The same issue affects `+()` extglobs equally.

## Impact
Nested `*()` extglobs produce regexps with nested unbounded quantifiers which exhibit catastrophic backtracking in V8. A 12-byte pattern with an 18-byte non-matching input stalls `minimatch()` for over 7 seconds. This is a HIGH severity ReDoS vulnerability affecting any context where an attacker can influence the glob pattern passed to `minimatch()`.

## Fix
- Bumped `minimatch` resolution to `^3.1.4` in `package.json`
- Version 3.1.4 addresses the catastrophic backtracking in nested extglob patterns

## Test Plan
- [ ] Verify `minimatch` resolves to `>=3.1.4` after `yarn install`
- [ ] Verify no regressions in build or tests