### PR TITLE
Resolve CVE-2026-27904 by bumping minimatch to ^3.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "vis-data": "7.1.6",
     "braces": "^3.0.3",
     "micromatch": "^4.0.8",
-    "ws": "^7.5.10"
+    "ws": "^7.5.10",
+    "minimatch": "^3.1.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-27904 (HIGH severity) by bumping the `minimatch` yarn resolution to `^3.1.4` in `package.json`.

## Details
Nested `*()` extglobs produce regexps with nested unbounded quantifiers (e.g. `(?:(?:a|b)*)*`), which exhibit catastrophic backtracking in V8. With a 12-byte pattern `*(*(*(a|b)))` and an 18-byte non-matching input, `minimatch()` stalls for over 7 seconds. Adding a single nesting level or a few input characters pushes this to minutes.

This is triggered by the default `minimatch()` API with no special options, and the minimum viable pattern is only 12 bytes. The same issue affects `+()` extglobs equally.

## Impact
Nested `*()` extglobs produce regexps with nested unbounded quantifiers which exhibit catastrophic backtracking in V8. A 12-byte pattern with an 18-byte non-matching input stalls `minimatch()` for over 7 seconds. This is a HIGH severity ReDoS vulnerability affecting any context where an attacker can influence the glob pattern passed to `minimatch()`.

## Fix
- Bumped `minimatch` resolution to `^3.1.4` in `package.json`
- Version 3.1.4 addresses the catastrophic backtracking in nested extglob patterns

## Test Plan
- [ ] Verify `minimatch` resolves to `>=3.1.4` after `yarn install`
- [ ] Verify no regressions in build or tests