### PR TITLE
Resolve CVE-2026-33672 by bumping picomatch to ^2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "vis-data": "7.1.6",
     "braces": "^3.0.3",
     "micromatch": "^4.0.8",
-    "ws": "^7.5.10"
+    "ws": "^7.5.10",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-33672 (MEDIUM severity) by adding `picomatch@^2.3.2` to yarn resolutions in `package.json`.

## Details
picomatch is vulnerable to a method injection vulnerability (CWE-1321) affecting the `POSIX_REGEX_SOURCE` object. Because the object inherits from `Object.prototype`, specially crafted POSIX bracket expressions (e.g., `[[:constructor:]]`) can reference inherited method names. These methods are implicitly converted to strings and injected into the generated regular expression.

This leads to incorrect glob matching behavior (integrity impact), where patterns may match unintended filenames. The issue does not enable remote code execution, but it can cause security-relevant logic errors in applications that rely on glob matching for filtering, validation, or access control.

## Impact
All users of affected picomatch versions that process untrusted or user-controlled glob patterns are potentially impacted. Specially crafted POSIX bracket expressions can cause patterns to match unintended filenames.

## Fix
- Added `picomatch: ^2.3.2` to yarn resolutions in `package.json`
- Version 2.3.2 fixes the `POSIX_REGEX_SOURCE` object to use a null prototype, preventing inherited method injection

## Test Plan
- [ ] Verify `picomatch` resolves to `>=2.3.2` after `yarn install`
- [ ] Verify no regressions in build or tests