### PR TITLE
fix(correlation): silent Create/Edit failure on uuid v14 (#1571)

### DIFF
--- a/public/pages/Correlations/containers/CreateCorrelationRule.tsx
+++ b/public/pages/Correlations/containers/CreateCorrelationRule.tsx
@@ -75,7 +75,7 @@ import {
   parseNotificationChannelsToOptions,
 } from '../../CreateDetector/components/ConfigureAlerts/utils/helpers';
 import { NotificationsCallOut } from '../../../../public/components/NotificationsCallOut';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 
 export interface CreateCorrelationRuleProps extends DataSourceProps {
@@ -367,8 +367,8 @@ export const CreateCorrelationRule: React.FC<CreateCorrelationRuleProps> = (
   };
 
   const submit = async (values: CorrelationRuleModel) => {
-    const randomTriggerId = uuid();
-    const randomActionId = uuid();
+    const randomTriggerId = uuidv4();
+    const randomActionId = uuidv4();
     let error;
     if ((error = validateCorrelationRule(values))) {
       errorNotificationToast(props.notifications, action, 'rule', error);


### PR DESCRIPTION
### Description
Backport of #1571 to 3.7.

  uuid v14 removed its default export. CreateCorrelationRule.tsx used a
  default import (`import uuid from 'uuid'`) and called uuid() as the first
  statements in submit(), throwing `TypeError: (0, uuid.default) is not a
  function` before any validation or API call — so Create/Update of a
  correlation rule silently failed. Switches to the named v4 import.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).