### PR TITLE
fix: Fix Overview page crash when threat intel findings have ioc_type

### DIFF
--- a/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
+++ b/public/pages/Overview/components/Widgets/RecentThreatIntelFindingsWidget.tsx
@@ -17,7 +17,7 @@ import { WidgetContainer } from './WidgetContainer';
 import { getEuiEmptyPrompt, renderTime } from '../../../../utils/helpers';
 import { ThreatIntelFinding } from '../../../../../types';
 import { getApplication, getUseUpdatedUx } from '../../../../services/utils/constants';
-import { IocLabel, ThreatIntelIocType } from '../../../../../common/constants';
+import { renderIoCType } from '../../../../utils/helpers';
 
 const columns: EuiBasicTableColumn<ThreatIntelFinding>[] = [
   {
@@ -32,7 +32,7 @@ const columns: EuiBasicTableColumn<ThreatIntelFinding>[] = [
   {
     name: 'Indicator type',
     field: 'ioc_type',
-    render: (iocType: ThreatIntelIocType) => IocLabel[iocType],
+    render: (iocType: string) => renderIoCType(iocType),
   },
   {
     name: 'Threat intel source',


### PR DESCRIPTION
Replace broken import of non-existent IocLabel/ThreatIntelIocType from common/constants with the working renderIoCType helper from utils/helpers. This is the same approach used by ThreatIntelFindingsTable which renders correctly.

The crash occurred because IocLabel was undefined, causing TypeError: Cannot read properties of undefined (reading 'ipv4-addr') when rendering the 'Indicator type' column.

Resolves opensearch-project#1563

### Description
  
  The Security Analytics Overview page crashes with `TypeError: Cannot read properties of undefined (reading 'ipv4-addr')` when threat intel  findings exist with IOC_UPLOAD type.
  
  **Root cause:** `RecentThreatIntelFindingsWidget.tsx` imports `IocLabel` and `ThreatIntelIocType` from `common/constants`, but these exports don't exist (removed in PR #1266). This causes `IocLabel` to be `undefined`, and `IocLabel[iocType]` throws TypeError.
  
  **Fix:** Replace the broken import with `renderIoCType` from `utils/helpers` — the same helper used by `ThreatIntelFindingsTable` which renders correctly.
  
  ### Issues Resolved
  
  Resolves #1563
  
  ### Check List
  - [x] New functionality includes testing.
  - [ ] New functionality has been documented.
  - [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).