### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.cypress/support/index.js
+++ b/.cypress/support/index.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 //
 // This is a great place to put global configuration and
 // behavior that modifies Cypress.

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,34 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".html",
+    ".config",
+    ".png",
+    ".svg",
+    ".ico",
+    ".lock",
+    ".snap",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".lintstagedrc",
+    ".prettierrc",
+    ".prettierignore",
+    "node_modules/",
+    "build/",
+    "dist/",
+    "target/",
+    "**/__snapshots__/",
+    "*.d.ts",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({

--- a/integtest.sh
+++ b/integtest.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 function usage() {

--- a/public/components/Charts/ChartContainer.scss
+++ b/public/components/Charts/ChartContainer.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .chart-view-container {
   position: relative;
   width: 90%;

--- a/public/components/Charts/ChartContainer.tsx
+++ b/public/components/Charts/ChartContainer.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import { EuiLoadingChart } from '@elastic/eui';
 

--- a/public/pages/Correlations/components/FindingCard.scss
+++ b/public/pages/Correlations/components/FindingCard.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .finding-card-header {
   .euiFlexItem:nth-child(2) {
     margin-right: 6px;

--- a/public/pages/Detectors/components/ReviewFieldMappings/ReviewFieldMappings.scss
+++ b/public/pages/Detectors/components/ReviewFieldMappings/ReviewFieldMappings.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .reviewFieldMappings {
   .editFieldMappings {
     .euiPanel {

--- a/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.scss
+++ b/public/pages/Findings/components/CorrelationsTable/CorrelationsTable.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .correlations-table-details-row {
   .correlations-table-details-row-value {
     font-weight: 600;

--- a/public/pages/Main/components/Callout.scss
+++ b/public/pages/Main/components/Callout.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .mainCallout {
   .euiCallOutHeader__title {
     width: 100% !important;

--- a/public/pages/Overview/components/Widgets/WidgetContainer.scss
+++ b/public/pages/Overview/components/Widgets/WidgetContainer.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .grid-item {
   > div {
     height: 100%;

--- a/public/pages/Overview/utils/helper.test.ts
+++ b/public/pages/Overview/utils/helper.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   addInteractiveLegends,
   DateOpts,

--- a/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
+++ b/public/pages/Rules/components/RuleEditor/DetectionVisualEditor.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 
 .detection-visual-editor {
   .euiAccordionForm:nth-of-type(1) {

--- a/public/pages/Rules/components/RuleEditor/RuleEditorForm.scss
+++ b/public/pages/Rules/components/RuleEditor/RuleEditorForm.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .rule-editor-form {
 
   .field-text-array-remove {

--- a/public/pages/Rules/components/RuleEditor/components/SelectionExpField.scss
+++ b/public/pages/Rules/components/RuleEditor/components/SelectionExpField.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .selection-exp-field-item {
   position: relative;
 

--- a/public/pages/Rules/components/RuleEditor/components/SelectionExpField.tsx
+++ b/public/pages/Rules/components/RuleEditor/components/SelectionExpField.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   EuiPopoverTitle,

--- a/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.scss
+++ b/public/pages/ThreatIntel/containers/AddThreatIntelSource/AddThreatIntelSource.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .label--danger {
   color: $ouiColorDanger !important;
 }

--- a/test/mocks/Detectors/components/FieldMappingsView/FieldMappingsView.mock.ts
+++ b/test/mocks/Detectors/components/FieldMappingsView/FieldMappingsView.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import notificationsStartMock from '../../../services/notifications/NotificationsStart.mock';
 import detectorMock from '../../containers/Detectors/Detector.mock';
 import fieldMappingMock from './FieldMapping.mock';

--- a/test/mocks/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.mock.ts
+++ b/test/mocks/Detectors/components/UpdateFieldMappings/UpdateFieldMappings.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import detectorHitMock from '../../containers/Detectors/DetectorHit.mock';
 import notificationsStartMock from '../../../services/notifications/NotificationsStart.mock';
 import browserHistoryMock from '../../../services/browserHistory.mock';

--- a/test/mocks/services/alertService.mock.ts
+++ b/test/mocks/services/alertService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { AlertService } from '../../../server/services';
 import legacyClusterClientMock from './iLegacyCustomClusterClient.mock';
 

--- a/test/mocks/services/detectorService.mock.ts
+++ b/test/mocks/services/detectorService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { DetectorService } from '../../../server/services';
 import detectorHitMock from '../Detectors/containers/Detectors/DetectorHit.mock';
 import legacyClusterClientMock from './iLegacyCustomClusterClient.mock';

--- a/test/mocks/services/fieldMappingService.mock.ts
+++ b/test/mocks/services/fieldMappingService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import FieldMappingService from '../../../public/services/FieldMappingService';
 import httpClientMock from './httpClient.mock';
 

--- a/test/mocks/services/findingsService.mock.ts
+++ b/test/mocks/services/findingsService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import httpClientMock from './httpClient.mock';
 import { FindingsService } from '../../../public/services';
 

--- a/test/mocks/services/indexService.mock.ts
+++ b/test/mocks/services/indexService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import httpClientMock from './httpClient.mock';
 import { IndexService } from '../../../public/services';
 jest.fn();

--- a/test/mocks/services/notifications/index.ts
+++ b/test/mocks/services/notifications/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import NotificationChannelOption from './NotificationChannelOption.mock';
 import NotificationTypeOptions from './NotificationChannelTypeOptions.mock';
 import NotificationsStart from './NotificationsStart.mock';

--- a/test/mocks/services/notifications/notificationsService.mock.ts
+++ b/test/mocks/services/notifications/notificationsService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NotificationsService } from '../../../../public/services';
 import httpClientMock from '../httpClient.mock';
 

--- a/test/mocks/services/ruleService.mock.ts
+++ b/test/mocks/services/ruleService.mock.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import httpClientMock from './httpClient.mock';
 import { RuleService } from '../../../public/services';
 


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)


### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).