### PR TITLE
Resolve CVE-2026-33532 by bumping yaml to ^1.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "vis-data": "7.1.6",
     "braces": "^3.0.3",
     "micromatch": "^4.0.8",
-    "ws": "^7.5.10"
+    "ws": "^7.5.10",
+    "yaml": "^1.10.3"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-33532 (MEDIUM severity) by adding `yaml@^1.10.3` to yarn resolutions in `package.json`.

## Details
Parsing a YAML document with the `yaml` npm package may throw a `RangeError` due to a stack overflow. The node resolution/composition phase uses recursive function calls without a depth bound. An attacker who can supply YAML for parsing can trigger a `RangeError: Maximum call stack size exceeded` with a small payload (~2-10 KB).

The `RangeError` is not a `YAMLParseError`, so applications that only catch YAML-specific errors will encounter an unexpected exception type. Depending on the host application's exception handling, this can fail requests or terminate the Node.js process.

## Impact
Parsing a YAML document with the `yaml` npm package may throw a `RangeError` due to a stack overflow with a small payload (~2-10 KB). Depending on exception handling, this can fail requests or terminate the Node.js process.

## Fix
- Added `yaml: ^1.10.3` to yarn resolutions in `package.json`
- Version 1.10.3 adds a depth bound to the compose/resolve phase, preventing stack overflow from deeply nested YAML documents

## Test Plan
- [ ] Verify `yaml` resolves to `>=1.10.3` after `yarn install`
- [ ] Verify no regressions in build or tests