### PR TITLE
Resolved CVE-2026-4800, CVE-2026-27904, CVE-2026-33532, and CVE-2026-33672.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.12.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.12'
   SECURITY_ANALYTICS_BRANCH: '2.12'
 jobs:
   tests:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.12.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.12'
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "kind-of": "^6.0.3",
     "glob-parent": "^5.1.2",
     "ssri": "^6.0.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "hosted-git-info": "^2.8.9",
     "json-schema": "^0.4.0",
     "ansi-regex": "^5.0.1",
@@ -56,7 +56,8 @@
     "word-wrap": "^1.2.4",
     "@cypress/request": "^3.0.0",
     "vis-data": "7.1.6",
-    "brace-expansion": "^5.0.5"
+    "brace-expansion": "^5.0.5",
+    "lodash-es": "^4.18.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
     "@cypress/request": "^3.0.0",
     "vis-data": "7.1.6",
     "brace-expansion": "^5.0.5",
-    "lodash-es": "^4.18.0"
+    "lodash-es": "^4.18.0",
+    "minimatch": "^3.1.4",
+    "yaml": "^1.10.3",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.22.9",


### PR DESCRIPTION
## Summary
Resolves CVE-2026-4800 (HIGH severity) by bumping `lodash` and `lodash-es` yarn resolutions to `^4.18.0` in `package.json`.

## Details
The fix for CVE-2021-23337 added validation for the `variable` option in `_.template` but did not apply the same validation to `options.imports` key names. Both paths flow into the same `Function()` constructor sink.

When an application passes untrusted input as `options.imports` key names, an attacker can inject default-parameter expressions that execute arbitrary code at template compilation time.

Additionally, `_.template` uses `assignInWith` to merge imports, which enumerates inherited properties via `for..in`. If `Object.prototype` has been polluted by any other vector, the polluted keys are copied into the imports object and passed to `Function()`.

## Impact
An attacker can inject default-parameter expressions that execute arbitrary code at template compilation time via untrusted `options.imports` key names. Prototype pollution can also be exploited via `assignInWith`.

## Fix
- Bumped `lodash` and `lodash-es` resolutions to `^4.18.0` in `package.json`
- Version 4.18.0 validates `importsKeys` against `reForbiddenIdentifierChars` and replaces `assignInWith` with `assignWith`

## Test Plan
- [ ] Verify `lodash` and `lodash-es` resolve to `>=4.18.0` after `yarn install`
- [ ] Verify no regressions in build or tests