### PR TITLE
fix(correlation): silent Create/Edit failure on uuid v14

### DIFF
--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -75,7 +75,7 @@ import {
   parseNotificationChannelsToOptions,
 } from '../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { NotificationsCallOut } from '../../../../public/components/NotificationsCallOut';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface CreateCorrelationRuleProps extends DataSourceProps {
@@ -367,8 +367,8 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
   };
 
   const submit = async (values: CorrelationRuleModel) => {
-    const randomTriggerId = uuid();
-    const randomActionId = uuid();
+    const randomTriggerId = uuidv4();
+    const randomActionId = uuidv4();
     let error;
     if ((error = validateCorrelationRule(values))) {
       errorNotificationToast(props.notifications, action, 'rule', error);


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 uuid v14 removed its default export. `CreateCorrelationRule.tsx` still used a default import (import uuid from
  'uuid') and called `uuid()` as the first statements in `submit()`. With uuid v14 this throws `TypeError: (0, 
  uuid.default) is not a function` before any validation or API call runs, so clicking Create or Update on a
  correlation rule silently fails (unhandled promise rejection - no request fires, no error surfaced to the
  user).

  This switches to the named v4 import (`import { v4 as uuidv4 } from 'uuid'`) the pattern already used
  elsewhere in the plugin (e.g. `DetectorsStore.tsx`) - and updates the two call sites. This is the only remaining
  default import call site in the plugin.

Testing (local OSD dev stack, OpenSearch 3.8 with the security-analytics backend, uuid@14 resolved):
  - Before: Console throws `TypeError: (0, uuid…default) is not a function` at CreateCorrelationRule.tsx:370; no
    correlation/rules request fires; Create/Edit silently do nothing.
  - After: Create returns 200 and the rule persists; Edit/Update returns 200 (ok: true) and changes persist.
    Both paths share submit(), so the same fix covers both.

### Issues Resolved
[List any issues this PR will resolve]

Fixes silent Create/Edit failure of correlation rules when the plugin resolves uuid v14.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).